### PR TITLE
loosening versions to better support more recent Python releases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.2.3
+version = 0.2.4
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -22,21 +22,21 @@ project_urls =
 packages = find:
 install_requires =
     Jinja2
-    PyYAML==6.*
-    click==8.*
+    PyYAML>=6.0.0,<7.0.0
+    click>=8.0.0,<9.0.0
     click-logging
-    fs==2.4.*
-    fs-gcsfs==1.5.*
+    fs>=2.4.0,<3.0.0
+    fs-gcsfs>=1.5.0,<2.0.0
     igraph
-    matplotlib==3.*
-    numpy==1.26.*
-    pandas==1.5.*
-    pydantic==2.*
+    matplotlib>=3.5.0,<4.0.0
+    numpy>=1.24.0,<3.0.0
+    pandas>=1.5.0,<3.0.0
+    pydantic>=2.0.0,<3.0.0
     python-libsbml
-    requests>=2
-    scipy==1.14.*
+    requests>=2.25.0
+    scipy>=1.10.0,<2.0.0
     tqdm
-    zeep==3.*
+    zeep>=3.0.0,<4.0.0
 
 python_requires = >=3.11
 package_dir =
@@ -51,26 +51,26 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    black==25.*
+    black>=24.0.0
     ipykernel
-    pre-commit==3.3.*
-    pytest==7.*
+    pre-commit>=3.0.0,<4.0.0
+    pytest>=7.0.0,<8.0.0
     pytest-asyncio
     pytest-cov
     ruff
     testcontainers
 mcp = 
-    fastmcp==2.3.*
-    mcp==1.9.*
-    httpx
-    beautifulsoup4>=4.11,<5
-    markdown
-    jupyter-client
-    nbformat
+    fastmcp>=2.0.0,<3.0.0
+    mcp>=1.0.0,<2.0.0  
+    httpx>=0.24.0
+    beautifulsoup4>=4.11.0,<5.0.0
+    markdown>=3.4.0
+    jupyter-client>=7.0.0
+    nbformat>=5.0.0
 rpy2 =
-    pyarrow==18.0.0
-    rpy2==3.5.*
-    rpy2-arrow==0.1.1
+    pyarrow>=15.0.0,<19.0.0
+    rpy2>=3.5.0,<4.0.0
+    rpy2-arrow>=0.1.0,<1.0.0
 
 [tool:pytest]
 filterwarnings =


### PR DESCRIPTION
Closes #73 . Hopefully this will speed up configuring and testing Python 3.12+ 