### PR TITLE
Issue 76 - Reorganized server and component specifications

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y curl && \
     apt-get clean
 
 # MCP server specific environment variables
-ENV MCP_PROFILE=remote
+ENV MCP_PROFILE=docs
 ENV MCP_SERVER_NAME=napistu-cloud-docs
 ENV PORT=8080
 ENV HOST=0.0.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.3.0
+version = 0.3.1
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/mcp/__init__.py
+++ b/src/napistu/mcp/__init__.py
@@ -18,15 +18,16 @@ except ImportError:
     is_available = False
 
 if is_available:
-    from .server import create_server
-    from .profiles import get_profile
+    from napistu.mcp.server import create_server
+    from napistu.mcp.profiles import get_profile
+    from napistu.mcp.constants import MCP_PROFILES
 
-    def start_server(profile_name: str = "local", **kwargs) -> Dict[str, Any]:
+    def start_server(profile_name: str = MCP_PROFILES.EXECUTION, **kwargs) -> Dict[str, Any]:
         """
         Start an MCP server with a specific profile.
 
         Args:
-            profile_name: Name of the profile ('local', 'remote', or 'full')
+            profile_name: Name of the profile ('execution', 'docs', or 'full')
             **kwargs: Additional configuration options
 
         Returns:

--- a/src/napistu/mcp/__main__.py
+++ b/src/napistu/mcp/__main__.py
@@ -1,4 +1,3 @@
-# src/napistu/mcp/__main__.py
 """
 MCP (Model Context Protocol) Server CLI for Napistu.
 """
@@ -15,6 +14,15 @@ from napistu.mcp.client import (
     print_health_status,
     list_server_resources,
     read_server_resource,
+)
+from napistu.mcp.config import (
+    validate_server_config_flags,
+    validate_client_config_flags,
+    server_config_options,
+    client_config_options,
+    local_server_config,
+    local_client_config,
+    production_client_config,
 )
 
 logger = logging.getLogger(napistu.__name__)
@@ -37,155 +45,203 @@ def server():
 @click.option(
     "--profile", type=click.Choice(["local", "remote", "full"]), default="remote"
 )
-@click.option("--host", type=str, default="127.0.0.1")
-@click.option("--port", type=int, default=8765)
-@click.option("--server-name", type=str)
+@server_config_options
 @click_logging.simple_verbosity_option(logger)
-def start_server(profile, host, port, server_name):
+def start_server(profile, production, local, host, port, server_name):
     """Start an MCP server with the specified profile."""
-    start_mcp_server(profile, host, port, server_name)
+    try:
+        config = validate_server_config_flags(
+            local, production, host, port, server_name
+        )
+
+        click.echo("Starting server with configuration:")
+        click.echo(f"  Profile: {profile}")
+        click.echo(f"  Host: {config.host}")
+        click.echo(f"  Port: {config.port}")
+        click.echo(f"  Server Name: {config.server_name}")
+
+        start_mcp_server(profile, config)
+
+    except click.BadParameter as e:
+        raise click.ClickException(str(e))
 
 
 @server.command(name="local")
-@click.option("--server-name", type=str, default="napistu-local")
 @click_logging.simple_verbosity_option(logger)
-def start_local(server_name):
+def start_local():
     """Start a local MCP server optimized for function execution."""
-    start_mcp_server("local", "127.0.0.1", 8765, server_name)
+    config = local_server_config()
+    click.echo("Starting local development server (execution profile)")
+    click.echo(f"  Host: {config.host}")
+    click.echo(f"  Port: {config.port}")
+    click.echo(f"  Server Name: {config.server_name}")
+
+    start_mcp_server("local", config)
 
 
 @server.command(name="full")
-@click.option("--server-name", type=str, default="napistu-full")
 @click_logging.simple_verbosity_option(logger)
-def start_full(server_name):
+def start_full():
     """Start a full MCP server with all components enabled (local debugging)."""
-    start_mcp_server("full", "127.0.0.1", 8765, server_name)
+    config = local_server_config()
+    # Override server name for full profile
+    config.server_name = "napistu-full"
+
+    click.echo("Starting full development server (all components)")
+    click.echo(f"  Host: {config.host}")
+    click.echo(f"  Port: {config.port}")
+    click.echo(f"  Server Name: {config.server_name}")
+
+    start_mcp_server("full", config)
 
 
 @cli.command()
-@click.option("--url", default="http://127.0.0.1:8765", help="Server URL")
+@client_config_options
 @click_logging.simple_verbosity_option(logger)
-def health(url):
+def health(production, local, host, port, https):
     """Quick health check of MCP server."""
 
     async def run_health_check():
-        print("🏥 Napistu MCP Server Health Check")
-        print("=" * 40)
-        print(f"Server URL: {url}")
-        print()
+        try:
+            config = validate_client_config_flags(local, production, host, port, https)
 
-        health = await check_server_health(server_url=url)
-        print_health_status(health)
+            print("🏥 Napistu MCP Server Health Check")
+            print("=" * 40)
+            print(f"Server URL: {config.base_url}")
+            print()
+
+            health = await check_server_health(config)
+            print_health_status(health)
+
+        except click.BadParameter as e:
+            raise click.ClickException(str(e))
 
     asyncio.run(run_health_check())
 
 
 @cli.command()
-@click.option("--url", default="http://127.0.0.1:8765", help="Server URL")
+@client_config_options
 @click_logging.simple_verbosity_option(logger)
-def resources(url):
+def resources(production, local, host, port, https):
     """List all available resources on the MCP server."""
 
     async def run_list_resources():
-        print("📋 Napistu MCP Server Resources")
-        print("=" * 40)
-        print(f"Server URL: {url}")
-        print()
+        try:
+            config = validate_client_config_flags(local, production, host, port, https)
 
-        resources = await list_server_resources(server_url=url)
+            print("📋 Napistu MCP Server Resources")
+            print("=" * 40)
+            print(f"Server URL: {config.base_url}")
+            print()
 
-        if resources:
-            print(f"Found {len(resources)} resources:")
-            for resource in resources:
-                print(f"  📄 {resource.uri}")
-                if resource.name != resource.uri:
-                    print(f"      Name: {resource.name}")
-                if hasattr(resource, "description") and resource.description:
-                    print(f"      Description: {resource.description}")
-                print()
-        else:
-            print("❌ Could not retrieve resources")
+            resources = await list_server_resources(config)
+
+            if resources:
+                print(f"Found {len(resources)} resources:")
+                for resource in resources:
+                    print(f"  📄 {resource.uri}")
+                    if resource.name != resource.uri:
+                        print(f"      Name: {resource.name}")
+                    if hasattr(resource, "description") and resource.description:
+                        print(f"      Description: {resource.description}")
+                    print()
+            else:
+                print("❌ Could not retrieve resources")
+
+        except click.BadParameter as e:
+            raise click.ClickException(str(e))
 
     asyncio.run(run_list_resources())
 
 
 @cli.command()
 @click.argument("resource_uri")
-@click.option("--url", default="http://127.0.0.1:8765", help="Server URL")
+@client_config_options
 @click.option(
     "--output", type=click.File("w"), default="-", help="Output file (default: stdout)"
 )
 @click_logging.simple_verbosity_option(logger)
-def read(resource_uri, url, output):
+def read(resource_uri, production, local, host, port, https, output):
     """Read a specific resource from the MCP server."""
 
     async def run_read_resource():
-        print(
-            f"📖 Reading Resource: {resource_uri}",
-            file=output if output.name != "<stdout>" else None,
-        )
-        print(f"Server URL: {url}", file=output if output.name != "<stdout>" else None)
-        print("=" * 50, file=output if output.name != "<stdout>" else None)
+        try:
+            config = validate_client_config_flags(local, production, host, port, https)
 
-        content = await read_server_resource(resource_uri, server_url=url)
-
-        if content:
-            print(content, file=output)
-        else:
             print(
-                "❌ Could not read resource",
+                f"📖 Reading Resource: {resource_uri}",
                 file=output if output.name != "<stdout>" else None,
             )
+            print(
+                f"Server URL: {config.base_url}",
+                file=output if output.name != "<stdout>" else None,
+            )
+            print("=" * 50, file=output if output.name != "<stdout>" else None)
+
+            content = await read_server_resource(resource_uri, config)
+
+            if content:
+                print(content, file=output)
+            else:
+                print(
+                    "❌ Could not read resource",
+                    file=output if output.name != "<stdout>" else None,
+                )
+
+        except click.BadParameter as e:
+            raise click.ClickException(str(e))
 
     asyncio.run(run_read_resource())
 
 
 @cli.command()
-@click.option("--local-url", default="http://127.0.0.1:8765", help="Local server URL")
-@click.option("--remote-url", required=True, help="Remote server URL")
 @click_logging.simple_verbosity_option(logger)
-def compare(local_url, remote_url):
-    """Compare health between local and remote servers."""
+def compare():
+    """Compare health between local development and production servers."""
 
     async def run_comparison():
-        print("🔍 Local vs Remote Server Comparison")
+
+        local_config = local_client_config()
+        production_config = production_client_config()
+
+        print("🔍 Local vs Production Server Comparison")
         print("=" * 50)
 
-        print(f"\n📍 Local Server: {local_url}")
-        local_health = await check_server_health(server_url=local_url)
+        print(f"\n📍 Local Server: {local_config.base_url}")
+        local_health = await check_server_health(local_config)
         print_health_status(local_health)
 
-        print(f"\n🌐 Remote Server: {remote_url}")
-        remote_health = await check_server_health(server_url=remote_url)
-        print_health_status(remote_health)
+        print(f"\n🌐 Production Server: {production_config.base_url}")
+        production_health = await check_server_health(production_config)
+        print_health_status(production_health)
 
         # Compare results
         print("\n📊 Comparison Summary:")
-        if local_health and remote_health:
+        if local_health and production_health:
             local_components = local_health.get("components", {})
-            remote_components = remote_health.get("components", {})
+            production_components = production_health.get("components", {})
 
             all_components = set(local_components.keys()) | set(
-                remote_components.keys()
+                production_components.keys()
             )
 
             for component in sorted(all_components):
                 local_status = local_components.get(component, {}).get(
                     "status", "missing"
                 )
-                remote_status = remote_components.get(component, {}).get(
+                production_status = production_components.get(component, {}).get(
                     "status", "missing"
                 )
 
-                if local_status == remote_status == "healthy":
+                if local_status == production_status == "healthy":
                     icon = "✅"
-                elif local_status != remote_status:
+                elif local_status != production_status:
                     icon = "⚠️ "
                 else:
                     icon = "❌"
 
                 print(
-                    f"  {icon} {component}: Local={local_status}, Remote={remote_status}"
+                    f"  {icon} {component}: Local={local_status}, Production={production_status}"
                 )
         else:
             print("  ❌ Cannot compare - one or both servers unreachable")

--- a/src/napistu/mcp/__main__.py
+++ b/src/napistu/mcp/__main__.py
@@ -43,7 +43,7 @@ def server():
 
 @server.command(name="start")
 @click.option(
-    "--profile", type=click.Choice(["local", "remote", "full"]), default="remote"
+    "--profile", type=click.Choice(["execution", "docs", "full"]), default="docs"
 )
 @server_config_options
 @click_logging.simple_verbosity_option(logger)
@@ -76,7 +76,7 @@ def start_local():
     click.echo(f"  Port: {config.port}")
     click.echo(f"  Server Name: {config.server_name}")
 
-    start_mcp_server("local", config)
+    start_mcp_server("execution", config)
 
 
 @server.command(name="full")

--- a/src/napistu/mcp/client.py
+++ b/src/napistu/mcp/client.py
@@ -1,4 +1,3 @@
-# src/napistu/mcp/client.py
 """
 MCP client for testing and interacting with Napistu MCP servers.
 """
@@ -8,20 +7,19 @@ import logging
 from typing import Optional, Dict, Any, Mapping
 
 from fastmcp import Client
+from napistu.mcp.config import MCPClientConfig
 
 logger = logging.getLogger(__name__)
 
 
-async def check_server_health(
-    server_url: str = "http://127.0.0.1:8765",
-) -> Optional[Dict[str, Any]]:
+async def check_server_health(config: MCPClientConfig) -> Optional[Dict[str, Any]]:
     """
     Health check using FastMCP client.
 
     Parameters
     ----------
-    server_url : str, optional
-        Server URL for HTTP transport. Defaults to 'http://127.0.0.1:8765'.
+    config : MCPClientConfig
+        Client configuration object with validated settings.
 
     Returns
     -------
