### PR TITLE
Issue 26 - first pass personalized pagerank

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,3 +64,4 @@ rpy2 =
 [tool:pytest]
 filterwarnings =
     ignore::DeprecationWarning
+    

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.2.0
+version = 0.2.1
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,3 +60,7 @@ rpy2 =
     pyarrow==18.0.0
     rpy2==3.5.*
     rpy2-arrow==0.1.1
+
+[tool:pytest]
+filterwarnings =
+    ignore::DeprecationWarning

--- a/src/napistu/mechanism_matching.py
+++ b/src/napistu/mechanism_matching.py
@@ -752,7 +752,7 @@ def filter_to_direct_mechanistic_interactions(
     )
 
     # reduce to distinct sc_id pairs
-    sc_id_pairs = edgelist_w_scids[CPR_EDGELIST_REQ_VARS].drop_duplicates()
+    sc_id_pairs = edgelist_w_scids[list(CPR_EDGELIST_REQ_VARS)].drop_duplicates()
 
     # define all existing direct regulatory interactions
     pathway_interactions = pd.concat(

--- a/src/napistu/network/net_propagation.py
+++ b/src/napistu/network/net_propagation.py
@@ -1,0 +1,109 @@
+import pandas as pd
+import numpy as np
+import igraph as ig
+import inspect
+
+from typing import Optional
+
+def personalized_pagerank_by_attribute(
+    g: ig.Graph,
+    attribute: str,
+    damping: float = 0.85,
+    calculate_uniform_dist: bool = True,
+    additional_propagation_args: Optional[dict] = None,
+) -> pd.DataFrame:
+    """
+    Run personalized PageRank with reset probability proportional to a vertex attribute.
+    Optionally computes uniform PPR over nonzero attribute nodes.
+
+    Parameters
+    ----------
+    g : igraph.Graph
+        The input graph.
+    attribute : str
+        The vertex attribute to use for personalization.
+    damping : float, optional
+        Damping factor (default 0.85).
+    calculate_uniform_dist : bool, optional
+        If True, also compute uniform PPR over nonzero attribute nodes.
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to igraph's personalized_pagerank. Keys must match the method's signature.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ['name', 'pagerank_by_attribute', attribute] and optionally 'pagerank_uniform'.
+
+    Example
+    -------
+    >>> import igraph as ig
+    >>> from scraps.utils import personalized_pagerank_by_attribute
+    >>> g = ig.Graph.Full(3)
+    >>> g.vs['name'] = ['A', 'B', 'C']
+    >>> g.vs['score'] = [1, 0, 2]
+    >>> df = personalized_pagerank_by_attribute(g, 'score')
+    >>> print(df)
+    """
+    # Validate and extract attribute (missing/None as 0)
+    attr = _ensure_nonnegative_vertex_attribute(g, attribute)
+
+    # Validate additional_propagation_args
+    if additional_propagation_args is None:
+        additional_propagation_args = {}
+    else:
+        valid_args = set(inspect.signature(g.personalized_pagerank).parameters.keys())
+        for k in additional_propagation_args:
+            if k not in valid_args:
+                raise ValueError(f"Invalid argument for personalized_pagerank: {k}")
+
+    # Personalized PageRank (no normalization, igraph handles it)
+    pr_attr = g.personalized_pagerank(reset=attr.tolist(), damping=damping, **additional_propagation_args)
+
+    # Node names
+    names = g.vs["name"] if "name" in g.vs.attributes() else list(range(g.vcount()))
+
+    data = {
+        "name": names,
+        "pagerank_by_attribute": pr_attr,
+        attribute: attr
+    }
+
+    # Uniform PPR over nonzero attribute nodes
+    if calculate_uniform_dist:
+        used_in_uniform = attr > 0
+        n_uniform = used_in_uniform.sum()
+        if n_uniform == 0:
+            raise ValueError("No nonzero attribute values for uniform PPR.")
+        uniform_vec = np.zeros_like(attr, dtype=float)
+        uniform_vec[used_in_uniform] = 1.0 / n_uniform
+        pr_uniform = g.personalized_pagerank(reset=uniform_vec.tolist(), damping=damping, **additional_propagation_args)
+        data["pagerank_uniform"] = pr_uniform
+
+    return pd.DataFrame(data)
+
+
+def _ensure_nonnegative_vertex_attribute(g: ig.Graph, attribute: str):
+    """
+    Utility to check that a vertex attribute is present, numeric, and non-negative.
+    Raises ValueError if checks fail.
+    Missing or None values are treated as 0.
+    Raises ValueError if attribute is missing for all vertices or all values are zero.
+    """
+    
+    all_missing = all((attribute not in v.attributes() or v[attribute] is None) for v in g.vs)
+    if all_missing:
+        raise ValueError(f"Vertex attribute '{attribute}' is missing for all vertices.")
+    
+    values = [
+        v[attribute] if (attribute in v.attributes() and v[attribute] is not None) else 0.0
+        for v in g.vs
+    ]
+    
+    arr = np.array(values, dtype=float)
+    
+    if np.all(arr == 0):
+        raise ValueError(f"Vertex attribute '{attribute}' is zero for all vertices; cannot use as reset vector.")
+    if np.any(arr < 0):
+        raise ValueError(f"Attribute '{attribute}' contains negative values.")
+    
+    return arr

--- a/src/napistu/sbml_dfs_core.py
+++ b/src/napistu/sbml_dfs_core.py
@@ -1265,6 +1265,7 @@ def filter_to_characteristic_species_ids(
         data=[True] * len(promiscuous_component_identifiers_index),
         index=promiscuous_component_identifiers_index,
         name="is_shared_component",
+        dtype=bool,
     )
 
     if len(promiscuous_component_identifiers) == 0:

--- a/src/tests/test_net_propagation.py
+++ b/src/tests/test_net_propagation.py
@@ -1,0 +1,74 @@
+import pytest
+import igraph as ig
+import numpy as np
+from napistu.network.net_propagation import personalized_pagerank_by_attribute
+
+
+def test_personalized_pagerank_by_attribute_basic():
+    g = ig.Graph.Full(3)
+    g.vs['name'] = ['A', 'B', 'C']
+    g.vs['score'] = [1, 0, 2]
+    df = personalized_pagerank_by_attribute(g, 'score')
+    assert set(df.columns) == {'name', 'pagerank_by_attribute', 'pagerank_uniform', 'score'}
+    assert np.isclose(df['score'].sum(), 3)
+    assert np.isclose(df['pagerank_by_attribute'].sum(), 1)
+    assert np.isclose(df['pagerank_uniform'].sum(), 1)
+    # Uniform should only include A and C
+    assert df.loc[df['name'] == 'B', 'pagerank_uniform'].values[0] > 0
+
+
+def test_personalized_pagerank_by_attribute_no_uniform():
+    g = ig.Graph.Full(3)
+    g.vs['score'] = [1, 0, 2]
+    df = personalized_pagerank_by_attribute(g, 'score', calculate_uniform_dist=False)
+    assert 'pagerank_uniform' not in df.columns
+    assert np.isclose(df['pagerank_by_attribute'].sum(), 1)
+
+
+def test_personalized_pagerank_by_attribute_missing_and_negative():
+    g = ig.Graph.Full(3)
+    g.vs['score'] = [1, None, 2]
+    # None should be treated as 0
+    df = personalized_pagerank_by_attribute(g, 'score')
+    assert np.isclose(df['score'].sum(), 3)
+    # Negative values should raise
+    g.vs['score'] = [1, -1, 2]
+    with pytest.raises(ValueError):
+        personalized_pagerank_by_attribute(g, 'score')
+
+
+def test_personalized_pagerank_by_attribute_additional_args_directed():
+    # create an asymmetric directed graph to test whether additional_propagation_args is respected
+    g = ig.Graph(directed=True)
+    g.add_vertices(3)
+    g.add_edges([(0, 1), (1, 2)])
+    g.vs['score'] = [1, 0, 2]
+    # Run with directed=False, which should treat the graph as undirected
+    df_directed = personalized_pagerank_by_attribute(g, 'score', additional_propagation_args={'directed': True})
+    df_undirected = personalized_pagerank_by_attribute(g, 'score', additional_propagation_args={'directed': False})
+    # The results should differ for directed vs undirected
+    assert not np.allclose(df_directed['pagerank_by_attribute'], df_undirected['pagerank_by_attribute'])
+    # Uniform should also be affected
+    assert not np.allclose(df_directed['pagerank_uniform'], df_undirected['pagerank_uniform'])
+
+
+def test_personalized_pagerank_by_attribute_additional_args_invalid():
+    g = ig.Graph.Full(3)
+    g.vs['score'] = [1, 0, 2]
+    # Passing an invalid argument should raise ValueError
+    with pytest.raises(ValueError):
+        personalized_pagerank_by_attribute(g, 'score', additional_propagation_args={'not_a_real_arg': 123})
+
+
+def test_personalized_pagerank_by_attribute_all_missing():
+    g = ig.Graph.Full(3)
+    # No 'score' attribute at all
+    with pytest.raises(ValueError, match="missing for all vertices"):
+        personalized_pagerank_by_attribute(g, 'score')
+
+
+def test_personalized_pagerank_by_attribute_all_zero():
+    g = ig.Graph.Full(3)
+    g.vs['score'] = [0, 0, 0]
+    with pytest.raises(ValueError, match="zero for all vertices"):
+        personalized_pagerank_by_attribute(g, 'score') 

--- a/src/tests/test_net_utils.py
+++ b/src/tests/test_net_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import igraph as ig
+import numpy as np
 import pandas as pd
 from napistu.network import net_utils
 from napistu.network import net_create
@@ -56,6 +57,37 @@ def test_validate_graph_attributes(sbml_dfs):
         net_utils._validate_vertex_attributes(cpr_graph, "baz")
 
 
+def test_pluck_entity_data_species_identity(sbml_dfs):
+    # Take first 10 species IDs
+    species_ids = sbml_dfs.species.index[:10]
+    # Create mock data
+    mock_df = pd.DataFrame({
+        'string_col': [f"str_{i}" for i in range(10)],
+        'mixed_col': np.arange(-5, 5),
+        'ones_col': np.ones(10),
+    }, index=species_ids)
+    # Assign to species_data
+    sbml_dfs.species_data["mock_table"] = mock_df
+    # Create graph_attrs for species
+    graph_attrs = {
+        "species": {
+            "string_col": {"table": "mock_table", "variable": "string_col", "trans": "identity"},
+            "mixed_col": {"table": "mock_table", "variable": "mixed_col", "trans": "identity"},
+            "ones_col": {"table": "mock_table", "variable": "ones_col", "trans": "identity"},
+        }
+    }
+    # Call pluck_entity_data
+    result = net_create.pluck_entity_data(sbml_dfs, graph_attrs, "species")
+    # Check output
+    assert isinstance(result, pd.DataFrame)
+    assert set(result.columns) == {"string_col", "mixed_col", "ones_col"}
+    assert list(result.index) == list(species_ids)
+    # Check values
+    pd.testing.assert_series_equal(result["string_col"], mock_df["string_col"])
+    pd.testing.assert_series_equal(result["mixed_col"], mock_df["mixed_col"])
+    pd.testing.assert_series_equal(result["ones_col"], mock_df["ones_col"])
+
+
 ################################################
 # __main__
 ################################################
@@ -64,3 +96,4 @@ if __name__ == "__main__":
     test_safe_fill()
     test_cpr_graph_to_pandas_dfs()
     test_validate_graph_attributes()
+    test_pluck_entity_data_species_identity()


### PR DESCRIPTION
- added support for custom transformations when adding species_data or reaction_data to graphs. This is helpful right now because setting reset Pr relative to an attribute requires the attribute to be non-negative. Now it is really easy to transfer the absolute value or apply any other transformation.
- simplified some of the logic in pluck_entity_data() which is the core function for pulling out and transforming entity data.
- created a PPR wrapper which takes a vertex attribute and dampening factor (plus other optional args) and calculate a pagerank distribution. Also, support uniform initialization over the relevant vertices as a way to adjust for PPR scores which are just high due to network topology. #26 
- added tests for PPR and plucking data.