@@ -37,13 +35,10 @@ async def check_server_health(
             - components : Dict[str, Dict[str, str]]
                 Status of each component ('healthy', 'inactive', or 'unavailable')
     """
-
     try:
-        # FastMCP streamable-http requires the /mcp path
-        mcp_url = server_url.rstrip("/") + "/mcp"
-        logger.info(f"Connecting to MCP server at: {mcp_url}")
+        logger.info(f"Connecting to MCP server at: {config.mcp_url}")
 
-        client = Client(mcp_url)
+        client = Client(config.mcp_url)
 
         async with client:
             logger.info("✅ FastMCP client connected")
@@ -137,16 +132,14 @@ def print_health_status(health: Optional[Mapping[str, Any]]) -> None:
         print(f"Version: {health['version']}")
 
 
-async def list_server_resources(
-    server_url: str = "http://127.0.0.1:8765",
-) -> Optional[list]:
+async def list_server_resources(config: MCPClientConfig) -> Optional[list]:
     """
     List all available resources on the MCP server.
 
     Parameters
     ----------
-    server_url : str, optional
-        Server URL for HTTP transport. Defaults to 'http://127.0.0.1:8765'.
+    config : MCPClientConfig
+        Client configuration object with validated settings.
 
     Returns
     -------
@@ -154,10 +147,9 @@ async def list_server_resources(
         List of available resources, or None if failed.
     """
     try:
-        mcp_url = server_url.rstrip("/") + "/mcp"
-        logger.info(f"Listing resources from: {mcp_url}")
+        logger.info(f"Listing resources from: {config.mcp_url}")
 
-        client = Client(mcp_url)
+        client = Client(config.mcp_url)
 
         async with client:
             resources = await client.list_resources()
@@ -170,7 +162,7 @@ async def list_server_resources(
 
 
 async def read_server_resource(
-    resource_uri: str, server_url: str = "http://127.0.0.1:8765"
+    resource_uri: str, config: MCPClientConfig
 ) -> Optional[str]:
     """
     Read a specific resource from the MCP server.
@@ -179,8 +171,8 @@ async def read_server_resource(
     ----------
     resource_uri : str
         URI of the resource to read (e.g., 'napistu://health')
-    server_url : str, optional
-        Server URL for HTTP transport. Defaults to 'http://127.0.0.1:8765'.
+    config : MCPClientConfig
+        Client configuration object with validated settings.
 
     Returns
     -------
@@ -188,10 +180,9 @@ async def read_server_resource(
         Resource content as text, or None if failed.
     """
     try:
-        mcp_url = server_url.rstrip("/") + "/mcp"
-        logger.info(f"Reading resource {resource_uri} from: {mcp_url}")
+        logger.info(f"Reading resource {resource_uri} from: {config.mcp_url}")
 
-        client = Client(mcp_url)
+        client = Client(config.mcp_url)
 
         async with client:
             result = await client.read_resource(resource_uri)

--- a/src/napistu/mcp/codebase.py
+++ b/src/napistu/mcp/codebase.py
@@ -2,173 +2,229 @@
 Codebase exploration components for the Napistu MCP server.
 """
 
-from napistu.mcp.constants import NAPISTU_PY_READTHEDOCS_API
+from typing import Dict, Any
+import json
+import logging
 
 from fastmcp import FastMCP
 
-from typing import Dict, Any
-import json
-
+from napistu.mcp.component_base import ComponentState, MCPComponent
+from napistu.mcp.constants import NAPISTU_PY_READTHEDOCS_API
 from napistu.mcp import codebase_utils
 from napistu.mcp import utils as mcp_utils
 
-# Global cache for codebase information
-_codebase_cache = {
-    "modules": {},
-    "classes": {},
-    "functions": {},
-}
+logger = logging.getLogger(__name__)
 
 
-async def initialize_components() -> bool:
+class CodebaseState(ComponentState):
+    """State management for codebase component."""
+
+    def __init__(self):
+        super().__init__()
+        self.codebase_cache: Dict[str, Dict[str, Any]] = {
+            "modules": {},
+            "classes": {},
+            "functions": {},
+        }
+
+    def is_healthy(self) -> bool:
+        """Component is healthy if it has loaded any codebase information."""
+        return any(bool(section) for section in self.codebase_cache.values())
+
+    def get_health_details(self) -> Dict[str, Any]:
+        """Provide codebase-specific health details."""
+        return {
+            "modules_count": len(self.codebase_cache["modules"]),
+            "classes_count": len(self.codebase_cache["classes"]),
+            "functions_count": len(self.codebase_cache["functions"]),
+            "total_items": sum(
+                len(section) for section in self.codebase_cache.values()
+            ),
+        }
+
+
+class CodebaseComponent(MCPComponent):
+    """MCP component for codebase exploration and search."""
+
+    def _create_state(self) -> CodebaseState:
+        """Create codebase-specific state."""
+        return CodebaseState()
+
+    async def initialize(self) -> bool:
+        """
+        Initialize codebase component by loading documentation from ReadTheDocs.
+
+        Returns
+        -------
+        bool
+            True if codebase information was loaded successfully
+        """
+        try:
+            logger.info("Loading codebase documentation from ReadTheDocs...")
+
+            # Load documentation from the ReadTheDocs API
+            modules = await codebase_utils.read_read_the_docs(
+                NAPISTU_PY_READTHEDOCS_API
+            )
+            self.state.codebase_cache["modules"] = modules
+
+            # Extract functions and classes from the modules
+            functions, classes = (
+                codebase_utils.extract_functions_and_classes_from_modules(modules)
+            )
+            self.state.codebase_cache["functions"] = functions
+            self.state.codebase_cache["classes"] = classes
+
+            logger.info(
+                f"Codebase loading complete: "
+                f"{len(modules)} modules, "
+                f"{len(classes)} classes, "
+                f"{len(functions)} functions"
+            )
+
+            # Consider successful if we loaded any modules
+            return len(modules) > 0
+
+        except Exception as e:
+            logger.error(f"Failed to load codebase documentation: {e}")
+            return False
+
+    def register(self, mcp: FastMCP) -> None:
+        """
+        Register codebase resources and tools with the MCP server.
+
+        Parameters
+        ----------
+        mcp : FastMCP
+            FastMCP server instance
+        """
+
+        # Register resources
+        @mcp.resource("napistu://codebase/summary")
+        async def get_codebase_summary():
+            """Get a summary of all available codebase information."""
+            return {
+                "modules": list(self.state.codebase_cache["modules"].keys()),
+                "classes": list(self.state.codebase_cache["classes"].keys()),
+                "functions": list(self.state.codebase_cache["functions"].keys()),
+            }
+
+        @mcp.resource("napistu://codebase/modules/{module_name}")
+        async def get_module_details(module_name: str) -> Dict[str, Any]:
+            """Get detailed information about a specific module."""
+            if module_name not in self.state.codebase_cache["modules"]:
+                return {"error": f"Module {module_name} not found"}
+
+            return self.state.codebase_cache["modules"][module_name]
+
+        # Register tools
+        @mcp.tool()
+        async def search_codebase(query: str) -> Dict[str, Any]:
+            """
+            Search the codebase for a specific query.
+
+            Args:
+                query: Search term
+
+            Returns:
+                Dictionary with search results organized by code element type, including snippets for context.
+            """
+            results = {
+                "modules": [],
+                "classes": [],
+                "functions": [],
+            }
+
+            # Search modules
+            for module_name, info in self.state.codebase_cache["modules"].items():
+                # Use docstring or description for snippet
+                doc = info.get("doc") or info.get("description") or ""
+                module_text = json.dumps(info)
+                if query.lower() in module_text.lower():
+                    snippet = mcp_utils.get_snippet(doc, query)
+                    results["modules"].append(
+                        {
+                            "name": module_name,
+                            "description": doc,
+                            "snippet": snippet,
+                        }
+                    )
+
+            # Search classes
+            for class_name, info in self.state.codebase_cache["classes"].items():
+                doc = info.get("doc") or info.get("description") or ""
+                class_text = json.dumps(info)
+                if query.lower() in class_text.lower():
+                    snippet = mcp_utils.get_snippet(doc, query)
+                    results["classes"].append(
+                        {
+                            "name": class_name,
+                            "description": doc,
+                            "snippet": snippet,
+                        }
+                    )
+
+            # Search functions
+            for func_name, info in self.state.codebase_cache["functions"].items():
+                doc = info.get("doc") or info.get("description") or ""
+                func_text = json.dumps(info)
+                if query.lower() in func_text.lower():
+                    snippet = mcp_utils.get_snippet(doc, query)
+                    results["functions"].append(
+                        {
+                            "name": func_name,
+                            "description": doc,
+                            "signature": info.get("signature", ""),
+                            "snippet": snippet,
+                        }
+                    )
+
+            return results
+
+        @mcp.tool()
+        async def get_function_documentation(function_name: str) -> Dict[str, Any]:
+            """
+            Get detailed documentation for a specific function.
+
+            Args:
+                function_name: Name of the function
+
+            Returns:
+                Dictionary with function documentation
+            """
+            if function_name not in self.state.codebase_cache["functions"]:
+                return {"error": f"Function {function_name} not found"}
+
+            return self.state.codebase_cache["functions"][function_name]
+
+        @mcp.tool()
+        async def get_class_documentation(class_name: str) -> Dict[str, Any]:
+            """
+            Get detailed documentation for a specific class.
+
+            Args:
+                class_name: Name of the class
+
+            Returns:
+                Dictionary with class documentation
+            """
+            if class_name not in self.state.codebase_cache["classes"]:
+                return {"error": f"Class {class_name} not found"}
+
+            return self.state.codebase_cache["classes"][class_name]
+
+
+# Module-level component instance
+_component = CodebaseComponent()
+
+
+def get_component() -> CodebaseComponent:
     """
-    Initialize codebase components.
+    Get the codebase component instance.
 
     Returns
     -------
-    bool
-        True if initialization is successful.
+    CodebaseComponent
+        The codebase component instance
     """
-    global _codebase_cache
-    # Load documentation from the ReadTheDocs API
-    _codebase_cache["modules"] = await codebase_utils.read_read_the_docs(
-        NAPISTU_PY_READTHEDOCS_API
-    )
-    # Extract functions and classes from the modules
-    _codebase_cache["functions"], _codebase_cache["classes"] = (
-        codebase_utils.extract_functions_and_classes_from_modules(
-            _codebase_cache["modules"]
-        )
-    )
-    return True
-
-
-def register_components(mcp: FastMCP):
-    """
-    Register codebase components with the MCP server.
-
-    Args:
-        mcp: FastMCP server instance
-    """
-    global _codebase_cache
-
-    # Register resources
-    @mcp.resource("napistu://codebase/summary")
-    async def get_codebase_summary():
-        """
-        Get a summary of all available codebase information.
-        """
-        return {
-            "modules": list(_codebase_cache["modules"].keys()),
-            "classes": list(_codebase_cache["classes"].keys()),
-            "functions": list(_codebase_cache["functions"].keys()),
-        }
-
-    @mcp.resource("napistu://codebase/modules/{module_name}")
-    async def get_module_details(module_name: str) -> Dict[str, Any]:
-        """
-        Get detailed information about a specific module.
-
-        Args:
-            module_name: Name of the module
-        """
-        if module_name not in _codebase_cache["modules"]:
-            return {"error": f"Module {module_name} not found"}
-
-        return _codebase_cache["modules"][module_name]
-
-    # Register tools
-    @mcp.tool()
-    async def search_codebase(query: str) -> Dict[str, Any]:
-        """
-        Search the codebase for a specific query.
-
-        Args:
-            query: Search term
-
-        Returns:
-            Dictionary with search results organized by code element type, including snippets for context.
-        """
-        results = {
-            "modules": [],
-            "classes": [],
-            "functions": [],
-        }
-
-        # Search modules
-        for module_name, info in _codebase_cache["modules"].items():
-            # Use docstring or description for snippet
-            doc = info.get("doc") or info.get("description") or ""
-            module_text = json.dumps(info)
-            if query.lower() in module_text.lower():
-                snippet = mcp_utils.get_snippet(doc, query)
-                results["modules"].append(
-                    {
-                        "name": module_name,
-                        "description": doc,
-                        "snippet": snippet,
-                    }
-                )
-
-        # Search classes
-        for class_name, info in _codebase_cache["classes"].items():
-            doc = info.get("doc") or info.get("description") or ""
-            class_text = json.dumps(info)
-            if query.lower() in class_text.lower():
-                snippet = mcp_utils.get_snippet(doc, query)
-                results["classes"].append(
-                    {
-                        "name": class_name,
-                        "description": doc,
-                        "snippet": snippet,
-                    }
-                )
-
-        # Search functions
-        for func_name, info in _codebase_cache["functions"].items():
-            doc = info.get("doc") or info.get("description") or ""
-            func_text = json.dumps(info)
-            if query.lower() in func_text.lower():
-                snippet = mcp_utils.get_snippet(doc, query)
-                results["functions"].append(
-                    {
-                        "name": func_name,
-                        "description": doc,
-                        "signature": info.get("signature", ""),
-                        "snippet": snippet,
-                    }
-                )
-
-        return results
-
-    @mcp.tool()
-    async def get_function_documentation(function_name: str) -> Dict[str, Any]:
-        """
-        Get detailed documentation for a specific function.
-
-        Args:
-            function_name: Name of the function
-
-        Returns:
-            Dictionary with function documentation
-        """
-        if function_name not in _codebase_cache["functions"]:
-            return {"error": f"Function {function_name} not found"}
-
-        return _codebase_cache["functions"][function_name]
-
-    @mcp.tool()
-    async def get_class_documentation(class_name: str) -> Dict[str, Any]:
-        """
-        Get detailed documentation for a specific class.
-
-        Args:
-            class_name: Name of the class
-
-        Returns:
-            Dictionary with class documentation
-        """
-        if class_name not in _codebase_cache["classes"]:
-            return {"error": f"Class {class_name} not found"}
-
-        return _codebase_cache["classes"][class_name]
+    return _component

--- a/src/napistu/mcp/component_base.py
+++ b/src/napistu/mcp/component_base.py
@@ -1,0 +1,170 @@
+"""
+Base classes for MCP server components.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+import logging
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+class ComponentState(ABC):
+    """
+    Base class for component state management.
+
+    Provides standard interface for health checking and initialization tracking.
+    """
+
+    def __init__(self):
+        self.initialized = False
+        self.initialization_error = None
+
+    @abstractmethod
+    def is_healthy(self) -> bool:
+        """
+        Check if component has successfully loaded data and is functioning.
+
+        Returns
+        -------
+        bool
+            True if component is healthy (has data and no errors)
+        """
+        pass
+
+    def is_available(self) -> bool:
+        """
+        Check if component is available (initialized without critical errors).
+
+        Returns
+        -------
+        bool
+            True if component initialized successfully, regardless of data status
+        """
+        return self.initialized and self.initialization_error is None
+
+    def get_health_status(self) -> Dict[str, Any]:
+        """
+        Get standardized health status for health checks.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Health status dictionary with standard format:
+            - status: 'initializing', 'unavailable', 'inactive', or 'healthy'
+            - error: error message if unavailable
+            - additional component-specific details if healthy
+        """
+        if not self.initialized:
+            return {"status": "initializing"}
+        elif self.initialization_error:
+            return {"status": "unavailable", "error": str(self.initialization_error)}
+        elif not self.is_healthy():
+            return {"status": "inactive"}
+        else:
+            return {"status": "healthy", **self.get_health_details()}
+
+    def get_health_details(self) -> Dict[str, Any]:
+        """
+        Get component-specific health details.
+
+        Override in subclasses to provide additional health information.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Component-specific health details
+        """
+        return {}
+
+
+class MCPComponent(ABC):
+    """
+    Base class for MCP server components.
+
+    Provides standard interface for initialization and registration.
+    """
+
+    def __init__(self):
+        self.state = self._create_state()
+
+    @abstractmethod
+    def _create_state(self) -> ComponentState:
+        """
+        Create the component state object.
+
+        Returns
+        -------
+        ComponentState
+            Component-specific state instance
+        """
+        pass
+
+    @abstractmethod
+    async def initialize(self) -> bool:
+        """
+        Initialize the component asynchronously.
+
+        Should populate component state and handle any external data loading.
+
+        Returns
+        -------
+        bool
+            True if initialization successful
+        """
+        pass
+
+    @abstractmethod
+    def register(self, mcp: FastMCP) -> None:
+        """
+        Register component resources and tools with the MCP server.
+
+        Parameters
+        ----------
+        mcp : FastMCP
+            FastMCP server instance to register with
+        """
+        pass
+
+    def get_state(self) -> ComponentState:
+        """
+        Get the component state for health checks and testing.
+
+        Returns
+        -------
+        ComponentState
+            Current component state
+        """
+        return self.state
+
+    async def safe_initialize(self) -> bool:
+        """
+        Initialize with error handling and state tracking.
+
+        Returns
+        -------
+        bool
+            True if initialization successful
+        """
+        try:
+            logger.info(f"Initializing {self.__class__.__name__}...")
+
+            result = await self.initialize()
+
+            self.state.initialized = True
+            self.state.initialization_error = None
+
+            if result:
+                logger.info(f"✅ {self.__class__.__name__} initialized successfully")
+            else:
+                logger.warning(f"⚠️ {self.__class__.__name__} initialized with issues")
+
+            return result
+
+        except Exception as e:
+            logger.error(f"❌ {self.__class__.__name__} failed to initialize: {e}")
+            self.state.initialized = True
+            self.state.initialization_error = e
+            return False

--- a/src/napistu/mcp/config.py
+++ b/src/napistu/mcp/config.py
@@ -1,0 +1,223 @@
+from pydantic import BaseModel, Field, computed_field, validator
+from typing import Optional
+import click
+from napistu.mcp.constants import MCP_DEFAULTS, MCP_PRODUCTION_URL
+
+
+class MCPServerConfig(BaseModel):
+    """Server-side MCP configuration with validation."""
+
+    host: str = Field(description="Host to bind server to")
+    port: int = Field(ge=1, le=65535, description="Port to bind server to")
+    server_name: str = Field(description="Server name")
+
+    @validator("host")
+    def validate_host(cls, v):
+        """Basic host validation."""
+        if not v or v.isspace():
+            raise ValueError("Host cannot be empty")
+        return v.strip()
+
+    @computed_field
+    @property
+    def bind_address(self) -> str:
+        """Full address for server binding."""
+        return f"{self.host}:{self.port}"
+
+
+class MCPClientConfig(BaseModel):
+    """Client-side MCP configuration with validation."""
+
+    host: str = Field(description="Target server host")
+    port: int = Field(ge=1, le=65535, description="Target server port")
+    use_https: bool = Field(description="Use HTTPS instead of HTTP")
+
+    @computed_field
+    @property
+    def base_url(self) -> str:
+        """Base URL for HTTP requests."""
+        protocol = "https" if self.use_https else "http"
+        return f"{protocol}://{self.host}:{self.port}"
+
+    @computed_field
+    @property
+    def mcp_url(self) -> str:
+        """Full MCP endpoint URL."""
+        return f"{self.base_url}{MCP_DEFAULTS.MCP_PATH}"
+
+
+# Preset configurations - no overrides needed
+def local_server_config() -> MCPServerConfig:
+    """Local development server configuration."""
+    return MCPServerConfig(
+        host=MCP_DEFAULTS.LOCAL_HOST,
+        port=MCP_DEFAULTS.LOCAL_PORT,
+        server_name=MCP_DEFAULTS.LOCAL_SERVER_NAME,
+    )
+
+
+def production_server_config() -> MCPServerConfig:
+    """Production server configuration."""
+    return MCPServerConfig(
+        host=MCP_DEFAULTS.PRODUCTION_HOST,
+        port=MCP_DEFAULTS.PRODUCTION_PORT,
+        server_name=MCP_DEFAULTS.PRODUCTION_SERVER_NAME,
+    )
+
+
+def local_client_config() -> MCPClientConfig:
+    """Local development client configuration."""
+    return MCPClientConfig(
+        host=MCP_DEFAULTS.LOCAL_HOST, port=MCP_DEFAULTS.LOCAL_PORT, use_https=False
+    )
+
+
+def production_client_config() -> MCPClientConfig:
+    """Production client configuration."""
+    # Parse production URL to extract host
+    production_host = MCP_PRODUCTION_URL.replace("https://", "").split("/")[0]
+    return MCPClientConfig(
+        host=production_host, port=MCP_DEFAULTS.HTTPS_PORT, use_https=True
+    )
+
+
+# Utility functions for CLI validation
+def validate_server_config_flags(
+    local: bool,
+    production: bool,
+    host: Optional[str],
+    port: Optional[int],
+    server_name: Optional[str],
+) -> MCPServerConfig:
+    """
+    Validate server configuration flags and return appropriate config.
+
+    Raises click.BadParameter if incompatible flags are used.
+    """
+    # Check for mutually exclusive presets
+    if local and production:
+        raise click.BadParameter("Cannot use both --local and --production flags")
+
+    # Check for preset + manual config conflicts
+    preset_used = local or production
+    manual_config_used = any(
+        [host is not None, port is not None, server_name is not None]
+    )
+
+    if preset_used and manual_config_used:
+        preset_name = "local" if local else "production"
+        raise click.BadParameter(
+            f"Cannot use --{preset_name} with manual host/port/server-name configuration. "
+            f"Use either preset flags OR manual configuration, not both."
+        )
+
+    # Return appropriate config
+    if local:
+        return local_server_config()
+    elif production:
+        return production_server_config()
+    else:
+        # Manual configuration - all required
+        if not all([host, port, server_name]):
+            raise click.BadParameter(
+                "Manual configuration requires --host, --port, and --server-name"
+            )
+        return MCPServerConfig(host=host, port=port, server_name=server_name)
+
+
+def validate_client_config_flags(
+    local: bool,
+    production: bool,
+    host: Optional[str],
+    port: Optional[int],
+    use_https: Optional[bool],
+) -> MCPClientConfig:
+    """
+    Validate client configuration flags and return appropriate config.
+
+    Raises click.BadParameter if incompatible flags are used.
+    """
+    # Check for mutually exclusive presets
+    if local and production:
+        raise click.BadParameter("Cannot use both --local and --production flags")
+
+    # Check for preset + manual config conflicts
+    preset_used = local or production
+    manual_config_used = any(
+        [host is not None, port is not None, use_https is not None]
+    )
+
+    if preset_used and manual_config_used:
+        preset_name = "local" if local else "production"
+        raise click.BadParameter(
+            f"Cannot use --{preset_name} with manual host/port/https configuration. "
+            f"Use either preset flags OR manual configuration, not both."
+        )
+
+    # Return appropriate config
+    if local:
+        return local_client_config()
+    elif production:
+        return production_client_config()
+    else:
+        # Manual configuration - all required
+        if not all([host is not None, port is not None, use_https is not None]):
+            raise click.BadParameter(
+                "Manual configuration requires --host, --port, and --https"
+            )
+        return MCPClientConfig(host=host, port=port, use_https=use_https)
+
+
+# Click option decorators for reuse
+def server_config_options(f):
+    """Decorator to add server configuration options to click commands."""
+    f = click.option(
+        "--production", is_flag=True, help="Use production server configuration"
+    )(f)
+    f = click.option(
+        "--local", is_flag=True, help="Use local development server configuration"
+    )(f)
+    f = click.option(
+        "--host",
+        type=str,
+        help="Host to bind server to (requires --port and --server-name)",
+    )(f)
+    f = click.option(
+        "--port",
+        type=int,
+        help="Port to bind server to (requires --host and --server-name)",
+    )(f)
+    f = click.option(
+        "--server-name", type=str, help="Server name (requires --host and --port)"
+    )(f)
+    return f
+
+
+def client_config_options(f):
+    """Decorator to add client configuration options to click commands."""
+    f = click.option("--production", is_flag=True, help="Connect to production server")(
+        f
+    )
+    f = click.option(
+        "--local", is_flag=True, help="Connect to local development server"
+    )(f)
+    f = click.option(
+        "--host",
+        type=str,
+        default=None,
+        help="Server host (requires --port and --https)",
+    )(f)
+    f = click.option(
+        "--port",
+        type=int,
+        default=None,
+        help="Server port (requires --host and --https)",
+    )(f)
+    f = click.option(
+        "--https",
+        is_flag=True,
+        default=None,
+        flag_value=True,
+        help="Use HTTPS (requires --host and --port)",
+    )(f)
+    return f

--- a/src/napistu/mcp/constants.py
+++ b/src/napistu/mcp/constants.py
@@ -56,8 +56,8 @@ MCP_PRODUCTION_URL = "https://napistu-mcp-server-844820030839.us-west1.run.app"
 
 # Profile names (component configurations)
 MCP_PROFILES = SimpleNamespace(
-    LOCAL="local",  # execution only
-    REMOTE="remote",  # docs + codebase + tutorials
+    EXECUTION="execution",  # execution only
+    DOCS="docs",  # docs + codebase + tutorials
     FULL="full",  # all components
 )
 

--- a/src/napistu/mcp/constants.py
+++ b/src/napistu/mcp/constants.py
@@ -31,6 +31,36 @@ TOOL_VARS = SimpleNamespace(
     SNIPPET="snippet",
 )
 
+# MCP Server Configuration Constants
+MCP_DEFAULTS = SimpleNamespace(
+    # Local development defaults
+    LOCAL_HOST="127.0.0.1",
+    LOCAL_PORT=8765,
+    # Production defaults
+    PRODUCTION_HOST="0.0.0.0",
+    PRODUCTION_PORT=8080,
+    # Server names
+    LOCAL_SERVER_NAME="napistu-local",
+    PRODUCTION_SERVER_NAME="napistu-production",
+    FULL_SERVER_NAME="napistu-full",
+    # Transport configuration
+    TRANSPORT="streamable-http",
+    MCP_PATH="/mcp",
+    # Standard protocol ports
+    HTTP_PORT=80,
+    HTTPS_PORT=443,
+)
+
+# Production server URL
+MCP_PRODUCTION_URL = "https://napistu-mcp-server-844820030839.us-west1.run.app"
+
+# Profile names (component configurations)
+MCP_PROFILES = SimpleNamespace(
+    LOCAL="local",  # execution only
+    REMOTE="remote",  # docs + codebase + tutorials
+    FULL="full",  # all components
+)
+
 READMES = {
     "napistu": "https://raw.githubusercontent.com/napistu/napistu/main/README.md",
     "napistu-py": "https://raw.githubusercontent.com/napistu/napistu-py/main/README.md",

--- a/src/napistu/mcp/documentation.py
+++ b/src/napistu/mcp/documentation.py
@@ -2,172 +2,282 @@
 Documentation components for the Napistu MCP server.
 """
 
+from typing import Dict, Any
+import logging
+
 from fastmcp import FastMCP
 
+from napistu.mcp.component_base import ComponentState, MCPComponent
 from napistu.mcp import documentation_utils
 from napistu.mcp import utils as mcp_utils
 from napistu.mcp.constants import DOCUMENTATION, READMES, REPOS_WITH_ISSUES, WIKI_PAGES
 
-# Global cache for documentation content
-_docs_cache = {
-    DOCUMENTATION.README: {},
-    DOCUMENTATION.WIKI: {},
-    DOCUMENTATION.ISSUES: {},
-    DOCUMENTATION.PRS: {},
-    DOCUMENTATION.PACKAGEDOWN: {},
-}
+logger = logging.getLogger(__name__)
 
 
-async def initialize_components() -> bool:
+class DocumentationState(ComponentState):
+    """State management for documentation component."""
+
+    def __init__(self):
+        super().__init__()
+        self.docs_cache: Dict[str, Dict[str, Any]] = {
+            DOCUMENTATION.README: {},
+            DOCUMENTATION.WIKI: {},
+            DOCUMENTATION.ISSUES: {},
+            DOCUMENTATION.PRS: {},
+            DOCUMENTATION.PACKAGEDOWN: {},
+        }
+
+    def is_healthy(self) -> bool:
+        """Component is healthy if it has loaded any documentation."""
+        return any(bool(section) for section in self.docs_cache.values())
+
+    def get_health_details(self) -> Dict[str, Any]:
+        """Provide documentation-specific health details."""
+        return {
+            "readme_count": len(self.docs_cache[DOCUMENTATION.README]),
+            "wiki_pages": len(self.docs_cache[DOCUMENTATION.WIKI]),
+            "issues_repos": len(self.docs_cache[DOCUMENTATION.ISSUES]),
+            "prs_repos": len(self.docs_cache[DOCUMENTATION.PRS]),
+            "total_sections": sum(len(section) for section in self.docs_cache.values()),
+        }
+
+
+class DocumentationComponent(MCPComponent):
+    """MCP component for documentation management and search."""
+
+    def _create_state(self) -> DocumentationState:
+        """Create documentation-specific state."""
+        return DocumentationState()
+
+    async def initialize(self) -> bool:
+        """
+        Initialize documentation component by loading all documentation sources.
+
+        Returns
+        -------
+        bool
+            True if at least some documentation was loaded successfully
+        """
+        success_count = 0
+        total_operations = 0
+
+        # Load README files
+        logger.info("Loading README files...")
+        for name, url in READMES.items():
+            total_operations += 1
+            try:
+                content = await documentation_utils.load_readme_content(url)
+                self.state.docs_cache[DOCUMENTATION.README][name] = content
+                success_count += 1
+                logger.debug(f"Loaded README: {name}")
+            except Exception as e:
+                logger.warning(f"Failed to load README {name}: {e}")
+
+        # Load wiki pages
+        logger.info("Loading wiki pages...")
+        for page in WIKI_PAGES:
+            total_operations += 1
+            try:
+                content = await documentation_utils.fetch_wiki_page(page)
+                self.state.docs_cache[DOCUMENTATION.WIKI][page] = content
+                success_count += 1
+                logger.debug(f"Loaded wiki page: {page}")
+            except Exception as e:
+                logger.warning(f"Failed to load wiki page {page}: {e}")
+
+        # Load issues and PRs
+        logger.info("Loading issues and pull requests...")
+        for repo in REPOS_WITH_ISSUES:
+            total_operations += 2  # Issues and PRs
+            try:
+                issues = await documentation_utils.list_issues(repo)
+                self.state.docs_cache[DOCUMENTATION.ISSUES][repo] = issues
+                success_count += 1
+                logger.debug(f"Loaded issues for repo: {repo}")
+            except Exception as e:
+                logger.warning(f"Failed to load issues for {repo}: {e}")
+
+            try:
+                prs = await documentation_utils.list_pull_requests(repo)
+                self.state.docs_cache[DOCUMENTATION.PRS][repo] = prs
+                success_count += 1
+                logger.debug(f"Loaded PRs for repo: {repo}")
+            except Exception as e:
+                logger.warning(f"Failed to load PRs for {repo}: {e}")
+
+        logger.info(
+            f"Documentation loading complete: {success_count}/{total_operations} operations successful"
+        )
+
+        # Consider successful if at least some documentation loaded
+        return success_count > 0
+
+    def register(self, mcp: FastMCP) -> None:
+        """
+        Register documentation resources and tools with the MCP server.
+
+        Parameters
+        ----------
+        mcp : FastMCP
+            FastMCP server instance
+        """
+
+        # Register resources
+        @mcp.resource("napistu://documentation/summary")
+        async def get_documentation_summary():
+            """Get a summary of all available documentation."""
+            return {
+                "readme_files": list(
+                    self.state.docs_cache[DOCUMENTATION.README].keys()
+                ),
+                "issues": list(self.state.docs_cache[DOCUMENTATION.ISSUES].keys()),
+                "prs": list(self.state.docs_cache[DOCUMENTATION.PRS].keys()),
+                "wiki_pages": list(self.state.docs_cache[DOCUMENTATION.WIKI].keys()),
+                "packagedown_sections": list(
+                    self.state.docs_cache[DOCUMENTATION.PACKAGEDOWN].keys()
+                ),
+            }
+
+        @mcp.resource("napistu://documentation/readme/{file_name}")
+        async def get_readme_content(file_name: str):
+            """Get the content of a specific README file."""
+            if file_name not in self.state.docs_cache[DOCUMENTATION.README]:
+                return {"error": f"README file {file_name} not found"}
+
+            return {
+                "content": self.state.docs_cache[DOCUMENTATION.README][file_name],
+                "format": "markdown",
+            }
+
+        @mcp.resource("napistu://documentation/issues/{repo}")
+        async def get_issues(repo: str):
+            """Get the list of issues for a given repository."""
+            return self.state.docs_cache[DOCUMENTATION.ISSUES].get(repo, [])
+
+        @mcp.resource("napistu://documentation/prs/{repo}")
+        async def get_prs(repo: str):
+            """Get the list of pull requests for a given repository."""
+            return self.state.docs_cache[DOCUMENTATION.PRS].get(repo, [])
+
+        @mcp.resource("napistu://documentation/issue/{repo}/{number}")
+        async def get_issue_resource(repo: str, number: int):
+            """Get a single issue by number for a given repository."""
+            # Try cache first
+            cached = next(
+                (
+                    i
+                    for i in self.state.docs_cache[DOCUMENTATION.ISSUES].get(repo, [])
+                    if i["number"] == number
+                ),
+                None,
+            )
+            if cached:
+                return cached
+            # Fallback to live fetch
+            return await documentation_utils.get_issue(repo, number)
+
+        @mcp.resource("napistu://documentation/pr/{repo}/{number}")
+        async def get_pr_resource(repo: str, number: int):
+            """Get a single pull request by number for a given repository."""
+            # Try cache first
+            cached = next(
+                (
+                    pr
+                    for pr in self.state.docs_cache[DOCUMENTATION.PRS].get(repo, [])
+                    if pr["number"] == number
+                ),
+                None,
+            )
+            if cached:
+                return cached
+            # Fallback to live fetch
+            return await documentation_utils.get_issue(repo, number)
+
+        # Register tools
+        @mcp.tool()
+        async def search_documentation(query: str):
+            """
+            Search all documentation for a specific query.
+
+            Args:
+                query: Search term
+
+            Returns:
+                Dictionary with search results organized by documentation type
+            """
+            results = {
+                DOCUMENTATION.README: [],
+                DOCUMENTATION.WIKI: [],
+                DOCUMENTATION.ISSUES: [],
+                DOCUMENTATION.PRS: [],
+                DOCUMENTATION.PACKAGEDOWN: [],
+            }
+
+            # Search README files
+            for readme_name, content in self.state.docs_cache[
+                DOCUMENTATION.README
+            ].items():
+                if query.lower() in content.lower():
+                    results[DOCUMENTATION.README].append(
+                        {
+                            "name": readme_name,
+                            "snippet": mcp_utils.get_snippet(content, query),
+                        }
+                    )
+
+            # Search wiki pages
+            for page_name, content in self.state.docs_cache[DOCUMENTATION.WIKI].items():
+                if query.lower() in content.lower():
+                    results[DOCUMENTATION.WIKI].append(
+                        {
+                            "name": page_name,
+                            "snippet": mcp_utils.get_snippet(content, query),
+                        }
+                    )
+
+            # Search issues
+            for repo, issues in self.state.docs_cache[DOCUMENTATION.ISSUES].items():
+                for issue in issues:
+                    issue_text = f"{issue.get('title', '')} {issue.get('body', '')}"
+                    if query.lower() in issue_text.lower():
+                        results[DOCUMENTATION.ISSUES].append(
+                            {
+                                "name": f"{repo}#{issue.get('number')}",
+                                "title": issue.get("title"),
+                                "url": issue.get("url"),
+                                "snippet": mcp_utils.get_snippet(issue_text, query),
+                            }
+                        )
+
+            # Search PRs
+            for repo, prs in self.state.docs_cache[DOCUMENTATION.PRS].items():
+                for pr in prs:
+                    pr_text = f"{pr.get('title', '')} {pr.get('body', '')}"
+                    if query.lower() in pr_text.lower():
+                        results[DOCUMENTATION.PRS].append(
+                            {
+                                "name": f"{repo}#{pr.get('number')}",
+                                "title": pr.get("title"),
+                                "url": pr.get("url"),
+                                "snippet": mcp_utils.get_snippet(pr_text, query),
+                            }
+                        )
+
+            return results
+
+
+# Module-level component instance
+_component = DocumentationComponent()
+
+
+def get_component() -> DocumentationComponent:
     """
-    Initialize documentation components.
-    Loads documentation content and should be called before the server starts handling requests.
+    Get the documentation component instance.
 
     Returns
     -------
-    bool
-        True if initialization is successful.
+    DocumentationComponent
+        The documentation component instance
     """
-    global _docs_cache
-    # Load documentation from the READMES dict
-    for name, url in READMES.items():
-        _docs_cache[DOCUMENTATION.README][name] = (
-            await documentation_utils.load_readme_content(url)
-        )
-
-    # Load wiki pages
-    for page in WIKI_PAGES:
-        _docs_cache[DOCUMENTATION.WIKI][page] = (
-            await documentation_utils.fetch_wiki_page(page)
-        )
-
-    # Load issue and PR summaries with the GitHub API
-    for repo in REPOS_WITH_ISSUES:
-        _docs_cache[DOCUMENTATION.ISSUES][repo] = await documentation_utils.list_issues(
-            repo
-        )
-        _docs_cache[DOCUMENTATION.PRS][repo] = (
-            await documentation_utils.list_pull_requests(repo)
-        )
-    return True
-
-
-def register_components(mcp: FastMCP):
-    """
-    Register documentation components with the MCP server.
-
-    Args:
-        mcp: FastMCP server instance
-    """
-
-    # Register resources
-    @mcp.resource("napistu://documentation/summary")
-    async def get_documentation_summary():
-        """
-        Get a summary of all available documentation.
-        """
-        return {
-            "readme_files": list(_docs_cache[DOCUMENTATION.README].keys()),
-            "issues": list(_docs_cache[DOCUMENTATION.ISSUES].keys()),
-            "prs": list(_docs_cache[DOCUMENTATION.PRS].keys()),
-            "wiki_pages": list(_docs_cache[DOCUMENTATION.WIKI].keys()),
-            "packagedown_sections": list(_docs_cache[DOCUMENTATION.PACKAGEDOWN].keys()),
-        }
-
-    @mcp.resource("napistu://documentation/readme/{file_name}")
-    async def get_readme_content(file_name: str):
-        """
-        Get the content of a specific README file.
-
-        Args:
-            file_name: Name of the README file
-        """
-        if file_name not in _docs_cache[DOCUMENTATION.README]:
-            return {"error": f"README file {file_name} not found"}
-
-        return {
-            "content": _docs_cache[DOCUMENTATION.README][file_name],
-            "format": "markdown",
-        }
-
-    @mcp.resource("napistu://documentation/issues/{repo}")
-    async def get_issues(repo: str):
-        """
-        Get the list of issues for a given repository.
-        """
-        return _docs_cache[DOCUMENTATION.ISSUES].get(repo, [])
-
-    @mcp.resource("napistu://documentation/prs/{repo}")
-    async def get_prs(repo: str):
-        """
-        Get the list of pull requests for a given repository.
-        """
-        return _docs_cache[DOCUMENTATION.PRS].get(repo, [])
-
-    @mcp.resource("napistu://documentation/issue/{repo}/{number}")
-    async def get_issue_resource(repo: str, number: int):
-        """
-        Get a single issue by number for a given repository.
-        """
-        # Try cache first
-        cached = next(
-            (
-                i
-                for i in _docs_cache[DOCUMENTATION.ISSUES].get(repo, [])
-                if i["number"] == number
-            ),
-            None,
-        )
-        if cached:
-            return cached
-        # Fallback to live fetch
-        return await documentation_utils.get_issue(repo, number)
-
-    @mcp.resource("napistu://documentation/pr/{repo}/{number}")
-    async def get_pr_resource(repo: str, number: int):
-        """
-        Get a single pull request by number for a given repository.
-        """
-        # Try cache first
-        cached = next(
-            (
-                pr
-                for pr in _docs_cache[DOCUMENTATION.PRS].get(repo, [])
-                if pr["number"] == number
-            ),
-            None,
-        )
-        if cached:
-            return cached
-        # Fallback to live fetch
-        return await documentation_utils.get_issue(repo, number)
-
-    # Register tools
-    @mcp.tool()
-    async def search_documentation(query: str):
-        """
-        Search all documentation for a specific query.
-
-        Args:
-            query: Search term
-
-        Returns:
-            Dictionary with search results organized by documentation type
-        """
-        results = {
-            DOCUMENTATION.README: [],
-            DOCUMENTATION.WIKI: [],
-            DOCUMENTATION.ISSUES: [],
-            DOCUMENTATION.PRS: [],
-            DOCUMENTATION.PACKAGEDOWN: [],
-        }
-        # Simple text search
-        for readme_name, content in _docs_cache[DOCUMENTATION.README].items():
-            if query.lower() in content.lower():
-                results[DOCUMENTATION.README].append(
-                    {
-                        "name": readme_name,
-                        "snippet": mcp_utils.get_snippet(content, query),
-                    }
-                )
-        return results
+    return _component

--- a/src/napistu/mcp/execution.py
+++ b/src/napistu/mcp/execution.py
@@ -4,379 +4,446 @@ Function execution components for the Napistu MCP server.
 
 from typing import Dict, List, Any, Optional
 import inspect
+import logging
 
-# Global storage for session context and objects
-_session_context = {}
-_session_objects = {}
+from fastmcp import FastMCP
+
+from napistu.mcp.component_base import ComponentState, MCPComponent
+
+logger = logging.getLogger(__name__)
 
 
-async def initialize_components() -> bool:
+class ExecutionState(ComponentState):
+    """State management for execution component."""
+
+    def __init__(
+        self,
+        session_context: Optional[Dict] = None,
+        object_registry: Optional[Dict] = None,
+    ):
+        super().__init__()
+        # Session context contains global functions and modules
+        self.session_context = session_context or {}
+        # Object registry contains user-registered objects
+        self.session_objects = object_registry or {}
+
+    def is_healthy(self) -> bool:
+        """Component is healthy if it has a session context."""
+        return bool(self.session_context)
+
+    def get_health_details(self) -> Dict[str, Any]:
+        """Provide execution-specific health details."""
+        return {
+            "session_context_items": len(self.session_context),
+            "registered_objects": len(self.session_objects),
+            "context_keys": list(self.session_context.keys()),
+            "object_names": list(self.session_objects.keys()),
+        }
+
+    def register_object(self, name: str, obj: Any) -> None:
+        """Register an object with the execution component."""
+        self.session_objects[name] = obj
+        logger.info(f"Registered object '{name}' with MCP server")
+
+
+class ExecutionComponent(MCPComponent):
+    """MCP component for function execution and object management."""
+
+    def __init__(
+        self,
+        session_context: Optional[Dict] = None,
+        object_registry: Optional[Dict] = None,
+    ):
+        # Override parent constructor to pass context to state
+        self.state = ExecutionState(session_context, object_registry)
+
+    def _create_state(self) -> ExecutionState:
+        """This won't be called due to overridden constructor."""
+        pass
+
+    async def initialize(self) -> bool:
+        """
+        Initialize execution component by setting up the session context.
+
+        Returns
+        -------
+        bool
+            True if initialization successful
+        """
+        try:
+            # Import and add napistu to session context
+            import napistu
+
+            self.state.session_context["napistu"] = napistu
+
+            logger.info("Execution component initialized with napistu module")
+            return True
+
+        except ImportError as e:
+            logger.error(f"Failed to import napistu module: {e}")
+            return False
+
+    def register_object(self, name: str, obj: Any) -> None:
+        """
+        Register an object with the execution component.
+
+        Args:
+            name: Name to reference the object by
+            obj: The object to register
+        """
+        self.state.register_object(name, obj)
+
+    def register(self, mcp: FastMCP) -> None:
+        """
+        Register execution resources and tools with the MCP server.
+
+        Parameters
+        ----------
+        mcp : FastMCP
+            FastMCP server instance
+        """
+
+        # Register resources
+        @mcp.resource("napistu://execution/registry")
+        async def get_registry():
+            """Get a summary of all objects registered with the server."""
+            return {
+                "object_count": len(self.state.session_objects),
+                "object_names": list(self.state.session_objects.keys()),
+                "object_types": {
+                    name: type(obj).__name__
+                    for name, obj in self.state.session_objects.items()
+                },
+            }
+
+        @mcp.resource("napistu://execution/environment")
+        async def get_environment_info() -> Dict[str, Any]:
+            """Get information about the local Python environment."""
+            try:
+                import napistu
+
+                napistu_version = getattr(napistu, "__version__", "unknown")
+            except ImportError:
+                napistu_version = "not installed"
+
+            import sys
+
+            return {
+                "python_version": sys.version,
+                "napistu_version": napistu_version,
+                "platform": sys.platform,
+                "registered_objects": list(self.state.session_objects.keys()),
+                "session_context": list(self.state.session_context.keys()),
+            }
+
+        # Register tools
+        @mcp.tool()
+        async def list_registry() -> Dict[str, Any]:
+            """List all objects registered with the server."""
+            result = {}
+
+            for name, obj in self.state.session_objects.items():
+                obj_type = type(obj).__name__
+
+                # Get additional info based on object type
+                if hasattr(obj, "shape"):  # For pandas DataFrame or numpy array
+                    obj_info = {
+                        "type": obj_type,
+                        "shape": str(obj.shape),
+                    }
+                elif hasattr(obj, "__len__"):  # For lists, dicts, etc.
+                    obj_info = {
+                        "type": obj_type,
+                        "length": len(obj),
+                    }
+                else:
+                    obj_info = {
+                        "type": obj_type,
+                    }
+
+                result[name] = obj_info
+
+            return result
+
+        @mcp.tool()
+        async def describe_object(object_name: str) -> Dict[str, Any]:
+            """Get detailed information about a registered object."""
+            if object_name not in self.state.session_objects:
+                return {"error": f"Object '{object_name}' not found in registry"}
+
+            obj = self.state.session_objects[object_name]
+            obj_type = type(obj).__name__
+
+            # Basic info for all objects
+            result = {
+                "name": object_name,
+                "type": obj_type,
+                "methods": [],
+                "attributes": [],
+            }
+
+            # Add methods and attributes
+            for name in dir(obj):
+                if name.startswith("_"):
+                    continue
+
+                try:
+                    attr = getattr(obj, name)
+
+                    if callable(attr):
+                        # Method
+                        sig = str(inspect.signature(attr))
+                        doc = inspect.getdoc(attr) or ""
+                        result["methods"].append(
+                            {
+                                "name": name,
+                                "signature": sig,
+                                "docstring": doc,
+                            }
+                        )
+                    else:
+                        # Attribute
+                        attr_type = type(attr).__name__
+                        result["attributes"].append(
+                            {
+                                "name": name,
+                                "type": attr_type,
+                            }
+                        )
+                except Exception:
+                    # Skip attributes that can't be accessed
+                    pass
+
+            return result
+
+        @mcp.tool()
+        async def execute_function(
+            function_name: str,
+            object_name: Optional[str] = None,
+            args: Optional[List] = None,
+            kwargs: Optional[Dict] = None,
+        ) -> Dict[str, Any]:
+            """Execute a Napistu function on a registered object."""
+            args = args or []
+            kwargs = kwargs or {}
+
+            try:
+                if object_name:
+                    # Method call on an object
+                    if object_name not in self.state.session_objects:
+                        return {
+                            "error": f"Object '{object_name}' not found in registry"
+                        }
+
+                    obj = self.state.session_objects[object_name]
+
+                    if not hasattr(obj, function_name):
+                        return {
+                            "error": f"Method '{function_name}' not found on object '{object_name}'"
+                        }
+
+                    func = getattr(obj, function_name)
+                    result = func(*args, **kwargs)
+                else:
+                    # Global function call
+                    if function_name in self.state.session_context:
+                        # Function from session context
+                        func = self.state.session_context[function_name]
+                        result = func(*args, **kwargs)
+                    else:
+                        # Try to find the function in Napistu
+                        try:
+                            import napistu
+
+                            # Split function name by dots for nested modules
+                            parts = function_name.split(".")
+                            current = napistu
+
+                            for part in parts[:-1]:
+                                current = getattr(current, part)
+
+                            func = getattr(current, parts[-1])
+                            result = func(*args, **kwargs)
+                        except (ImportError, AttributeError):
+                            return {"error": f"Function '{function_name}' not found"}
+
+                # Register result if it's a return value
+                if result is not None:
+                    result_name = f"result_{len(self.state.session_objects) + 1}"
+                    self.state.session_objects[result_name] = result
+
+                    # Basic type conversion for JSON serialization
+                    if hasattr(result, "to_dict"):
+                        # For pandas DataFrame or similar
+                        return {
+                            "success": True,
+                            "result_name": result_name,
+                            "result_type": type(result).__name__,
+                            "result_preview": (
+                                result.to_dict()
+                                if hasattr(result, "__len__") and len(result) < 10
+                                else "Result too large to preview"
+                            ),
+                        }
+                    elif hasattr(result, "to_json"):
+                        # For objects with JSON serialization
+                        return {
+                            "success": True,
+                            "result_name": result_name,
+                            "result_type": type(result).__name__,
+                            "result_preview": result.to_json(),
+                        }
+                    elif hasattr(result, "__dict__"):
+                        # For custom objects
+                        return {
+                            "success": True,
+                            "result_name": result_name,
+                            "result_type": type(result).__name__,
+                            "result_preview": str(result),
+                        }
+                    else:
+                        # For simple types
+                        return {
+                            "success": True,
+                            "result_name": result_name,
+                            "result_type": type(result).__name__,
+                            "result_preview": str(result),
+                        }
+                else:
+                    return {
+                        "success": True,
+                        "result": None,
+                    }
+            except Exception as e:
+                import traceback
+
+                return {
+                    "error": str(e),
+                    "traceback": traceback.format_exc(),
+                }
+
+        @mcp.tool()
+        async def search_paths(
+            source_node: str,
+            target_node: str,
+            network_object: str,
+            max_depth: int = 3,
+        ) -> Dict[str, Any]:
+            """Find paths between two nodes in a network."""
+            if network_object not in self.state.session_objects:
+                return {
+                    "error": f"Network object '{network_object}' not found in registry"
+                }
+
+            network = self.state.session_objects[network_object]
+
+            try:
+                # Import necessary modules
+                import napistu
+
+                # Check if the object is a valid network type
+                if hasattr(network, "find_paths"):
+                    # Direct method call
+                    paths = network.find_paths(
+                        source_node, target_node, max_depth=max_depth
+                    )
+                elif hasattr(napistu.graph, "find_paths"):
+                    # Function call
+                    paths = napistu.graph.find_paths(
+                        network, source_node, target_node, max_depth=max_depth
+                    )
+                else:
+                    return {"error": "Could not find appropriate path-finding function"}
+
+                # Register result
+                result_name = f"paths_{len(self.state.session_objects) + 1}"
+                self.state.session_objects[result_name] = paths
+
+                # Return results
+                if hasattr(paths, "to_dict"):
+                    return {
+                        "success": True,
+                        "result_name": result_name,
+                        "paths_found": (
+                            len(paths) if hasattr(paths, "__len__") else "unknown"
+                        ),
+                        "result_preview": (
+                            paths.to_dict()
+                            if hasattr(paths, "__len__") and len(paths) < 10
+                            else "Result too large to preview"
+                        ),
+                    }
+                else:
+                    return {
+                        "success": True,
+                        "result_name": result_name,
+                        "paths_found": (
+                            len(paths) if hasattr(paths, "__len__") else "unknown"
+                        ),
+                        "result_preview": str(paths),
+                    }
+            except Exception as e:
+                import traceback
+
+                return {
+                    "error": str(e),
+                    "traceback": traceback.format_exc(),
+                }
+
+
+# Module-level component instance (will be created by server with proper context)
+_component: Optional[ExecutionComponent] = None
+
+
+def create_component(
+    session_context: Optional[Dict] = None, object_registry: Optional[Dict] = None
+) -> ExecutionComponent:
     """
-    Initialize execution components.
+    Create and configure the execution component with session context.
+
+    Args:
+        session_context: Dictionary of the user's current session (e.g., globals())
+        object_registry: Dictionary of named objects to make available
+
+    Returns:
+        ExecutionComponent: Configured execution component
+    """
+    global _component
+    _component = ExecutionComponent(session_context, object_registry)
+    return _component
+
+
+def get_component() -> ExecutionComponent:
+    """
+    Get the execution component instance.
 
     Returns
     -------
-    bool
-        True if initialization is successful.
-    """
-    global _session_context, _session_objects
-    import napistu
+    ExecutionComponent
+        The execution component instance
 
-    _session_context["napistu"] = napistu
-    return True
+    Raises
+    ------
+    RuntimeError
+        If component hasn't been created yet
+    """
+    if _component is None:
+        raise RuntimeError(
+            "Execution component not created. Call create_component() first."
+        )
+    return _component
 
 
 def register_object(name: str, obj: Any) -> None:
     """
-    Register an object with the execution component.
+    Register an object with the execution component (legacy function).
 
     Args:
         name: Name to reference the object by
         obj: The object to register
     """
-    global _session_objects
-    _session_objects[name] = obj
-    print(f"Registered object '{name}' with MCP server")
-
-
-def register_components(mcp, session_context=None, object_registry=None):
-    """
-    Register function execution components with the MCP server.
-
-    Args:
-        mcp: FastMCP server instance
-        session_context: Dictionary of the user's current session (e.g., globals())
-        object_registry: Dictionary of named objects to make available
-    """
-    global _session_context, _session_objects
-
-    # Initialize context
-    if session_context:
-        _session_context = session_context
-
-    if object_registry:
-        _session_objects = object_registry
-
-    import napistu
-
-    _session_context["napistu"] = napistu
-
-    # Register resources
-    @mcp.resource("napistu://execution/registry")
-    async def get_registry():
-        """
-        Get a summary of all objects registered with the server.
-        """
-        return {
-            "object_count": len(_session_objects),
-            "object_names": list(_session_objects.keys()),
-            "object_types": {
-                name: type(obj).__name__ for name, obj in _session_objects.items()
-            },
-        }
-
-    @mcp.resource("napistu://execution/environment")
-    async def get_environment_info() -> Dict[str, Any]:
-        """
-        Get information about the local Python environment.
-        """
-        try:
-            import napistu
-
-            napistu_version = getattr(napistu, "__version__", "unknown")
-        except ImportError:
-            napistu_version = "not installed"
-
-        import sys
-
-        return {
-            "python_version": sys.version,
-            "napistu_version": napistu_version,
-            "platform": sys.platform,
-            "registered_objects": list(_session_objects.keys()),
-        }
-
-    # Register tools
-    @mcp.tool()
-    async def list_registry() -> Dict[str, Any]:
-        """
-        List all objects registered with the server.
-
-        Returns:
-            Dictionary with information about registered objects
-        """
-        result = {}
-
-        for name, obj in _session_objects.items():
-            obj_type = type(obj).__name__
-
-            # Get additional info based on object type
-            if hasattr(obj, "shape"):  # For pandas DataFrame or numpy array
-                obj_info = {
-                    "type": obj_type,
-                    "shape": str(obj.shape),
-                }
-            elif hasattr(obj, "__len__"):  # For lists, dicts, etc.
-                obj_info = {
-                    "type": obj_type,
-                    "length": len(obj),
-                }
-            else:
-                obj_info = {
-                    "type": obj_type,
-                }
-
-            result[name] = obj_info
-
-        return result
-
-    @mcp.tool()
-    async def describe_object(object_name: str) -> Dict[str, Any]:
-        """
-        Get detailed information about a registered object.
-
-        Args:
-            object_name: Name of the registered object
-
-        Returns:
-            Dictionary with object information
-        """
-        if object_name not in _session_objects:
-            return {"error": f"Object '{object_name}' not found in registry"}
-
-        obj = _session_objects[object_name]
-        obj_type = type(obj).__name__
-
-        # Basic info for all objects
-        result = {
-            "name": object_name,
-            "type": obj_type,
-            "methods": [],
-            "attributes": [],
-        }
-
-        # Add methods and attributes
-        for name in dir(obj):
-            if name.startswith("_"):
-                continue
-
-            try:
-                attr = getattr(obj, name)
-
-                if callable(attr):
-                    # Method
-                    sig = str(inspect.signature(attr))
-                    doc = inspect.getdoc(attr) or ""
-                    result["methods"].append(
-                        {
-                            "name": name,
-                            "signature": sig,
-                            "docstring": doc,
-                        }
-                    )
-                else:
-                    # Attribute
-                    attr_type = type(attr).__name__
-                    result["attributes"].append(
-                        {
-                            "name": name,
-                            "type": attr_type,
-                        }
-                    )
-            except Exception:
-                # Skip attributes that can't be accessed
-                pass
-
-        return result
-
-    @mcp.tool()
-    async def execute_function(
-        function_name: str,
-        object_name: Optional[str] = None,
-        args: Optional[List] = None,
-        kwargs: Optional[Dict] = None,
-    ) -> Dict[str, Any]:
-        """
-        Execute a Napistu function on a registered object.
-
-        Args:
-            function_name: Name of the function to execute
-            object_name: Name of the registered object to operate on (if method call)
-            args: Positional arguments to pass to the function
-            kwargs: Keyword arguments to pass to the function
-
-        Returns:
-            Dictionary with execution results
-        """
-        args = args or []
-        kwargs = kwargs or {}
-
-        try:
-            if object_name:
-                # Method call on an object
-                if object_name not in _session_objects:
-                    return {"error": f"Object '{object_name}' not found in registry"}
-
-                obj = _session_objects[object_name]
-
-                if not hasattr(obj, function_name):
-                    return {
-                        "error": f"Method '{function_name}' not found on object '{object_name}'"
-                    }
-
-                func = getattr(obj, function_name)
-                result = func(*args, **kwargs)
-            else:
-                # Global function call
-                if function_name in _session_context:
-                    # Function from session context
-                    func = _session_context[function_name]
-                    result = func(*args, **kwargs)
-                else:
-                    # Try to find the function in Napistu
-                    try:
-                        import napistu
-
-                        # Split function name by dots for nested modules
-                        parts = function_name.split(".")
-                        current = napistu
-
-                        for part in parts[:-1]:
-                            current = getattr(current, part)
-
-                        func = getattr(current, parts[-1])
-                        result = func(*args, **kwargs)
-                    except (ImportError, AttributeError):
-                        return {"error": f"Function '{function_name}' not found"}
-
-            # Register result if it's a return value
-            if result is not None:
-                result_name = f"result_{len(_session_objects) + 1}"
-                _session_objects[result_name] = result
-
-                # Basic type conversion for JSON serialization
-                if hasattr(result, "to_dict"):
-                    # For pandas DataFrame or similar
-                    return {
-                        "success": True,
-                        "result_name": result_name,
-                        "result_type": type(result).__name__,
-                        "result_preview": (
-                            result.to_dict()
-                            if hasattr(result, "__len__") and len(result) < 10
-                            else "Result too large to preview"
-                        ),
-                    }
-                elif hasattr(result, "to_json"):
-                    # For objects with JSON serialization
-                    return {
-                        "success": True,
-                        "result_name": result_name,
-                        "result_type": type(result).__name__,
-                        "result_preview": result.to_json(),
-                    }
-                elif hasattr(result, "__dict__"):
-                    # For custom objects
-                    return {
-                        "success": True,
-                        "result_name": result_name,
-                        "result_type": type(result).__name__,
-                        "result_preview": str(result),
-                    }
-                else:
-                    # For simple types
-                    return {
-                        "success": True,
-                        "result_name": result_name,
-                        "result_type": type(result).__name__,
-                        "result_preview": str(result),
-                    }
-            else:
-                return {
-                    "success": True,
-                    "result": None,
-                }
-        except Exception as e:
-            import traceback
-
-            return {
-                "error": str(e),
-                "traceback": traceback.format_exc(),
-            }
-
-    @mcp.tool()
-    async def search_paths(
-        source_node: str,
-        target_node: str,
-        network_object: str,
-        max_depth: int = 3,
-    ) -> Dict[str, Any]:
-        """
-        Find paths between two nodes in a network.
-
-        Args:
-            source_node: Source node identifier
-            target_node: Target node identifier
-            network_object: Name of the registered network object
-            max_depth: Maximum path length
-
-        Returns:
-            Dictionary with paths found
-        """
-        if network_object not in _session_objects:
-            return {"error": f"Network object '{network_object}' not found in registry"}
-
-        network = _session_objects[network_object]
-
-        try:
-            # Import necessary modules
-            import napistu
-
-            # Check if the object is a valid network type
-            if hasattr(network, "find_paths"):
-                # Direct method call
-                paths = network.find_paths(
-                    source_node, target_node, max_depth=max_depth
-                )
-            elif hasattr(napistu.graph, "find_paths"):
-                # Function call
-                paths = napistu.graph.find_paths(
-                    network, source_node, target_node, max_depth=max_depth
-                )
-            else:
-                return {"error": "Could not find appropriate path-finding function"}
-
-            # Register result
-            result_name = f"paths_{len(_session_objects) + 1}"
-            _session_objects[result_name] = paths
-
-            # Return results
-            if hasattr(paths, "to_dict"):
-                return {
-                    "success": True,
-                    "result_name": result_name,
-                    "paths_found": (
-                        len(paths) if hasattr(paths, "__len__") else "unknown"
-                    ),
-                    "result_preview": (
-                        paths.to_dict()
-                        if hasattr(paths, "__len__") and len(paths) < 10
-                        else "Result too large to preview"
-                    ),
-                }
-            else:
-                return {
-                    "success": True,
-                    "result_name": result_name,
-                    "paths_found": (
-                        len(paths) if hasattr(paths, "__len__") else "unknown"
-                    ),
-                    "result_preview": str(paths),
-                }
-        except Exception as e:
-            import traceback
-
-            return {
-                "error": str(e),
-                "traceback": traceback.format_exc(),
-            }
+    if _component is None:
+        raise RuntimeError(
+            "Execution component not created. Call create_component() first."
+        )
+    _component.register_object(name, obj)

--- a/src/napistu/mcp/profiles.py
+++ b/src/napistu/mcp/profiles.py
@@ -1,5 +1,7 @@
 from typing import Dict, Any
 
+from napistu.mcp.constants import MCP_PROFILES
+
 
 class ServerProfile:
     """Base profile for MCP server configuration."""
@@ -31,9 +33,11 @@ class ServerProfile:
 
 
 # Pre-defined profiles
-LOCAL_PROFILE = ServerProfile(server_name="napistu-local", enable_execution=True)
+EXECUTION_PROFILE = ServerProfile(
+    server_name="napistu-execution", enable_execution=True
+)
 
-REMOTE_PROFILE = ServerProfile(
+DOCS_PROFILE = ServerProfile(
     server_name="napistu-docs",
     enable_documentation=True,
     enable_codebase=True,
@@ -54,16 +58,16 @@ def get_profile(profile_name: str, **overrides) -> ServerProfile:
     Get a predefined profile with optional overrides.
 
     Args:
-        profile_name: Name of the profile ('local', 'remote', or 'full')
+        profile_name: Name of the profile ('execution', 'docs', or 'full')
         **overrides: Configuration overrides
 
     Returns:
         ServerProfile instance
     """
     profiles = {
-        "local": LOCAL_PROFILE,
-        "remote": REMOTE_PROFILE,
-        "full": FULL_PROFILE,
+        MCP_PROFILES.EXECUTION: EXECUTION_PROFILE,
+        MCP_PROFILES.DOCS: DOCS_PROFILE,
+        MCP_PROFILES.FULL: FULL_PROFILE,
     }
 
     if profile_name not in profiles:

--- a/src/napistu/mcp/server.py
+++ b/src/napistu/mcp/server.py
@@ -65,7 +65,7 @@ def create_server(profile: ServerProfile, server_config: MCPServerConfig) -> Fas
     Parameters
     ----------
     profile : ServerProfile
-        Server profile to use. All configuration must be set in the profile.
+        Server profile to use. All configuration must be set in the profile. (Valid profiles: 'execution', 'docs', 'full')
     server_config : MCPServerConfig
         Server configuration with validated host, port, and server name.
 

--- a/src/napistu/mcp/tutorials.py
+++ b/src/napistu/mcp/tutorials.py
@@ -7,118 +7,170 @@ import logging
 
 from fastmcp import FastMCP
 
+from napistu.mcp.component_base import ComponentState, MCPComponent
 from napistu.mcp import tutorials_utils
 from napistu.mcp import utils as mcp_utils
-from napistu.mcp.constants import TUTORIALS
 from napistu.mcp.constants import TUTORIAL_URLS
-from napistu.mcp.constants import TOOL_VARS
-
-# Global cache for tutorial content
-_tutorial_cache: Dict[str, Dict[str, str]] = {
-    TUTORIALS.TUTORIALS: {},
-}
 
 logger = logging.getLogger(__name__)
 
 
-async def initialize_components() -> bool:
+class TutorialsState(ComponentState):
+    """State management for tutorials component."""
+
+    def __init__(self):
+        super().__init__()
+        self.tutorials: Dict[str, str] = {}
+
+    def is_healthy(self) -> bool:
+        """Component is healthy if it has loaded tutorials."""
+        return bool(self.tutorials)
+
+    def get_health_details(self) -> Dict[str, Any]:
+        """Provide tutorials-specific health details."""
+        return {
+            "tutorial_count": len(self.tutorials),
+            "tutorial_ids": list(self.tutorials.keys()),
+        }
+
+
+class TutorialsComponent(MCPComponent):
+    """MCP component for tutorial management and search."""
+
+    def _create_state(self) -> TutorialsState:
+        """Create tutorials-specific state."""
+        return TutorialsState()
+
+    async def initialize(self) -> bool:
+        """
+        Initialize tutorials component by loading all tutorials.
+
+        Returns
+        -------
+        bool
+            True if at least one tutorial was loaded successfully
+        """
+        tutorials_loaded = 0
+
+        for tutorial_id, url in TUTORIAL_URLS.items():
+            try:
+                content = await tutorials_utils.get_tutorial_markdown(tutorial_id)
+                self.state.tutorials[tutorial_id] = content
+                tutorials_loaded += 1
+                logger.debug(f"Loaded tutorial: {tutorial_id}")
+            except Exception as e:
+                logger.warning(f"Failed to load tutorial {tutorial_id}: {e}")
+                # Continue loading other tutorials even if one fails
+
+        logger.info(f"Loaded {tutorials_loaded}/{len(TUTORIAL_URLS)} tutorials")
+
+        # Consider successful if at least one tutorial loaded
+        return tutorials_loaded > 0
+
+    def register(self, mcp: FastMCP) -> None:
+        """
+        Register tutorial resources and tools with the MCP server.
+
+        Parameters
+        ----------
+        mcp : FastMCP
+            FastMCP server instance
+        """
+
+        # Register resources
+        @mcp.resource("napistu://tutorials/index")
+        async def get_tutorials_index() -> List[Dict[str, Any]]:
+            """
+            Get the index of all available tutorials.
+
+            Returns
+            -------
+            List[dict]
+                List of dictionaries with tutorial IDs and URLs.
+            """
+            return [
+                {"id": tutorial_id, "url": url}
+                for tutorial_id, url in TUTORIAL_URLS.items()
+            ]
+
+        @mcp.resource("napistu://tutorials/content/{tutorial_id}")
+        async def get_tutorial_content_resource(tutorial_id: str) -> Dict[str, Any]:
+            """
+            Get the content of a specific tutorial as markdown.
+
+            Parameters
+            ----------
+            tutorial_id : str
+                ID of the tutorial.
+
+            Returns
+            -------
+            dict
+                Dictionary with markdown content and format.
+
+            Raises
+            ------
+            Exception
+                If the tutorial cannot be loaded.
+            """
+            # Check local state first
+            content = self.state.tutorials.get(tutorial_id)
+
+            if content is None:
+                # Fallback: try to load on-demand
+                try:
+                    logger.info(f"Loading tutorial {tutorial_id} on-demand")
+                    content = await tutorials_utils.get_tutorial_markdown(tutorial_id)
+                    self.state.tutorials[tutorial_id] = content  # Cache for future use
+                except Exception as e:
+                    logger.error(f"Tutorial {tutorial_id} could not be loaded: {e}")
+                    raise
+
+            return {
+                "content": content,
+                "format": "markdown",
+            }
+
+        @mcp.tool()
+        async def search_tutorials(query: str) -> List[Dict[str, Any]]:
+            """
+            Search tutorials for a specific query.
+
+            Parameters
+            ----------
+            query : str
+                Search term.
+
+            Returns
+            -------
+            List[dict]
+                List of matching tutorials with metadata and snippet.
+            """
+            results: List[Dict[str, Any]] = []
+
+            for tutorial_id, content in self.state.tutorials.items():
+                if query.lower() in content.lower():
+                    results.append(
+                        {
+                            "id": tutorial_id,
+                            "snippet": mcp_utils.get_snippet(content, query),
+                        }
+                    )
+
+            return results
+
+
+# Module-level component instance
+_component = TutorialsComponent()
+
+
+def get_component() -> TutorialsComponent:
     """
-    Initialize tutorial components by preloading all tutorials into the cache.
+    Get the tutorials component instance.
 
     Returns
     -------
-    bool
-        True if initialization is successful.
+    TutorialsComponent
+        The tutorials component instance
     """
-    global _tutorial_cache
-    for k, v in TUTORIAL_URLS.items():
-        _tutorial_cache[TUTORIALS.TUTORIALS][k] = (
-            await tutorials_utils.get_tutorial_markdown(k)
-        )
-    return True
-
-
-def register_components(mcp: FastMCP) -> None:
-    """
-    Register tutorial components with the MCP server.
-
-    Parameters
-    ----------
-    mcp : FastMCP
-        FastMCP server instance.
-    """
-
-    # Register resources
-    @mcp.resource("napistu://tutorials/index")
-    async def get_tutorials_index() -> List[Dict[str, Any]]:
-        """
-        Get the index of all available tutorials.
-
-        Returns
-        -------
-        List[dict]
-            List of dictionaries with tutorial IDs and URLs.
-        """
-        return [
-            {"id": tutorial_id, "url": url}
-            for tutorial_id, url in TUTORIAL_URLS.items()
-        ]
-
-    @mcp.resource("napistu://tutorials/content/{tutorial_id}")
-    async def get_tutorial_content_resource(tutorial_id: str) -> Dict[str, Any]:
-        """
-        Get the content of a specific tutorial as markdown.
-
-        Parameters
-        ----------
-        tutorial_id : str
-            ID of the tutorial.
-
-        Returns
-        -------
-        dict
-            Dictionary with markdown content and format.
-
-        Raises
-        ------
-        Exception
-            If the tutorial cannot be loaded.
-        """
-        content = _tutorial_cache[TUTORIALS.TUTORIALS].get(tutorial_id)
-        if content is None:
-            try:
-                content = await tutorials_utils.get_tutorial_markdown(tutorial_id)
-                _tutorial_cache[TUTORIALS.TUTORIALS][tutorial_id] = content
-            except Exception as e:
-                logger.error(f"Tutorial {tutorial_id} could not be loaded: {e}")
-                raise
-        return {
-            "content": content,
-            "format": "markdown",
-        }
-
-    @mcp.tool()
-    async def search_tutorials(query: str) -> List[Dict[str, Any]]:
-        """
-        Search tutorials for a specific query.
-
-        Parameters
-        ----------
-        query : str
-            Search term.
-
-        Returns
-        -------
-        List[dict]
-            List of matching tutorials with metadata and snippet.
-        """
-        results: List[Dict[str, Any]] = []
-        for tutorial_id, content in _tutorial_cache[TUTORIALS.TUTORIALS].items():
-            if query.lower() in content.lower():
-                results.append(
-                    {
-                        TOOL_VARS.ID: tutorial_id,
-                        TOOL_VARS.SNIPPET: mcp_utils.get_snippet(content, query),
-                    }
-                )
-        return results
+    return _component

--- a/src/tests/test_mcp_config.py
+++ b/src/tests/test_mcp_config.py
@@ -21,38 +21,72 @@ from napistu.mcp.constants import MCP_DEFAULTS
 
 def test_configuration_validation():
     """Test validation logic for preset conflicts and manual configuration requirements."""
-    
+
     # Test conflicting presets
-    with pytest.raises(click.BadParameter, match="Cannot use both --local and --production"):
-        validate_server_config_flags(local=True, production=True, host=None, port=None, server_name=None)
-    
-    with pytest.raises(click.BadParameter, match="Cannot use both --local and --production"):
-        validate_client_config_flags(local=True, production=True, host=None, port=None, use_https=None)
-    
+    with pytest.raises(
+        click.BadParameter, match="Cannot use both --local and --production"
+    ):
+        validate_server_config_flags(
+            local=True, production=True, host=None, port=None, server_name=None
+        )
+
+    with pytest.raises(
+        click.BadParameter, match="Cannot use both --local and --production"
+    ):
+        validate_client_config_flags(
+            local=True, production=True, host=None, port=None, use_https=None
+        )
+
     # Test preset + manual config conflicts
     with pytest.raises(click.BadParameter, match="Cannot use --local with manual"):
-        validate_server_config_flags(local=True, production=False, host="192.168.1.1", port=None, server_name=None)
-    
+        validate_server_config_flags(
+            local=True,
+            production=False,
+            host="192.168.1.1",
+            port=None,
+            server_name=None,
+        )
+
     with pytest.raises(click.BadParameter, match="Cannot use --production with manual"):
-        validate_client_config_flags(local=False, production=True, host="localhost", port=None, use_https=None)
-    
+        validate_client_config_flags(
+            local=False, production=True, host="localhost", port=None, use_https=None
+        )
+
     # Test incomplete manual configuration
-    with pytest.raises(click.BadParameter, match="Manual configuration requires --host, --port, and --server-name"):
-        validate_server_config_flags(local=False, production=False, host="localhost", port=None, server_name=None)
-    
-    with pytest.raises(click.BadParameter, match="Manual configuration requires --host, --port, and --https"):
-        validate_client_config_flags(local=False, production=False, host="localhost", port=8080, use_https=None)
-    
+    with pytest.raises(
+        click.BadParameter,
+        match="Manual configuration requires --host, --port, and --server-name",
+    ):
+        validate_server_config_flags(
+            local=False, production=False, host="localhost", port=None, server_name=None
+        )
+
+    with pytest.raises(
+        click.BadParameter,
+        match="Manual configuration requires --host, --port, and --https",
+    ):
+        validate_client_config_flags(
+            local=False, production=False, host="localhost", port=8080, use_https=None
+        )
+
     # Test valid configurations don't raise errors
-    config = validate_server_config_flags(local=True, production=False, host=None, port=None, server_name=None)
+    config = validate_server_config_flags(
+        local=True, production=False, host=None, port=None, server_name=None
+    )
     assert isinstance(config, MCPServerConfig)
-    
-    config = validate_client_config_flags(local=False, production=True, host=None, port=None, use_https=None)
+
+    config = validate_client_config_flags(
+        local=False, production=True, host=None, port=None, use_https=None
+    )
     assert isinstance(config, MCPClientConfig)
-    
+
     # Test valid manual configuration
     config = validate_server_config_flags(
-        local=False, production=False, host="localhost", port=9000, server_name="test-server"
+        local=False,
+        production=False,
+        host="localhost",
+        port=9000,
+        server_name="test-server",
     )
     assert config.host == "localhost"
     assert config.port == 9000
@@ -61,36 +95,47 @@ def test_configuration_validation():
 
 def test_preset_configurations():
     """Test that preset functions return correct and consistent configurations."""
-    
+
     # Test local server preset
     local_server = local_server_config()
     assert local_server.host == MCP_DEFAULTS.LOCAL_HOST
     assert local_server.port == MCP_DEFAULTS.LOCAL_PORT
     assert local_server.server_name == MCP_DEFAULTS.LOCAL_SERVER_NAME
-    assert local_server.bind_address == f"{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}"
-    
+    assert (
+        local_server.bind_address
+        == f"{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}"
+    )
+
     # Test production server preset
     production_server = production_server_config()
     assert production_server.host == MCP_DEFAULTS.PRODUCTION_HOST
     assert production_server.port == MCP_DEFAULTS.PRODUCTION_PORT
     assert production_server.server_name == MCP_DEFAULTS.PRODUCTION_SERVER_NAME
-    
+
     # Test local client preset
     local_client = local_client_config()
     assert local_client.host == MCP_DEFAULTS.LOCAL_HOST
     assert local_client.port == MCP_DEFAULTS.LOCAL_PORT
-    assert local_client.use_https == False
-    assert local_client.base_url == f"http://{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}"
-    assert local_client.mcp_url == f"http://{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}{MCP_DEFAULTS.MCP_PATH}"
-    
+    assert not local_client.use_https
+    assert (
+        local_client.base_url
+        == f"http://{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}"
+    )
+    assert (
+        local_client.mcp_url
+        == f"http://{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}{MCP_DEFAULTS.MCP_PATH}"
+    )
+
     # Test production client preset
     production_client = production_client_config()
-    assert production_client.use_https == True
+    assert production_client.use_https
     assert production_client.port == MCP_DEFAULTS.HTTPS_PORT
-    assert "napistu-mcp-server" in production_client.host  # Extracted from production URL
+    assert (
+        "napistu-mcp-server" in production_client.host
+    )  # Extracted from production URL
     assert production_client.base_url.startswith("https://")
     assert production_client.mcp_url.endswith(MCP_DEFAULTS.MCP_PATH)
-    
+
     # Test that presets are deterministic (same result on multiple calls)
     assert local_server_config().host == local_server_config().host
     assert production_client_config().port == production_client_config().port
@@ -98,43 +143,51 @@ def test_preset_configurations():
 
 def test_pydantic_model_validation():
     """Test Pydantic model validation for ports, hosts, and computed properties."""
-    
+
     # Test valid configurations
     valid_server = MCPServerConfig(host="localhost", port=8080, server_name="test")
     assert valid_server.host == "localhost"
     assert valid_server.port == 8080
     assert valid_server.server_name == "test"
     assert valid_server.bind_address == "localhost:8080"
-    
+
     valid_client = MCPClientConfig(host="example.com", port=443, use_https=True)
     assert valid_client.host == "example.com"
     assert valid_client.base_url == "https://example.com:443"
     assert valid_client.mcp_url == f"https://example.com:443{MCP_DEFAULTS.MCP_PATH}"
-    
+
     # Test invalid port validation
-    with pytest.raises(ValidationError, match="Input should be greater than or equal to 1"):
+    with pytest.raises(
+        ValidationError, match="Input should be greater than or equal to 1"
+    ):
         MCPServerConfig(host="localhost", port=0, server_name="test")
-    
-    with pytest.raises(ValidationError, match="Input should be less than or equal to 65535"):
+
+    with pytest.raises(
+        ValidationError, match="Input should be less than or equal to 65535"
+    ):
         MCPServerConfig(host="localhost", port=70000, server_name="test")
-    
-    with pytest.raises(ValidationError, match="Input should be greater than or equal to 1"):
+
+    with pytest.raises(
+        ValidationError, match="Input should be greater than or equal to 1"
+    ):
         MCPClientConfig(host="localhost", port=-1, use_https=False)
-    
+
     # Test empty/whitespace host validation
     with pytest.raises(ValidationError, match="Host cannot be empty"):
         MCPServerConfig(host="", port=8080, server_name="test")
-    
+
     with pytest.raises(ValidationError, match="Host cannot be empty"):
         MCPServerConfig(host="   ", port=8080, server_name="test")
-    
+
     # Test host whitespace trimming
-    server_with_spaces = MCPServerConfig(host="  localhost  ", port=8080, server_name="test")
+    server_with_spaces = MCPServerConfig(
+        host="  localhost  ", port=8080, server_name="test"
+    )
     assert server_with_spaces.host == "localhost"  # Should be trimmed
-    
+
     # Test URL generation with different protocols
     http_client = MCPClientConfig(host="localhost", port=8080, use_https=False)
     assert http_client.base_url == "http://localhost:8080"
-    
+
     https_client = MCPClientConfig(host="secure.com", port=443, use_https=True)
     assert https_client.base_url == "https://secure.com:443"

--- a/src/tests/test_mcp_config.py
+++ b/src/tests/test_mcp_config.py
@@ -1,0 +1,140 @@
+"""
+Tests for MCP configuration validation, presets, and Pydantic models.
+"""
+
+import pytest
+from pydantic import ValidationError
+import click
+
+from napistu.mcp.config import (
+    MCPServerConfig,
+    MCPClientConfig,
+    local_server_config,
+    production_server_config,
+    local_client_config,
+    production_client_config,
+    validate_server_config_flags,
+    validate_client_config_flags,
+)
+from napistu.mcp.constants import MCP_DEFAULTS
+
+
+def test_configuration_validation():
+    """Test validation logic for preset conflicts and manual configuration requirements."""
+    
+    # Test conflicting presets
+    with pytest.raises(click.BadParameter, match="Cannot use both --local and --production"):
+        validate_server_config_flags(local=True, production=True, host=None, port=None, server_name=None)
+    
+    with pytest.raises(click.BadParameter, match="Cannot use both --local and --production"):
+        validate_client_config_flags(local=True, production=True, host=None, port=None, use_https=None)
+    
+    # Test preset + manual config conflicts
+    with pytest.raises(click.BadParameter, match="Cannot use --local with manual"):
+        validate_server_config_flags(local=True, production=False, host="192.168.1.1", port=None, server_name=None)
+    
+    with pytest.raises(click.BadParameter, match="Cannot use --production with manual"):
+        validate_client_config_flags(local=False, production=True, host="localhost", port=None, use_https=None)
+    
+    # Test incomplete manual configuration
+    with pytest.raises(click.BadParameter, match="Manual configuration requires --host, --port, and --server-name"):
+        validate_server_config_flags(local=False, production=False, host="localhost", port=None, server_name=None)
+    
+    with pytest.raises(click.BadParameter, match="Manual configuration requires --host, --port, and --https"):
+        validate_client_config_flags(local=False, production=False, host="localhost", port=8080, use_https=None)
+    
+    # Test valid configurations don't raise errors
+    config = validate_server_config_flags(local=True, production=False, host=None, port=None, server_name=None)
+    assert isinstance(config, MCPServerConfig)
+    
+    config = validate_client_config_flags(local=False, production=True, host=None, port=None, use_https=None)
+    assert isinstance(config, MCPClientConfig)
+    
+    # Test valid manual configuration
+    config = validate_server_config_flags(
+        local=False, production=False, host="localhost", port=9000, server_name="test-server"
+    )
+    assert config.host == "localhost"
+    assert config.port == 9000
+    assert config.server_name == "test-server"
+
+
+def test_preset_configurations():
+    """Test that preset functions return correct and consistent configurations."""
+    
+    # Test local server preset
+    local_server = local_server_config()
+    assert local_server.host == MCP_DEFAULTS.LOCAL_HOST
+    assert local_server.port == MCP_DEFAULTS.LOCAL_PORT
+    assert local_server.server_name == MCP_DEFAULTS.LOCAL_SERVER_NAME
+    assert local_server.bind_address == f"{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}"
+    
+    # Test production server preset
+    production_server = production_server_config()
+    assert production_server.host == MCP_DEFAULTS.PRODUCTION_HOST
+    assert production_server.port == MCP_DEFAULTS.PRODUCTION_PORT
+    assert production_server.server_name == MCP_DEFAULTS.PRODUCTION_SERVER_NAME
+    
+    # Test local client preset
+    local_client = local_client_config()
+    assert local_client.host == MCP_DEFAULTS.LOCAL_HOST
+    assert local_client.port == MCP_DEFAULTS.LOCAL_PORT
+    assert local_client.use_https == False
+    assert local_client.base_url == f"http://{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}"
+    assert local_client.mcp_url == f"http://{MCP_DEFAULTS.LOCAL_HOST}:{MCP_DEFAULTS.LOCAL_PORT}{MCP_DEFAULTS.MCP_PATH}"
+    
+    # Test production client preset
+    production_client = production_client_config()
+    assert production_client.use_https == True
+    assert production_client.port == MCP_DEFAULTS.HTTPS_PORT
+    assert "napistu-mcp-server" in production_client.host  # Extracted from production URL
+    assert production_client.base_url.startswith("https://")
+    assert production_client.mcp_url.endswith(MCP_DEFAULTS.MCP_PATH)
+    
+    # Test that presets are deterministic (same result on multiple calls)
+    assert local_server_config().host == local_server_config().host
+    assert production_client_config().port == production_client_config().port
+
+
+def test_pydantic_model_validation():
+    """Test Pydantic model validation for ports, hosts, and computed properties."""
+    
+    # Test valid configurations
+    valid_server = MCPServerConfig(host="localhost", port=8080, server_name="test")
+    assert valid_server.host == "localhost"
+    assert valid_server.port == 8080
+    assert valid_server.server_name == "test"
+    assert valid_server.bind_address == "localhost:8080"
+    
+    valid_client = MCPClientConfig(host="example.com", port=443, use_https=True)
+    assert valid_client.host == "example.com"
+    assert valid_client.base_url == "https://example.com:443"
+    assert valid_client.mcp_url == f"https://example.com:443{MCP_DEFAULTS.MCP_PATH}"
+    
+    # Test invalid port validation
+    with pytest.raises(ValidationError, match="Input should be greater than or equal to 1"):
+        MCPServerConfig(host="localhost", port=0, server_name="test")
+    
+    with pytest.raises(ValidationError, match="Input should be less than or equal to 65535"):
+        MCPServerConfig(host="localhost", port=70000, server_name="test")
+    
+    with pytest.raises(ValidationError, match="Input should be greater than or equal to 1"):
+        MCPClientConfig(host="localhost", port=-1, use_https=False)
+    
+    # Test empty/whitespace host validation
+    with pytest.raises(ValidationError, match="Host cannot be empty"):
+        MCPServerConfig(host="", port=8080, server_name="test")
+    
+    with pytest.raises(ValidationError, match="Host cannot be empty"):
+        MCPServerConfig(host="   ", port=8080, server_name="test")
+    
+    # Test host whitespace trimming
+    server_with_spaces = MCPServerConfig(host="  localhost  ", port=8080, server_name="test")
+    assert server_with_spaces.host == "localhost"  # Should be trimmed
+    
+    # Test URL generation with different protocols
+    http_client = MCPClientConfig(host="localhost", port=8080, use_https=False)
+    assert http_client.base_url == "http://localhost:8080"
+    
+    https_client = MCPClientConfig(host="secure.com", port=443, use_https=True)
+    assert https_client.base_url == "https://secure.com:443"

--- a/src/tests/test_mcp_documentation_utils.py
+++ b/src/tests/test_mcp_documentation_utils.py
@@ -1,13 +1,22 @@
 import pytest
-from napistu.mcp.documentation_utils import load_readme_content
-from napistu.mcp.constants import READMES
+from napistu.mcp.documentation_utils import load_readme_content, fetch_wiki_page
+from napistu.mcp.constants import READMES, WIKI_PAGES
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("name,url", READMES.items())
+@pytest.mark.parametrize("name,url", list(READMES.items())[:2])
 async def test_load_readme_content(name, url):
     content = await load_readme_content(url)
     assert isinstance(content, str)
     assert len(content) > 0
     # Optionally, check for a keyword in the content
+    assert "napistu" in content.lower() or "Napistu" in content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("page_name", list(WIKI_PAGES)[:2])
+async def test_fetch_wiki_page(page_name):
+    content = await fetch_wiki_page(page_name)
+    assert isinstance(content, str)
+    assert len(content) > 0
     assert "napistu" in content.lower() or "Napistu" in content

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -48,7 +48,8 @@ def collect_resources_and_tools(mcp: FastMCP) -> Tuple[List[str], List[str]]:
 def test_documentation_naming():
     """Test that documentation component uses valid names."""
     mcp = FastMCP("test")
-    documentation.register_components(mcp)
+    documentation_component = documentation.get_component()
+    documentation_component.register(mcp)
 
     resource_paths, tool_names = collect_resources_and_tools(mcp)
 
@@ -64,7 +65,8 @@ def test_documentation_naming():
 def test_codebase_naming():
     """Test that codebase component uses valid names."""
     mcp = FastMCP("test")
-    codebase.register_components(mcp)
+    codebase_component = codebase.get_component()
+    codebase_component.register(mcp)
 
     resource_paths, tool_names = collect_resources_and_tools(mcp)
 
@@ -80,7 +82,8 @@ def test_codebase_naming():
 def test_tutorials_naming():
     """Test that tutorials component uses valid names."""
     mcp = FastMCP("test")
-    tutorials.register_components(mcp)
+    tutorials_component = tutorials.get_component()
+    tutorials_component.register(mcp)
 
     resource_paths, tool_names = collect_resources_and_tools(mcp)
 
@@ -96,7 +99,14 @@ def test_tutorials_naming():
 def test_execution_naming():
     """Test that execution component uses valid names."""
     mcp = FastMCP("test")
-    execution.register_components(mcp)
+
+    # Create execution component with test session context
+    test_session_context = {}
+    test_object_registry = {}
+    execution_component = execution.create_component(
+        session_context=test_session_context, object_registry=test_object_registry
+    )
+    execution_component.register(mcp)
 
     resource_paths, tool_names = collect_resources_and_tools(mcp)
 
@@ -129,11 +139,25 @@ def test_all_components_naming():
     """Test that all components together use valid names without conflicts."""
     mcp = FastMCP("test")
 
-    # Register all components
-    documentation.register_components(mcp)
-    codebase.register_components(mcp)
-    tutorials.register_components(mcp)
-    execution.register_components(mcp)
+    # Register all components using new class-based API
+    documentation_component = documentation.get_component()
+    documentation_component.register(mcp)
+
+    codebase_component = codebase.get_component()
+    codebase_component.register(mcp)
+
+    tutorials_component = tutorials.get_component()
+    tutorials_component.register(mcp)
+
+    # Create execution component with test context
+    test_session_context = {}
+    test_object_registry = {}
+    execution_component = execution.create_component(
+        session_context=test_session_context, object_registry=test_object_registry
+    )
+    execution_component.register(mcp)
+
+    # Health component still uses legacy registration
     health.register_components(mcp)
 
     resource_paths, tool_names = collect_resources_and_tools(mcp)
@@ -157,11 +181,25 @@ def test_expected_resources_exist():
     """Test that all expected resources are registered."""
     mcp = FastMCP("test")
 
-    # Register all components
-    documentation.register_components(mcp)
-    codebase.register_components(mcp)
-    tutorials.register_components(mcp)
-    execution.register_components(mcp)
+    # Register all components using new class-based API
+    documentation_component = documentation.get_component()
+    documentation_component.register(mcp)
+
+    codebase_component = codebase.get_component()
+    codebase_component.register(mcp)
+
+    tutorials_component = tutorials.get_component()
+    tutorials_component.register(mcp)
+
+    # Create execution component with test context
+    test_session_context = {}
+    test_object_registry = {}
+    execution_component = execution.create_component(
+        session_context=test_session_context, object_registry=test_object_registry
+    )
+    execution_component.register(mcp)
+
+    # Health component still uses legacy registration
     health.register_components(mcp)
 
     resource_paths, _ = collect_resources_and_tools(mcp)
@@ -191,14 +229,34 @@ def test_expected_tools_exist():
     """Test that all expected tools are registered."""
     mcp = FastMCP("test")
 
-    # Register all components
-    documentation.register_components(mcp)
-    codebase.register_components(mcp)
-    tutorials.register_components(mcp)
-    execution.register_components(mcp)
+    # Register all components using new class-based API
+    documentation_component = documentation.get_component()
+    documentation_component.register(mcp)
+
+    codebase_component = codebase.get_component()
+    codebase_component.register(mcp)
+
+    tutorials_component = tutorials.get_component()
+    tutorials_component.register(mcp)
+
+    # Create execution component with test context
+    test_session_context = {}
+    test_object_registry = {}
+    execution_component = execution.create_component(
+        session_context=test_session_context, object_registry=test_object_registry
+    )
+    execution_component.register(mcp)
+
+    # Health component still uses legacy registration
     health.register_components(mcp)
 
     _, tool_names = collect_resources_and_tools(mcp)
+
+    # Debug: Print all registered tools
+    print("\nRegistered tools:")
+    for name in sorted(tool_names):
+        print(f"  {name}")
+    print()
 
     # List of expected tools
     expected_tools = {
@@ -217,3 +275,82 @@ def test_expected_tools_exist():
     # Check that all expected tools exist
     for tool in expected_tools:
         assert tool in tool_names, f"Missing expected tool: {tool}"
+
+
+def test_component_state_health():
+    """Test that component states can provide health information."""
+    # Test documentation component state
+    doc_component = documentation.get_component()
+    doc_state = doc_component.get_state()
+    health_status = doc_state.get_health_status()
+    assert "status" in health_status
+    assert health_status["status"] in [
+        "initializing",
+        "healthy",
+        "inactive",
+        "unavailable",
+    ]
+
+    # Test codebase component state
+    codebase_component = codebase.get_component()
+    codebase_state = codebase_component.get_state()
+    health_status = codebase_state.get_health_status()
+    assert "status" in health_status
+    assert health_status["status"] in [
+        "initializing",
+        "healthy",
+        "inactive",
+        "unavailable",
+    ]
+
+    # Test tutorials component state
+    tutorials_component = tutorials.get_component()
+    tutorials_state = tutorials_component.get_state()
+    health_status = tutorials_state.get_health_status()
+    assert "status" in health_status
+    assert health_status["status"] in [
+        "initializing",
+        "healthy",
+        "inactive",
+        "unavailable",
+    ]
+
+    # Test execution component state
+    test_session_context = {"test": "value"}
+    test_object_registry = {}
+    execution_component = execution.create_component(
+        session_context=test_session_context, object_registry=test_object_registry
+    )
+    execution_state = execution_component.get_state()
+    health_status = execution_state.get_health_status()
+    assert "status" in health_status
+    assert health_status["status"] in [
+        "initializing",
+        "healthy",
+        "inactive",
+        "unavailable",
+    ]
+
+
+def test_execution_object_registration():
+    """Test that execution component can register and track objects."""
+    test_session_context = {}
+    test_object_registry = {}
+    execution_component = execution.create_component(
+        session_context=test_session_context, object_registry=test_object_registry
+    )
+
+    # Register a test object
+    test_object = {"test": "data"}
+    execution_component.register_object("test_obj", test_object)
+
+    # Check that object was registered
+    state = execution_component.get_state()
+    assert "test_obj" in state.session_objects
+    assert state.session_objects["test_obj"] == test_object
+
+    # Check health details include the object
+    health_details = state.get_health_details()
+    assert "registered_objects" in health_details
+    assert health_details["registered_objects"] == 1
+    assert "test_obj" in health_details["object_names"]


### PR DESCRIPTION
- Created classes for server- and client-side configuration of MCP servers. 
- Moved defaults into constants
- Added decorators for specifying server- and client-side server with support for --production and --local defaults.
- renamed the profiles which determine included components as local -> execution; and remote -> docs to avoid confusing these settings with the actual server settings. Closes #81 
 - updated the approach for tracking component data from loose dictionaries to a class; subclass approach with common methods for initializion and registration. Closes #76
