### PR TITLE
Issue 109 - `sbml_dfs_core` <> `sbml_dfs_utils` refactor

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.3.5
+version = 0.3.6
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ dev =
     ruff
     testcontainers
 mcp = 
-    fastmcp>=2.0.0,<3.0.0
+    fastmcp>=2.0.0,<2.9.0
     mcp>=1.0.0,<2.0.0  
     httpx>=0.24.0
     beautifulsoup4>=4.11.0,<5.0.0

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -343,9 +343,9 @@ def infer_uncompartmentalized_species_location(model_uri: str, output_model_uri:
     If the compartment of a subset of compartmentalized species was
     not specified, infer an appropriate compartment from other members of reactions they particpate in
     """
-    model = utils.load_pickle(model_uri)
-    model = sbml_dfs_core.infer_uncompartmentalized_species_location(model)
-    utils.save_pickle(output_model_uri, model)
+    sbml_dfs = utils.load_pickle(model_uri)
+    sbml_dfs.infer_uncompartmentalized_species_location()
+    utils.save_pickle(output_model_uri, sbml_dfs)
 
 
 @refine.command(name="name_compartmentalized_species")
@@ -357,9 +357,9 @@ def name_compartmentalized_species(model_uri: str, output_model_uri: str):
 
     Rename compartmentalized species if they have the same name as their species
     """
-    model = utils.load_pickle(model_uri)
-    model = sbml_dfs_core.name_compartmentalized_species(model)
-    utils.save_pickle(output_model_uri, model)
+    sbml_dfs = utils.load_pickle(model_uri)
+    sbml_dfs.name_compartmentalized_species()
+    utils.save_pickle(output_model_uri, sbml_dfs)
 
 
 @refine.command(name="merge_model_compartments")
@@ -786,9 +786,9 @@ def export_sbml_dfs_tables(
     logger.debug(f"nondogmatic = {nondogmatic}; dogmatic = {dogmatic}")
     logger.info(f"Exporting tables with dogmatic = {dogmatic}")
 
-    model = utils.load_pickle(model_uri)
-    sbml_dfs_core.export_sbml_dfs(
-        model_prefix, model, output_uri, overwrite=overwrite, dogmatic=dogmatic
+    sbml_dfs = utils.load_pickle(model_uri)
+    sbml_dfs.export_sbml_dfs(
+        model_prefix, output_uri, overwrite=overwrite, dogmatic=dogmatic
     )
 
 

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -54,12 +54,12 @@ def cli():
 
 
 @click.group()
-def load():
+def ingestion():
     """Command line tools to retrieve raw data."""
     pass
 
 
-@load.command(name="reactome")
+@ingestion.command(name="reactome")
 @click.argument("base_folder", type=str)
 @click.option(
     "--overwrite", "-o", is_flag=True, default=False, help="Overwrite existing files?"
@@ -70,7 +70,7 @@ def load_reactome(base_folder: str, overwrite=True):
     reactome.reactome_sbml_download(f"{base_folder}/sbml", overwrite=overwrite)
 
 
-@load.command(name="bigg")
+@ingestion.command(name="bigg")
 @click.argument("base_folder", type=str)
 @click.option(
     "--overwrite", "-o", is_flag=True, default=False, help="Overwrite existing files?"
@@ -81,7 +81,7 @@ def load_bigg(base_folder: str, overwrite: bool):
     bigg.bigg_sbml_download(base_folder, overwrite)
 
 
-@load.command(name="trrust")
+@ingestion.command(name="trrust")
 @click.argument("target_uri", type=str)
 @click_logging.simple_verbosity_option(logger)
 def load_ttrust(target_uri: str):
@@ -89,7 +89,7 @@ def load_ttrust(target_uri: str):
     trrust.download_trrust(target_uri)
 
 
-@load.command(name="proteinatlas-subcell")
+@ingestion.command(name="proteinatlas-subcell")
 @click.argument("target_uri", type=str)
 @click.option(
     "--url",
@@ -102,7 +102,7 @@ def load_proteinatlas_subcell(target_uri: str, url: str):
     hpa.download_hpa_data(target_uri, url)
 
 
-@load.command(name="gtex-rnaseq-expression")
+@ingestion.command(name="gtex-rnaseq-expression")
 @click.argument("target_uri", type=str)
 @click.option(
     "--url",
@@ -115,7 +115,7 @@ def load_gtex_rnaseq(target_uri: str, url: str):
     gtex.download_gtex_rnaseq(target_uri, url)
 
 
-@load.command(name="string-db")
+@ingestion.command(name="string-db")
 @click.argument("target_uri", type=str)
 @click.option(
     "--species",
@@ -128,7 +128,7 @@ def load_string_db(target_uri: str, species: str):
     string.download_string(target_uri, species)
 
 
-@load.command(name="string-aliases")
+@ingestion.command(name="string-aliases")
 @click.argument("target_uri", type=str)
 @click.option(
     "--species",
@@ -884,7 +884,7 @@ def calculate_igraph_stats(input_uri, output_uri):
     utils.save_json(output_uri, stats)
 
 
-cli.add_command(load)
+cli.add_command(ingestion)
 cli.add_command(integrate)
 cli.add_command(consensus)
 cli.add_command(refine)

--- a/src/napistu/consensus.py
+++ b/src/napistu/consensus.py
@@ -843,8 +843,8 @@ def report_consensus_merges(
         indexed_models = merges_lookup.set_index("model").sort_index()
         merges_dict = dict()
         for mod in indexed_models.index.unique():
-            merges_dict[mod] = sbml_dfs_core.reaction_summaries(
-                sbml_dfs_dict[mod], indexed_models.loc[mod]["r_id"]
+            merges_dict[mod] = sbml_dfs_dict[mod].reaction_summaries(
+                indexed_models.loc[mod]["r_id"]
             )
         merge_labels = pd.concat(merges_dict, names=["model", "r_id"]).rename("label")
 

--- a/src/napistu/consensus.py
+++ b/src/napistu/consensus.py
@@ -843,9 +843,10 @@ def report_consensus_merges(
         indexed_models = merges_lookup.set_index("model").sort_index()
         merges_dict = dict()
         for mod in indexed_models.index.unique():
-            merges_dict[mod] = sbml_dfs_dict[mod].reaction_summaries(
+            merges_dict[mod] = sbml_dfs_dict[mod].reaction_formulas(
                 indexed_models.loc[mod]["r_id"]
             )
+
         merge_labels = pd.concat(merges_dict, names=["model", "r_id"]).rename("label")
 
         # add labels to models + r_id

--- a/src/napistu/constants.py
+++ b/src/napistu/constants.py
@@ -135,7 +135,7 @@ REQUIRED_REACTION_FROMEDGELIST_COLUMNS = [
     "r_isreversible",
 ]
 
-CPR_STANDARD_OUTPUTS = SimpleNamespace(
+NAPISTU_STANDARD_OUTPUTS = SimpleNamespace(
     SPECIES_IDENTIFIERS="species_identifiers.tsv",
     SPECIES="species.json",
     REACTIONS="reactions.json",

--- a/src/napistu/context/filtering.py
+++ b/src/napistu/context/filtering.py
@@ -5,6 +5,7 @@ from typing import Union, List, Optional
 import pandas as pd
 
 from napistu import sbml_dfs_core
+from napistu import sbml_dfs_utils
 from napistu import utils
 from napistu.constants import SBML_DFS
 
@@ -236,7 +237,7 @@ def _find_reactions_with_disconnected_cspecies(
     sbml_dfs._validate_table(SBML_DFS.REACTION_SPECIES)
     sbml_dfs._validate_table(SBML_DFS.COMPARTMENTALIZED_SPECIES)
 
-    reaction_species = sbml_dfs_core.add_sbo_role(sbml_dfs.reaction_species)
+    reaction_species = sbml_dfs_utils.add_sbo_role(sbml_dfs.reaction_species)
 
     logger.info(
         "Finding disconnected pairs of cspecies based on the zero values in the coccurrence_edgelist"

--- a/src/napistu/identifiers.py
+++ b/src/napistu/identifiers.py
@@ -12,7 +12,6 @@ import pandas as pd
 from pydantic import BaseModel
 
 from napistu import sbml_dfs_core
-from napistu import sbml_dfs_utils
 from napistu import utils
 
 from napistu.constants import IDENTIFIERS
@@ -883,9 +882,7 @@ def _prepare_species_identifiers(
     """Accepts and validates species_identifiers, or extracts a fresh table if None."""
 
     if species_identifiers is None:
-        species_identifiers = sbml_dfs_utils.get_characteristic_species_ids(
-            sbml_dfs, dogmatic=dogmatic
-        )
+        species_identifiers = sbml_dfs.get_characteristic_species_ids(dogmatic=dogmatic)
     else:
         # check for compatibility
         try:
@@ -898,8 +895,8 @@ def _prepare_species_identifiers(
             logger.warning(
                 f"The provided identifiers are not compatible with your `sbml_dfs` object. Extracting a fresh species identifier table. {e}"
             )
-            species_identifiers = sbml_dfs_utils.get_characteristic_species_ids(
-                sbml_dfs, dogmatic=dogmatic
+            species_identifiers = sbml_dfs.get_characteristic_species_ids(
+                dogmatic=dogmatic
             )
 
     return species_identifiers

--- a/src/napistu/ingestion/bigg.py
+++ b/src/napistu/ingestion/bigg.py
@@ -122,10 +122,10 @@ def construct_bigg_consensus(
         raise NotImplementedError("Merging of models not implemented yet for BiGG")
 
     # In Bigg there should be only one model
-    model = list(sbml_dfs_dict.values())[0]
+    sbml_dfs = list(sbml_dfs_dict.values())[0]
     # fix missing compartimentalization
-    model = sbml_dfs_core.infer_uncompartmentalized_species_location(model)
-    model = sbml_dfs_core.name_compartmentalized_species(model)
-    rename_species_ontologies(model)
-    model.validate()
-    return model
+    sbml_dfs.infer_uncompartmentalized_species_location()
+    sbml_dfs.name_compartmentalized_species()
+    rename_species_ontologies(sbml_dfs)
+    sbml_dfs.validate()
+    return sbml_dfs

--- a/src/napistu/ingestion/string.py
+++ b/src/napistu/ingestion/string.py
@@ -5,6 +5,7 @@ import logging
 import pandas as pd
 from napistu import identifiers
 from napistu import sbml_dfs_core
+from napistu import sbml_dfs_utils
 from napistu import source
 from napistu import utils
 from napistu.constants import BQB
@@ -158,7 +159,7 @@ def convert_string_to_sbml_dfs(
     # Define compartments
     # Currently we are mapping everything to the `CELLULAR_COMPONENT`
     # which is a catch-all go: for unknown localisation
-    compartments_df = sbml_dfs_core._stub_compartments()
+    compartments_df = sbml_dfs_utils.stub_compartments()
 
     # define interactions
     interaction_edgelist = _build_interactor_edgelist(uq_string_edgelist)

--- a/src/napistu/ingestion/yeast.py
+++ b/src/napistu/ingestion/yeast.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pandas as pd
 from napistu import identifiers
 from napistu import sbml_dfs_core
+from napistu import sbml_dfs_utils
 from napistu import source
 from napistu import utils
 from napistu.constants import BQB
@@ -105,7 +106,7 @@ def convert_idea_kinetics_to_sbml_dfs(
     # Constant fields (for this data source)
 
     # setup compartments (just treat this as uncompartmentalized for now)
-    compartments_df = sbml_dfs_core._stub_compartments()
+    compartments_df = sbml_dfs_utils.stub_compartments()
 
     # Per convention unaggregated models receive an empty source
     interaction_source = source.Source(init=True)

--- a/src/napistu/matching/interactions.py
+++ b/src/napistu/matching/interactions.py
@@ -40,7 +40,7 @@ def edgelist_to_pathway_species(
         pd.Dataframe containing a "identifier_upstream" and "identifier_downstream" variables used to to match entries
     species_identifiers: pd.DataFrame
         A table of molecular species identifiers produced from sbml_dfs.get_identifiers("species") generally using
-        sbml_dfs_core.export_sbml_dfs()
+        sbml_dfs.export_sbml_dfs()
     ontologies: set
         A set of ontologies used to match features to pathway species
     feature_id_var: str, default=FEATURE_ID_VAR_DEFAULT
@@ -138,7 +138,7 @@ def edgelist_to_scids(
         A mechanistic model
     species_identifiers: pd.DataFrame
         A table of molecular species identifiers produced from
-        sbml_dfs.get_identifiers("species") generally using sbml_dfs_core.export_sbml_dfs()
+        sbml_dfs.get_identifiers("species") generally using sbml_dfs.export_sbml_dfs()
     ontologies: set
         A set of ontologies used to match features to pathway species
 
@@ -218,7 +218,7 @@ def filter_to_direct_mechanistic_interactions(
     species_identifiers: pd.DataFrame
         A table of molecular species identifiers
         produced from sbml_dfs.get_identifiers("species") generally
-        using sbml_dfs_core.export_sbml_dfs()
+        using sbml_dfs.export_sbml_dfs()
     ontologies: set
         A set of ontologies used to match features to pathway species
 
@@ -342,7 +342,7 @@ def filter_to_indirect_mechanistic_interactions(
         A mechanistic model
     species_identifiers: pandas.DataFrame
         A table of molecular species identifiers produced from
-        sbml_dfs.get_identifiers("species") generally using sbml_dfs_core.export_sbml_dfs()
+        sbml_dfs.get_identifiers("species") generally using sbml_dfs.export_sbml_dfs()
     napistu_graph: igraph.Graph
         A network representation of the sbml_dfs model
     ontologies: set

--- a/src/napistu/modify/uncompartmentalize.py
+++ b/src/napistu/modify/uncompartmentalize.py
@@ -48,7 +48,7 @@ def uncompartmentalize_sbml_dfs(
         )
 
     # 1. update the compartments table to the stubbed default level: GO CELLULAR_COMPONENT
-    stubbed_compartment = sbml_dfs_core._stub_compartments().assign(
+    stubbed_compartment = sbml_dfs_utils.stub_compartments().assign(
         c_Source=_create_stubbed_source()
     )
 

--- a/src/napistu/network/net_create.py
+++ b/src/napistu/network/net_create.py
@@ -1697,7 +1697,7 @@ def _create_topology_weights(
         base_score (float): offset which will be added to all weights.
         protein_multiplier (int): multiplier for non-metabolite species (lower weight paths will tend to be selected).
         metabolite_multiplier (int): multiplier for metabolites [defined a species with a ChEBI ID).
-        unknown_multiplier (int): multiplier for species without any identifier. See sbml_dfs_core.species_type_types.
+        unknown_multiplier (int): multiplier for species without any identifier. See sbml_dfs_utils.species_type_types.
         scale_multiplier_by_meandegree (bool): if True then multipliers will be rescaled by the average number of
             connections a node has (i.e., its degree) so that weights will be relatively similar regardless of network
             size and sparsity.

--- a/src/napistu/network/paths.py
+++ b/src/napistu/network/paths.py
@@ -489,7 +489,7 @@ def _label_path_reactions(sbml_dfs: sbml_dfs_core.SBML_dfs, paths_df: pd.DataFra
         reaction_info = (
             pd.concat(
                 [
-                    sbml_dfs_core.reaction_summaries(sbml_dfs, r_ids=x)
+                    sbml_dfs.reaction_summaries(r_ids=x)
                     for x in set(reaction_paths["node"])
                 ]
             )

--- a/src/napistu/network/paths.py
+++ b/src/napistu/network/paths.py
@@ -489,7 +489,7 @@ def _label_path_reactions(sbml_dfs: sbml_dfs_core.SBML_dfs, paths_df: pd.DataFra
         reaction_info = (
             pd.concat(
                 [
-                    sbml_dfs.reaction_summaries(r_ids=x)
+                    sbml_dfs.reaction_formulas(r_ids=x)
                     for x in set(reaction_paths["node"])
                 ]
             )

--- a/src/napistu/ontologies/dogma.py
+++ b/src/napistu/ontologies/dogma.py
@@ -4,6 +4,7 @@ import logging
 import pandas as pd
 
 from napistu import sbml_dfs_core
+from napistu import sbml_dfs_utils
 from napistu import source
 from napistu import identifiers
 from napistu import utils
@@ -59,7 +60,7 @@ def create_dogmatic_sbml_dfs(
     )
 
     # stub required but invariant variables
-    compartments_df = sbml_dfs_core._stub_compartments()
+    compartments_df = sbml_dfs_utils.stub_compartments()
     interaction_source = source.Source(init=True)
 
     # interactions table. This is required to create the sbml_dfs but we'll drop the info later

--- a/src/napistu/sbml_dfs_core.py
+++ b/src/napistu/sbml_dfs_core.py
@@ -58,28 +58,76 @@ class SBML_dfs:
     schema : dict
         Dictionary representing the structure of the other attributes and meaning of their variables
 
-    Methods
-    -------
-    get_table(entity_type, required_attributes)
-        Get a table from the SBML_dfs object with optional attribute validation
-    search_by_ids(ids, entity_type, identifiers_df, ontologies)
-        Find entities and identifiers matching a set of query IDs
-    search_by_name(name, entity_type, partial_match)
-        Find entities by exact or partial name match
+    Public Methods (alphabetical)
+    ----------------------------
+    add_reactions_data(label, data)
+        Add a new reactions data table to the model with validation.
+    add_species_data(label, data)
+        Add a new species data table to the model with validation.
+    export_sbml_dfs(model_prefix, outdir, overwrite=False, dogmatic=True)
+        Export the SBML_dfs model and its tables to files in a specified directory.
+    get_characteristic_species_ids(dogmatic=True)
+        Return characteristic systematic identifiers for molecular species, optionally using a strict or loose definition.
     get_cspecies_features()
-        Get additional attributes of compartmentalized species
-    get_species_features()
-        Get additional attributes of species
+        Compute and return additional features for compartmentalized species, such as degree and type.
     get_identifiers(id_type)
-        Get identifiers from a specified entity type
-    get_uri_urls(entity_type, entity_ids)
-        Get reference URLs for specified entities
+        Retrieve a table of identifiers for a specified entity type (e.g., species or reactions).
+    get_network_summary()
+        Return a dictionary of diagnostic statistics summarizing the network structure.
+    get_species_features()
+        Compute and return additional features for species, such as species type.
+    get_table(entity_type, required_attributes=None)
+        Retrieve a table for a given entity type, optionally validating required attributes.
+    get_uri_urls(entity_type, entity_ids=None, required_ontology=None)
+        Return reference URLs for specified entities, optionally filtered by ontology.
+    infer_sbo_terms()
+        Infer and fill in missing SBO terms for reaction species based on stoichiometry.
+    infer_uncompartmentalized_species_location()
+        Infer and assign compartments for compartmentalized species with missing compartment information.
+    name_compartmentalized_species()
+        Rename compartmentalized species to include compartment information if needed.
+    reaction_formulas(r_ids=None)
+        Generate human-readable reaction formulas for specified reactions.
+    reaction_summaries(r_ids=None)
+        Return a summary DataFrame for specified reactions, including names and formulas.
+    remove_compartmentalized_species(sc_ids)
+        Remove specified compartmentalized species and associated reactions from the model.
+    remove_reactions(r_ids, remove_species=False)
+        Remove specified reactions and optionally remove unused species.
+    remove_reactions_data(label)
+        Remove a reactions data table by label.
+    remove_species_data(label)
+        Remove a species data table by label.
+    search_by_ids(ids, entity_type, identifiers_df, ontologies=None)
+        Find entities and identifiers matching a set of query IDs.
+    search_by_name(name, entity_type, partial_match=True)
+        Find entities by exact or partial name match.
+    select_species_data(species_data_table)
+        Select a species data table from the SBML_dfs object by name.
+    species_status(s_id)
+        Return all reactions a species participates in, with stoichiometry and formula information.
     validate()
-        Validate the SBML_dfs structure and relationships
+        Validate the SBML_dfs structure and relationships.
     validate_and_resolve()
-        Validate and attempt to automatically fix common issues
-    export_sbml_dfs(model_prefix: str, outdir: str, overwrite: bool = False, dogmatic: bool = True)
-        Export SBML_dfs
+        Validate and attempt to automatically fix common issues.
+
+    Private/Hidden Methods (alphabetical, appear after public methods)
+    -----------------------------------------------------------------
+    _attempt_resolve(e)
+    _check_pk_fk_correspondence()
+    _find_underspecified_reactions_by_scids(sc_ids)
+    _get_unused_cspecies()
+    _get_unused_species()
+    _remove_compartmentalized_species(sc_ids)
+    _remove_entity_data(entity_type, label)
+    _remove_species(s_ids)
+    _remove_unused_cspecies()
+    _remove_unused_species()
+    _validate_r_ids(r_ids)
+    _validate_reaction_species()
+    _validate_reactions_data(reactions_data_table)
+    _validate_species_data(species_data_table)
+    _validate_table(table_name)
     """
 
     compartments: pd.DataFrame
@@ -157,197 +205,176 @@ class SBML_dfs:
                     '"validate" = False so "resolve" will be ignored (eventhough it was True)'
                 )
 
-    def get_table(
-        self, entity_type: str, required_attributes: None | set[str] = None
-    ) -> pd.DataFrame:
+    # =============================================================================
+    # PUBLIC METHODS (ALPHABETICAL ORDER)
+    # =============================================================================
+
+    def add_reactions_data(self, label: str, data: pd.DataFrame):
         """
-        Get a table from the SBML_dfs object with optional attribute validation.
+        Add additional reaction data with validation.
 
         Parameters
         ----------
-        entity_type : str
-            The type of entity table to retrieve (e.g., 'species', 'reactions')
-        required_attributes : Optional[Set[str]], optional
-            Set of attributes that must be present in the table, by default None.
-            Must be passed as a set, e.g. {'id'}, not a string.
-
-        Returns
-        -------
-        pd.DataFrame
-            The requested table
+        label : str
+            Label for the new data
+        data : pd.DataFrame
+            Data to add, must be indexed by reaction_id
 
         Raises
         ------
         ValueError
-            If entity_type is invalid or required attributes are missing
-        TypeError
-            If required_attributes is not a set
+            If the data is invalid or label already exists
         """
-
-        schema = self.schema
-
-        if entity_type not in schema.keys():
+        self._validate_reactions_data(data)
+        if label in self.reactions_data:
             raise ValueError(
-                f"{entity_type} does not match a table in the SBML_dfs object. The tables "
-                f"which are present are {', '.join(schema.keys())}"
+                f"{label} already exists in reactions_data. " "Drop it first."
             )
+        self.reactions_data[label] = data
 
-        if required_attributes is not None:
-            if not isinstance(required_attributes, set):
-                raise TypeError(
-                    f"required_attributes must be a set (e.g. {{'id'}}), but got {type(required_attributes).__name__}. "
-                    "Did you pass a string instead of a set?"
-                )
-
-            # determine whether required_attributes are appropriate
-            VALID_REQUIRED_ATTRIBUTES = {"id", "source", "label"}
-            invalid_required_attributes = required_attributes.difference(
-                VALID_REQUIRED_ATTRIBUTES
-            )
-
-            if len(invalid_required_attributes) > 0:
-                raise ValueError(
-                    f"The following required attributes are not valid: {', '.join(invalid_required_attributes)}. "
-                    f"Requiered attributes must be a subset of {', '.join(VALID_REQUIRED_ATTRIBUTES)}"
-                )
-
-            # determine if required_attributes are satisified
-            invalid_attrs = [
-                s for s in required_attributes if s not in schema[entity_type].keys()
-            ]
-            if len(invalid_attrs) > 0:
-                raise ValueError(
-                    f"The following required attributes are not present for the {entity_type} table: "
-                    f"{', '.join(invalid_attrs)}."
-                )
-
-        return getattr(self, entity_type)
-
-    def search_by_ids(
-        self,
-        ids: list[str],
-        entity_type: str,
-        identifiers_df: pd.DataFrame,
-        ontologies: None | set[str] = None,
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+    def add_species_data(self, label: str, data: pd.DataFrame):
         """
-        Find entities and identifiers matching a set of query IDs.
+        Add additional species data with validation.
 
         Parameters
         ----------
-        ids : List[str]
-            List of identifiers to search for
-        entity_type : str
-            Type of entity to search (e.g., 'species', 'reactions')
-        identifiers_df : pd.DataFrame
-            DataFrame containing identifier mappings
-        ontologies : Optional[Set[str]], optional
-            Set of ontologies to filter by, by default None
-
-        Returns
-        -------
-        Tuple[pd.DataFrame, pd.DataFrame]
-            - Matching entities
-            - Matching identifiers
+        label : str
+            Label for the new data
+        data : pd.DataFrame
+            Data to add, must be indexed by species_id
 
         Raises
         ------
         ValueError
-            If entity_type is invalid or ontologies are invalid
-        TypeError
-            If ontologies is not a set
+            If the data is invalid or label already exists
         """
-        # validate inputs
-        entity_table = self.get_table(entity_type, required_attributes={"id"})
-        entity_pk = self.schema[entity_type]["pk"]
+        self._validate_species_data(data)
+        if label in self.species_data:
+            raise ValueError(
+                f"{label} already exists in species_data. " "Drop it first."
+            )
+        self.species_data[label] = data
 
-        utils.match_pd_vars(
-            identifiers_df,
-            req_vars={
-                entity_pk,
-                IDENTIFIERS.ONTOLOGY,
-                IDENTIFIERS.IDENTIFIER,
-                IDENTIFIERS.URL,
-                IDENTIFIERS.BQB,
-            },
-            allow_series=False,
-        ).assert_present()
-
-        if ontologies is not None:
-            if not isinstance(ontologies, set):
-                # for clarity this should not be reachable based on type hints
-                raise TypeError(
-                    f"ontologies must be a set, but got {type(ontologies).__name__}"
-                )
-            ALL_VALID_ONTOLOGIES = identifiers_df["ontology"].unique()
-            invalid_ontologies = ontologies.difference(ALL_VALID_ONTOLOGIES)
-            if len(invalid_ontologies) > 0:
-                raise ValueError(
-                    f"The following ontologies are not valid: {', '.join(invalid_ontologies)}.\n"
-                    f"Valid ontologies are {', '.join(ALL_VALID_ONTOLOGIES)}"
-                )
-
-            # fitler to just to identifiers matchign the ontologies of interest
-            identifiers_df = identifiers_df.query("ontology in @ontologies")
-
-        matching_identifiers = identifiers_df.loc[
-            identifiers_df["identifier"].isin(ids)
-        ]
-        entity_subset = entity_table.loc[matching_identifiers[entity_pk].tolist()]
-
-        return entity_subset, matching_identifiers
-
-    def search_by_name(
-        self, name: str, entity_type: str, partial_match: bool = True
-    ) -> pd.DataFrame:
+    def export_sbml_dfs(
+        self,
+        model_prefix: str,
+        outdir: str,
+        overwrite: bool = False,
+        dogmatic: bool = True,
+    ) -> None:
         """
-        Find entities by exact or partial name match.
+        Export SBML_dfs
+
+        Export summaries of species identifiers and each table underlying
+        an SBML_dfs pathway model
+
+        Params
+        ------
+        model_prefix: str
+            Label to prepend to all exported files
+        outdir: str
+            Path to an existing directory where results should be saved
+        overwrite: bool
+            Should the directory be overwritten if it already exists?
+        dogmatic: bool
+            If True then treat genes, transcript, and proteins as separate species. If False
+            then treat them interchangeably.
+
+        Returns
+        -------
+        None
+        """
+        if not isinstance(model_prefix, str):
+            raise TypeError(
+                f"model_prefix was a {type(model_prefix)} " "and must be a str"
+            )
+        if not isinstance(self, SBML_dfs):
+            raise TypeError(
+                f"sbml_dfs was a {type(self)} and must" " be an sbml.SBML_dfs"
+            )
+
+        # filter to identifiers which make sense when mapping from ids -> species
+        species_identifiers = self.get_characteristic_species_ids(dogmatic=dogmatic)
+
+        try:
+            utils.initialize_dir(outdir, overwrite=overwrite)
+        except FileExistsError:
+            logger.warning(
+                f"Directory {outdir} already exists and overwrite is False. "
+                "Files will be added to the existing directory."
+            )
+        with open_fs(outdir, writeable=True) as fs:
+            species_identifiers_path = (
+                model_prefix + NAPISTU_STANDARD_OUTPUTS.SPECIES_IDENTIFIERS
+            )
+            with fs.openbin(species_identifiers_path, "w") as f:
+                species_identifiers.drop([SBML_DFS.S_SOURCE], axis=1).to_csv(
+                    f, sep="\t", index=False
+                )
+
+            # export jsons
+            species_path = model_prefix + NAPISTU_STANDARD_OUTPUTS.SPECIES
+            reactions_path = model_prefix + NAPISTU_STANDARD_OUTPUTS.REACTIONS
+            reation_species_path = (
+                model_prefix + NAPISTU_STANDARD_OUTPUTS.REACTION_SPECIES
+            )
+            compartments_path = model_prefix + NAPISTU_STANDARD_OUTPUTS.COMPARTMENTS
+            compartmentalized_species_path = (
+                model_prefix + NAPISTU_STANDARD_OUTPUTS.COMPARTMENTALIZED_SPECIES
+            )
+            with fs.openbin(species_path, "w") as f:
+                self.species[[SBML_DFS.S_NAME]].to_json(f)
+
+            with fs.openbin(reactions_path, "w") as f:
+                self.reactions[[SBML_DFS.R_NAME]].to_json(f)
+
+            with fs.openbin(reation_species_path, "w") as f:
+                self.reaction_species.to_json(f)
+
+            with fs.openbin(compartments_path, "w") as f:
+                self.compartments[[SBML_DFS.C_NAME]].to_json(f)
+
+            with fs.openbin(compartmentalized_species_path, "w") as f:
+                self.compartmentalized_species.drop(SBML_DFS.SC_SOURCE, axis=1).to_json(
+                    f
+                )
+
+        return None
+
+    def get_characteristic_species_ids(self, dogmatic: bool = True) -> pd.DataFrame:
+        """
+        Get Characteristic Species IDs
+
+        List the systematic identifiers which are characteristic of molecular species, e.g., excluding subcomponents, and optionally, treating proteins, transcripts, and genes equiavlently.
 
         Parameters
         ----------
-        name : str
-            Name to search for
-        entity_type : str
-            Type of entity to search (e.g., 'species', 'reactions')
-        partial_match : bool, optional
-            Whether to allow partial string matches, by default True
+        sbml_dfs : sbml_dfs_core.SBML_dfs
+            The SBML_dfs object.
+        dogmatic : bool, default=True
+            Whether to use the dogmatic flag to determine which BQB attributes are valid.
 
         Returns
         -------
         pd.DataFrame
-            Matching entities
+            A DataFrame containing the systematic identifiers which are characteristic of molecular species.
         """
-        entity_table = self.get_table(entity_type, required_attributes={"label"})
-        label_attr = self.schema[entity_type]["label"]
 
-        if partial_match:
-            matches = entity_table.loc[
-                entity_table[label_attr].str.contains(name, case=False)
-            ]
-        else:
-            matches = entity_table.loc[entity_table[label_attr].str.lower() == name]
-        return matches
-
-    def get_species_features(self) -> pd.DataFrame:
-        """
-        Get additional attributes of species.
-
-        Returns
-        -------
-        pd.DataFrame
-            Species with additional features including:
-            - species_type: Classification of the species (e.g., metabolite, protein)
-        """
-        species = self.species
-        augmented_species = species.assign(
-            **{
-                "species_type": lambda d: d["s_Identifiers"].apply(
-                    sbml_dfs_utils.species_type_types
-                )
-            }
+        # select valid BQB attributes based on dogmatic flag
+        defining_biological_qualifiers = sbml_dfs_utils._dogmatic_to_defining_bqbs(
+            dogmatic
         )
 
-        return augmented_species
+        # pre-summarize ontologies
+        species_identifiers = self.get_identifiers(SBML_DFS.SPECIES)
+
+        # drop some BQB_HAS_PART annotations
+        species_identifiers = sbml_dfs_utils.filter_to_characteristic_species_ids(
+            species_identifiers,
+            defining_biological_qualifiers=defining_biological_qualifiers,
+        )
+
+        return species_identifiers
 
     def get_cspecies_features(self) -> pd.DataFrame:
         """
@@ -444,91 +471,6 @@ class SBML_dfs:
 
         return named_identifiers
 
-    def get_uri_urls(
-        self,
-        entity_type: str,
-        entity_ids: Iterable[str] | None = None,
-        required_ontology: str | None = None,
-    ) -> pd.Series:
-        """
-        Get reference URLs for specified entities.
-
-        Parameters
-        ----------
-        entity_type : str
-            Type of entity to get URLs for (e.g., 'species', 'reactions')
-        entity_ids : Optional[Iterable[str]], optional
-            Specific entities to get URLs for, by default None (all entities)
-        required_ontology : Optional[str], optional
-            Specific ontology to get URLs from, by default None
-
-        Returns
-        -------
-        pd.Series
-            Series mapping entity IDs to their reference URLs
-
-        Raises
-        ------
-        ValueError
-            If entity_type is invalid
-        """
-        schema = self.schema
-
-        # valid entities and their identifier variables
-        valid_entity_types = [
-            SBML_DFS.COMPARTMENTS,
-            SBML_DFS.SPECIES,
-            SBML_DFS.REACTIONS,
-        ]
-
-        if entity_type not in valid_entity_types:
-            raise ValueError(
-                f"{entity_type} is an invalid entity_type; valid types "
-                f"are {', '.join(valid_entity_types)}"
-            )
-
-        entity_table = getattr(self, entity_type)
-
-        if entity_ids is not None:
-            # ensure that entity_ids are unique and then convert back to list
-            # to support pandas indexing
-            entity_ids = list(set(entity_ids))
-
-            # filter to a subset of identifiers if one is provided
-            entity_table = entity_table.loc[entity_ids]
-
-        # create a dataframe of all identifiers for the select entities
-        all_ids = pd.concat(
-            [
-                sbml_dfs_utils._id_dict_to_df(
-                    entity_table[schema[entity_type]["id"]].iloc[i].ids
-                ).assign(id=entity_table.index[i])
-                for i in range(0, entity_table.shape[0])
-            ]
-        ).rename(columns={"id": schema[entity_type]["pk"]})
-
-        # set priorities for ontologies and bqb terms
-
-        if required_ontology is None:
-            all_ids = all_ids.merge(BQB_PRIORITIES, how="left").merge(
-                ONTOLOGY_PRIORITIES, how="left"
-            )
-        else:
-            ontology_priorities = pd.DataFrame(
-                [{IDENTIFIERS.ONTOLOGY: required_ontology, "ontology_rank": 1}]
-            )
-            # if only a single ontology is sought then just return matching entries
-            all_ids = all_ids.merge(BQB_PRIORITIES, how="left").merge(
-                ontology_priorities, how="inner"
-            )
-
-        uri_urls = (
-            all_ids.sort_values(["bqb_rank", "ontology_rank", IDENTIFIERS.URL])
-            .groupby(schema[entity_type]["pk"])
-            .first()[IDENTIFIERS.URL]
-        )
-        return uri_urls
-
     def get_network_summary(self) -> Mapping[str, Any]:
         """
         Get diagnostic statistics about the network.
@@ -615,720 +557,228 @@ class SBML_dfs:
 
         return stats
 
-    def add_species_data(self, label: str, data: pd.DataFrame):
+    def get_species_features(self) -> pd.DataFrame:
         """
-        Add additional species data with validation.
-
-        Parameters
-        ----------
-        label : str
-            Label for the new data
-        data : pd.DataFrame
-            Data to add, must be indexed by species_id
-
-        Raises
-        ------
-        ValueError
-            If the data is invalid or label already exists
-        """
-        self._validate_species_data(data)
-        if label in self.species_data:
-            raise ValueError(
-                f"{label} already exists in species_data. " "Drop it first."
-            )
-        self.species_data[label] = data
-
-    def remove_species_data(self, label: str):
-        """
-        Remove species data by label.
-        """
-        self._remove_entity_data(SBML_DFS.SPECIES, label)
-
-    def add_reactions_data(self, label: str, data: pd.DataFrame):
-        """
-        Add additional reaction data with validation.
-
-        Parameters
-        ----------
-        label : str
-            Label for the new data
-        data : pd.DataFrame
-            Data to add, must be indexed by reaction_id
-
-        Raises
-        ------
-        ValueError
-            If the data is invalid or label already exists
-        """
-        self._validate_reactions_data(data)
-        if label in self.reactions_data:
-            raise ValueError(
-                f"{label} already exists in reactions_data. Drop it first."
-            )
-        self.reactions_data[label] = data
-
-    def remove_reactions_data(self, label: str):
-        """
-        Remove reactions data by label.
-        """
-        self._remove_entity_data(SBML_DFS.REACTIONS, label)
-
-    def remove_compartmentalized_species(self, sc_ids: Iterable[str]):
-        """
-        Remove compartmentalized species and associated reactions.
-
-        Starting with a set of compartmentalized species, determine which reactions
-        should be removed based on their removal. Then remove these reactions,
-        compartmentalized species, and species.
-
-        Parameters
-        ----------
-        sc_ids : Iterable[str]
-            IDs of compartmentalized species to remove
-        """
-
-        # find reactions which should be totally removed since they are losing critical species
-        removed_reactions = self._find_underspecified_reactions_by_scids(sc_ids)
-        self.remove_reactions(removed_reactions)
-
-        self._remove_compartmentalized_species(sc_ids)
-
-        # remove species (and their associated species data if all their cspecies have been lost)
-        self._remove_unused_species()
-
-    def remove_reactions(self, r_ids: Iterable[str], remove_species: bool = False):
-        """
-        Remove reactions from the model.
-
-        Parameters
-        ----------
-        r_ids : Iterable[str]
-            IDs of reactions to remove
-        remove_species : bool, optional
-            Whether to remove species that are no longer part of any reactions,
-            by default False
-        """
-        # remove corresponding reactions_species
-        self.reaction_species = self.reaction_species.query("r_id not in @r_ids")
-        # remove reactions
-        self.reactions = self.reactions.drop(index=list(r_ids))
-        # remove reactions_data
-        if hasattr(self, "reactions_data"):
-            for k, data in self.reactions_data.items():
-                self.reactions_data[k] = data.drop(index=list(r_ids))
-        # remove species if requested
-        if remove_species:
-            self._remove_unused_cspecies()
-            self._remove_unused_species()
-
-    def validate(self):
-        """
-        Validate the SBML_dfs structure and relationships.
-
-        Checks:
-        - Schema existence
-        - Required tables presence
-        - Individual table structure
-        - Primary key uniqueness
-        - Foreign key relationships
-        - Optional data table validity
-        - Reaction species validity
-
-        Raises
-        ------
-        ValueError
-            If any validation check fails
-        """
-
-        if not hasattr(self, "schema"):
-            raise ValueError("No schema found")
-
-        required_tables = self._required_entities
-        schema_tables = set(self.schema.keys())
-
-        extra_tables = schema_tables.difference(required_tables)
-        if len(extra_tables) != 0:
-            logger.debug(
-                f"{len(extra_tables)} unexpected tables found: "
-                f"{', '.join(extra_tables)}"
-            )
-
-        missing_tables = required_tables.difference(schema_tables)
-        if len(missing_tables) != 0:
-            raise ValueError(
-                f"Missing {len(missing_tables)} required tables: "
-                f"{', '.join(missing_tables)}"
-            )
-
-        # check individual tables
-        for table in required_tables:
-            self._validate_table(table)
-
-        # check whether pks and fks agree
-        self._check_pk_fk_correspondence()
-
-        # check optional data tables:
-        for k, v in self.species_data.items():
-            try:
-                self._validate_species_data(v)
-            except ValueError as e:
-                raise ValueError(f"species data {k} was invalid.") from e
-
-        for k, v in self.reactions_data.items():
-            try:
-                self._validate_reactions_data(v)
-            except ValueError as e:
-                raise ValueError(f"reactions data {k} was invalid.") from e
-
-        # validate reaction_species sbo_terms and stoi
-        self._validate_reaction_species()
-
-    def validate_and_resolve(self):
-        """
-        Validate and attempt to automatically fix common issues.
-
-        This method iteratively:
-        1. Attempts validation
-        2. If validation fails, tries to resolve the issue
-        3. Repeats until validation passes or issue cannot be resolved
-
-        Raises
-        ------
-        ValueError
-            If validation fails and cannot be automatically resolved
-        """
-
-        current_exception = None
-        validated = False
-
-        while not validated:
-            try:
-                self.validate()
-                validated = True
-            except Exception as e:
-                e_str = str(e)
-                if e_str == current_exception:
-                    logger.warning(
-                        "Automated resolution of an Exception was attempted but failed"
-                    )
-                    raise e
-
-                # try to resolve
-                self._attempt_resolve(e)
-
-    def select_species_data(self, species_data_table: str) -> pd.DataFrame:
-        """
-        Select a species data table from the SBML_dfs object.
-
-        Parameters
-        ----------
-        species_data_table : str
-            Name of the species data table to select
+        Get additional attributes of species.
 
         Returns
         -------
         pd.DataFrame
-            The selected species data table
-
-        Raises
-        ------
-        ValueError
-            If species_data_table is not found
+            Species with additional features including:
+            - species_type: Classification of the species (e.g., metabolite, protein)
         """
-        # Check if species_data_table exists in sbml_dfs.species_data
-        if species_data_table not in self.species_data:
-            raise ValueError(
-                f"species_data_table {species_data_table} not found in sbml_dfs.species_data. "
-                f"Available tables: {self.species_data.keys()}"
-            )
+        species = self.species
+        augmented_species = species.assign(
+            **{
+                "species_type": lambda d: d["s_Identifiers"].apply(
+                    sbml_dfs_utils.species_type_types
+                )
+            }
+        )
 
-        # Get the species data
-        return self.species_data[species_data_table]
+        return augmented_species
 
-    def _validate_table(self, table_name: str) -> None:
+    def get_table(
+        self, entity_type: str, required_attributes: None | set[str] = None
+    ) -> pd.DataFrame:
         """
-        Validate a table in this SBML_dfs object against its schema.
-
-        This is an internal method that validates a table that is part of this SBML_dfs
-        object against the schema stored in self.schema.
-
-        Parameters
-        ----------
-        table : str
-            Name of the table to validate
-
-        Raises
-        ------
-        ValueError
-            If the table does not conform to its schema
-        """
-        table_data = getattr(self, table_name)
-
-        sbml_dfs_utils.validate_sbml_dfs_table(table_data, table_name)
-
-    def _remove_entity_data(self, entity_type: str, label: str) -> None:
-        """
-        Remove data from species_data or reactions_data by table name and label.
+        Get a table from the SBML_dfs object with optional attribute validation.
 
         Parameters
         ----------
         entity_type : str
-            Name of the table to remove data from ('species' or 'reactions')
-        label : str
-            Label of the data to remove
-
-        Notes
-        -----
-        If the label does not exist, a warning will be logged that includes the existing labels.
-        """
-        if entity_type not in ENTITIES_W_DATA:
-            raise ValueError("table_name must be either 'species' or 'reactions'")
-
-        data_dict = getattr(self, ENTITIES_TO_ENTITY_DATA[entity_type])
-        if label not in data_dict:
-            existing_labels = list(data_dict.keys())
-            logger.warning(
-                f"Label '{label}' not found in {ENTITIES_TO_ENTITY_DATA[entity_type]}. "
-                f"Existing labels: {existing_labels}"
-            )
-            return
-
-        del data_dict[label]
-
-    def _remove_unused_cspecies(self):
-        """Removes compartmentalized species that are no
-        longer part of any reactions"""
-        sc_ids = self._get_unused_cspecies()
-        self._remove_compartmentalized_species(sc_ids)
-
-    def _get_unused_cspecies(self) -> set[str]:
-        """Returns a set of compartmentalized species
-        that are not part of any reactions"""
-        sc_ids = set(self.compartmentalized_species.index) - set(
-            self.reaction_species[SBML_DFS.SC_ID]
-        )
-        return sc_ids  # type: ignore
-
-    def _remove_unused_species(self):
-        """Removes species that are no longer part of any
-        compartmentalized species"""
-        s_ids = self._get_unused_species()
-        self._remove_species(s_ids)
-
-    def _get_unused_species(self) -> set[str]:
-        """Returns a list of species that are not part of any reactions"""
-        s_ids = set(self.species.index) - set(
-            self.compartmentalized_species[SBML_DFS.S_ID]
-        )
-        return s_ids  # type: ignore
-
-    def _remove_compartmentalized_species(self, sc_ids: Iterable[str]):
-        """Removes compartmentalized species from the model
-
-        This should not be directly used by the user, as it can lead to
-        invalid reactions when removing species without a logic to decide
-        if the reaction needs to be removed as well.
-
-        Args:
-            sc_ids (Iterable[str]): the compartmentalized species to remove
-        """
-        # Remove compartmentalized species
-        self.compartmentalized_species = self.compartmentalized_species.drop(
-            index=list(sc_ids)
-        )
-        # remove corresponding reactions_species
-        self.reaction_species = self.reaction_species.query("sc_id not in @sc_ids")
-
-    def _remove_species(self, s_ids: Iterable[str]):
-        """Removes species from the model
-
-        This should not be directly used by the user, as it can lead to
-        invalid reactions when removing species without a logic to decide
-        if the reaction needs to be removed as well.
-
-        This removes the species and corresponding compartmentalized species and
-        reactions_species.
-
-        Args:
-            s_ids (Iterable[str]): the species to remove
-        """
-        sc_ids = self.compartmentalized_species.query("s_id in @s_ids").index.tolist()
-        self._remove_compartmentalized_species(sc_ids)
-        # Remove species
-        self.species = self.species.drop(index=list(s_ids))
-        # remove data
-        for k, data in self.species_data.items():
-            self.species_data[k] = data.drop(index=list(s_ids))
-
-    def _validate_species_data(self, species_data_table: pd.DataFrame):
-        """Validates species data attribute
-
-        Args:
-            species_data_table (pd.DataFrame): a species data table
-
-        Raises:
-            ValueError: s_id not index name
-            ValueError: s_id index contains duplicates
-            ValueError: s_id not in species table
-        """
-        sbml_dfs_utils._validate_matching_data(species_data_table, self.species)
-
-    def _validate_reactions_data(self, reactions_data_table: pd.DataFrame):
-        """Validates reactions data attribute
-
-        Args:
-            reactions_data_table (pd.DataFrame): a reactions data table
-
-        Raises:
-            ValueError: r_id not index name
-            ValueError: r_id index contains duplicates
-            ValueError: r_id not in reactions table
-        """
-        sbml_dfs_utils._validate_matching_data(reactions_data_table, self.reactions)
-
-    def _validate_reaction_species(self):
-        if not all(self.reaction_species[SBML_DFS.STOICHIOMETRY].notnull()):
-            raise ValueError(
-                "All reaction_species[SBML_DFS.STOICHIOMETRY] must be not null"
-            )
-
-        # test for null SBO terms
-        n_null_sbo_terms = sum(self.reaction_species[SBML_DFS.SBO_TERM].isnull())
-        if n_null_sbo_terms != 0:
-            raise ValueError(
-                f"{n_null_sbo_terms} sbo_terms were None; all terms should be defined"
-            )
-
-        # find invalid SBO terms
-        sbo_counts = self.reaction_species.value_counts(SBML_DFS.SBO_TERM)
-        invalid_sbo_term_counts = sbo_counts[
-            ~sbo_counts.index.isin(MINI_SBO_TO_NAME.keys())
-        ]
-
-        if invalid_sbo_term_counts.shape[0] != 0:
-            invalid_sbo_counts_str = ", ".join(
-                [f"{k} (N={v})" for k, v in invalid_sbo_term_counts.to_dict().items()]
-            )
-            raise ValueError(
-                f"{invalid_sbo_term_counts.shape[0]} sbo_terms were not "
-                f"defined {invalid_sbo_counts_str}"
-            )
-
-    def _attempt_resolve(self, e):
-        str_e = str(e)
-        if str_e == "compartmentalized_species included missing c_id values":
-            logger.warning(str_e)
-            logger.warning(
-                "Attempting to resolve with infer_uncompartmentalized_species_location()"
-            )
-            self.infer_uncompartmentalized_species_location()
-        elif re.search("sbo_terms were not defined", str_e):
-            logger.warning(str_e)
-            logger.warning("Attempting to resolve with infer_sbo_terms()")
-            self.infer_sbo_terms()
-        else:
-            logger.warning(
-                "An error occurred which could not be automatically resolved"
-            )
-            raise e
-
-    def _check_pk_fk_correspondence(self):
-        """
-        Check whether primary keys and foreign keys agree for all tables in the schema.
-        Raises ValueError if any correspondence fails.
-        """
-
-        pk_df = pd.DataFrame(
-            [{"pk_table": k, "key": v["pk"]} for k, v in self.schema.items()]
-        )
-
-        fk_df = (
-            pd.DataFrame(
-                [
-                    {"fk_table": k, "fk": v["fk"]}
-                    for k, v in self.schema.items()
-                    if "fk" in v.keys()
-                ]
-            )
-            .set_index("fk_table")["fk"]
-            .apply(pd.Series)
-            .reset_index()
-            .melt(id_vars="fk_table")
-            .drop(["variable"], axis=1)
-            .rename(columns={"value": "key"})
-        )
-
-        pk_fk_correspondences = pk_df.merge(fk_df)
-
-        for i in range(0, pk_fk_correspondences.shape[0]):
-            pk_table_keys = set(
-                getattr(self, pk_fk_correspondences["pk_table"][i]).index.tolist()
-            )
-            if None in pk_table_keys:
-                raise ValueError(
-                    f"{pk_fk_correspondences['pk_table'][i]} had "
-                    "missing values in its index"
-                )
-
-            fk_table_keys = set(
-                getattr(self, pk_fk_correspondences["fk_table"][i]).loc[
-                    :, pk_fk_correspondences["key"][i]
-                ]
-            )
-            if None in fk_table_keys:
-                raise ValueError(
-                    f"{pk_fk_correspondences['fk_table'][i]} included "
-                    f"missing {pk_fk_correspondences['key'][i]} values"
-                )
-
-            # all foreign keys need to match a primary key
-            extra_fks = fk_table_keys.difference(pk_table_keys)
-            if len(extra_fks) != 0:
-                raise ValueError(
-                    f"{len(extra_fks)} distinct "
-                    f"{pk_fk_correspondences['key'][i]} values were"
-                    f" found in {pk_fk_correspondences['fk_table'][i]} "
-                    f"but missing from {pk_fk_correspondences['pk_table'][i]}."
-                    " All foreign keys must have a matching primary key.\n\n"
-                    f"Extra key are: {', '.join(extra_fks)}"
-                )
-
-    def species_status(self, s_id: str) -> pd.DataFrame:
-        """
-        Species Status
-
-        Return all of the reactions a species participates in.
-
-        Parameters:
-        s_id: str
-            A species ID
-
-        Returns:
-        pd.DataFrame, one row per reaction the species participates in
-        with columns:
-        - sc_name: str, name of the compartment the species participates in
-        - stoichiometry: float, stoichiometry of the species in the reaction
-        - r_name: str, name of the reaction
-        - r_formula_str: str, human-readable formula of the reaction
-        """
-
-        if s_id not in self.species.index:
-            raise ValueError(f"{s_id} not found in species table")
-
-        matching_species = self.species.loc[s_id]
-
-        if not isinstance(matching_species, pd.Series):
-            raise ValueError(f"{s_id} did not match a single species")
-
-        # find all rxns species participate in
-        matching_compartmentalized_species = self.compartmentalized_species[
-            self.compartmentalized_species.s_id.isin([s_id])
-        ]
-
-        rxns_participating = self.reaction_species[
-            self.reaction_species.sc_id.isin(matching_compartmentalized_species.index)
-        ]
-
-        # find all participants in these rxns
-        full_rxns_participating = self.reaction_species[
-            self.reaction_species.r_id.isin(rxns_participating[SBML_DFS.R_ID])
-        ].merge(
-            self.compartmentalized_species, left_on=SBML_DFS.SC_ID, right_index=True
-        )
-
-        participating_rids = full_rxns_participating[SBML_DFS.R_ID].unique()
-        reaction_descriptions = self.reaction_summaries(r_ids=participating_rids)
-
-        status = (
-            full_rxns_participating.loc[
-                full_rxns_participating[SBML_DFS.SC_ID].isin(
-                    matching_compartmentalized_species.index.values.tolist()
-                ),
-                [SBML_DFS.SC_NAME, SBML_DFS.STOICHIOMETRY, SBML_DFS.R_ID],
-            ]
-            .merge(reaction_descriptions, left_on=SBML_DFS.R_ID, right_index=True)
-            .reset_index(drop=True)
-            .drop(SBML_DFS.R_ID, axis=1)
-        )
-
-        return status
-
-    def reaction_summaries(
-        self, r_ids: Optional[Union[str, list[str]]] = None
-    ) -> pd.DataFrame:
-        """
-        Reaction Summary
-
-        Return a summary of reactions.
-
-        Parameters:
-        ----------
-        r_ids: [str], str or None
-            Reaction IDs or None for all reactions
-
-        Returns
-        ----------
-        reaction_summaries_df: pd.DataFrame
-            A table with r_id as an index and columns:
-            - r_name: str, name of the reaction
-            - r_formula_str: str, human-readable formula of the reaction
-        """
-
-        validated_rids = self._validate_r_ids(r_ids)
-
-        participating_r_names = self.reactions.loc[validated_rids, SBML_DFS.R_NAME]
-        participating_r_formulas = self.reaction_formulas(r_ids=validated_rids)
-        reaction_summareis_df = pd.concat(
-            [participating_r_names, participating_r_formulas], axis=1
-        )
-
-        return reaction_summareis_df
-
-    def reaction_formulas(
-        self, r_ids: Optional[Union[str, list[str]]] = None
-    ) -> pd.Series:
-        """
-        Reaction Summary
-
-        Return human-readable formulas for reactions.
-
-        Parameters:
-        ----------
-        r_ids: [str], str or None
-            Reaction IDs or None for all reactions
-
-        Returns
-        ----------
-        formula_strs: pd.Series
-        """
-
-        validated_rids = self._validate_r_ids(r_ids)
-
-        matching_reaction_species = self.reaction_species[
-            self.reaction_species.r_id.isin(validated_rids)
-        ].merge(
-            self.compartmentalized_species, left_on=SBML_DFS.SC_ID, right_index=True
-        )
-
-        # split into within compartment and cross-compartment reactions
-        r_id_compartment_counts = matching_reaction_species.groupby(SBML_DFS.R_ID)[
-            SBML_DFS.C_ID
-        ].nunique()
-
-        # identify reactions which work across compartments
-        r_id_cross_compartment = r_id_compartment_counts[r_id_compartment_counts > 1]
-        # there species must be labelled with the sc_name to specify where a species exists
-        if r_id_cross_compartment.shape[0] > 0:
-            rxn_eqtn_cross_compartment = (
-                matching_reaction_species[
-                    matching_reaction_species[SBML_DFS.R_ID].isin(
-                        r_id_cross_compartment.index
-                    )
-                ]
-                .sort_values([SBML_DFS.SC_NAME])
-                .groupby(SBML_DFS.R_ID)
-                .apply(
-                    lambda x: sbml_dfs_utils.construct_formula_string(
-                        x, self.reactions, SBML_DFS.SC_NAME
-                    )
-                )
-                .rename("r_formula_str")
-            )
-        else:
-            rxn_eqtn_cross_compartment = None
-
-        # identify reactions which occur within a single compartment; for these the reaction
-        # can be labelled with the compartment and individual species can receive a more readable s_name
-        r_id_within_compartment = r_id_compartment_counts[r_id_compartment_counts == 1]
-        if r_id_within_compartment.shape[0] > 0:
-            # add s_name
-            augmented_matching_reaction_species = (
-                matching_reaction_species[
-                    matching_reaction_species[SBML_DFS.R_ID].isin(
-                        r_id_within_compartment.index
-                    )
-                ]
-                .merge(self.compartments, left_on=SBML_DFS.C_ID, right_index=True)
-                .merge(self.species, left_on=SBML_DFS.S_ID, right_index=True)
-                .sort_values([SBML_DFS.S_NAME])
-            )
-            # create formulas based on s_names of components
-            rxn_eqtn_within_compartment = augmented_matching_reaction_species.groupby(
-                [SBML_DFS.R_ID, SBML_DFS.C_NAME]
-            ).apply(
-                lambda x: sbml_dfs_utils.construct_formula_string(
-                    x, self.reactions, SBML_DFS.S_NAME
-                )
-            )
-            # add compartment for each reaction
-            rxn_eqtn_within_compartment = pd.Series(
-                [
-                    y + ": " + x
-                    for x, y in zip(
-                        rxn_eqtn_within_compartment,
-                        rxn_eqtn_within_compartment.index.get_level_values(
-                            SBML_DFS.C_NAME
-                        ),
-                    )
-                ],
-                index=rxn_eqtn_within_compartment.index.get_level_values(SBML_DFS.R_ID),
-            ).rename("r_formula_str")
-        else:
-            rxn_eqtn_within_compartment = None
-
-        formula_strs = pd.concat(
-            [rxn_eqtn_cross_compartment, rxn_eqtn_within_compartment]
-        )
-
-        return formula_strs
-
-    def get_characteristic_species_ids(self, dogmatic: bool = True) -> pd.DataFrame:
-        """
-        Get Characteristic Species IDs
-
-        List the systematic identifiers which are characteristic of molecular species, e.g., excluding subcomponents, and optionally, treating proteins, transcripts, and genes equiavlently.
-
-        Parameters
-        ----------
-        sbml_dfs : sbml_dfs_core.SBML_dfs
-            The SBML_dfs object.
-        dogmatic : bool, default=True
-            Whether to use the dogmatic flag to determine which BQB attributes are valid.
+            The type of entity table to retrieve (e.g., 'species', 'reactions')
+        required_attributes : Optional[Set[str]], optional
+            Set of attributes that must be present in the table, by default None.
+            Must be passed as a set, e.g. {'id'}, not a string.
 
         Returns
         -------
         pd.DataFrame
-            A DataFrame containing the systematic identifiers which are characteristic of molecular species.
+            The requested table
+
+        Raises
+        ------
+        ValueError
+            If entity_type is invalid or required attributes are missing
+        TypeError
+            If required_attributes is not a set
         """
 
-        # select valid BQB attributes based on dogmatic flag
-        defining_biological_qualifiers = sbml_dfs_utils._dogmatic_to_defining_bqbs(
-            dogmatic
-        )
+        schema = self.schema
 
-        # pre-summarize ontologies
-        species_identifiers = self.get_identifiers(SBML_DFS.SPECIES)
+        if entity_type not in schema.keys():
+            raise ValueError(
+                f"{entity_type} does not match a table in the SBML_dfs object. The tables "
+                f"which are present are {', '.join(schema.keys())}"
+            )
 
-        # drop some BQB_HAS_PART annotations
-        species_identifiers = sbml_dfs_utils.filter_to_characteristic_species_ids(
-            species_identifiers,
-            defining_biological_qualifiers=defining_biological_qualifiers,
-        )
+        if required_attributes is not None:
+            if not isinstance(required_attributes, set):
+                raise TypeError(
+                    f"required_attributes must be a set (e.g. {{'id'}}), but got {type(required_attributes).__name__}. "
+                    "Did you pass a string instead of a set?"
+                )
 
-        return species_identifiers
+            # determine whether required_attributes are appropriate
+            VALID_REQUIRED_ATTRIBUTES = {"id", "source", "label"}
+            invalid_required_attributes = required_attributes.difference(
+                VALID_REQUIRED_ATTRIBUTES
+            )
 
-    def _validate_r_ids(self, r_ids: Optional[Union[str, list[str]]]) -> list[str]:
+            if len(invalid_required_attributes) > 0:
+                raise ValueError(
+                    f"The following required attributes are not valid: {', '.join(invalid_required_attributes)}. "
+                    f"Requiered attributes must be a subset of {', '.join(VALID_REQUIRED_ATTRIBUTES)}"
+                )
 
-        if isinstance(r_ids, str):
-            r_ids = [r_ids]
+            # determine if required_attributes are satisified
+            invalid_attrs = [
+                s for s in required_attributes if s not in schema[entity_type].keys()
+            ]
+            if len(invalid_attrs) > 0:
+                raise ValueError(
+                    f"The following required attributes are not present for the {entity_type} table: "
+                    f"{', '.join(invalid_attrs)}."
+                )
 
-        if r_ids is None:
-            return self.reactions.index.tolist()
+        return getattr(self, entity_type)
+
+    def get_uri_urls(
+        self,
+        entity_type: str,
+        entity_ids: Iterable[str] | None = None,
+        required_ontology: str | None = None,
+    ) -> pd.Series:
+        """
+        Get reference URLs for specified entities.
+
+        Parameters
+        ----------
+        entity_type : str
+            Type of entity to get URLs for (e.g., 'species', 'reactions')
+        entity_ids : Optional[Iterable[str]], optional
+            Specific entities to get URLs for, by default None (all entities)
+        required_ontology : Optional[str], optional
+            Specific ontology to get URLs from, by default None
+
+        Returns
+        -------
+        pd.Series
+            Series mapping entity IDs to their reference URLs
+
+        Raises
+        ------
+        ValueError
+            If entity_type is invalid
+        """
+        schema = self.schema
+
+        # valid entities and their identifier variables
+        valid_entity_types = [
+            SBML_DFS.COMPARTMENTS,
+            SBML_DFS.SPECIES,
+            SBML_DFS.REACTIONS,
+        ]
+
+        if entity_type not in valid_entity_types:
+            raise ValueError(
+                f"{entity_type} is an invalid entity_type; valid types "
+                f"are {', '.join(valid_entity_types)}"
+            )
+
+        entity_table = getattr(self, entity_type)
+
+        if entity_ids is not None:
+            # ensure that entity_ids are unique and then convert back to list
+            # to support pandas indexing
+            entity_ids = list(set(entity_ids))
+
+            # filter to a subset of identifiers if one is provided
+            entity_table = entity_table.loc[entity_ids]
+
+        # create a dataframe of all identifiers for the select entities
+        all_ids = pd.concat(
+            [
+                sbml_dfs_utils._id_dict_to_df(
+                    entity_table[schema[entity_type]["id"]].iloc[i].ids
+                ).assign(id=entity_table.index[i])
+                for i in range(0, entity_table.shape[0])
+            ]
+        ).rename(columns={"id": schema[entity_type]["pk"]})
+
+        # set priorities for ontologies and bqb terms
+
+        if required_ontology is None:
+            all_ids = all_ids.merge(BQB_PRIORITIES, how="left").merge(
+                ONTOLOGY_PRIORITIES, how="left"
+            )
         else:
-            if not all(r_id in self.reactions.index for r_id in r_ids):
-                raise ValueError(f"Reaction IDs {r_ids} not found in reactions table")
+            ontology_priorities = pd.DataFrame(
+                [{IDENTIFIERS.ONTOLOGY: required_ontology, "ontology_rank": 1}]
+            )
+            # if only a single ontology is sought then just return matching entries
+            all_ids = all_ids.merge(BQB_PRIORITIES, how="left").merge(
+                ontology_priorities, how="inner"
+            )
 
-            return r_ids
+        uri_urls = (
+            all_ids.sort_values(["bqb_rank", "ontology_rank", IDENTIFIERS.URL])
+            .groupby(schema[entity_type]["pk"])
+            .first()[IDENTIFIERS.URL]
+        )
+        return uri_urls
+
+    def infer_sbo_terms(self):
+        """
+        Infer SBO Terms
+
+        Define SBO terms based on stoichiometry for reaction_species with missing terms.
+        Modifies the SBML_dfs object in-place.
+
+        Returns
+        -------
+        None (modifies SBML_dfs object in-place)
+        """
+        valid_sbo_terms = self.reaction_species[
+            self.reaction_species[SBML_DFS.SBO_TERM].isin(MINI_SBO_TO_NAME.keys())
+        ]
+
+        invalid_sbo_terms = self.reaction_species[
+            ~self.reaction_species[SBML_DFS.SBO_TERM].isin(MINI_SBO_TO_NAME.keys())
+        ]
+
+        if not all(self.reaction_species[SBML_DFS.SBO_TERM].notnull()):
+            raise ValueError("All reaction_species[SBML_DFS.SBO_TERM] must be not null")
+        if invalid_sbo_terms.shape[0] == 0:
+            logger.info("All sbo_terms were valid; nothing to update.")
+            return
+
+        logger.info(f"Updating {invalid_sbo_terms.shape[0]} reaction_species' sbo_term")
+
+        # add missing/invalid terms based on stoichiometry
+        invalid_sbo_terms.loc[
+            invalid_sbo_terms[SBML_DFS.STOICHIOMETRY] < 0, SBML_DFS.SBO_TERM
+        ] = MINI_SBO_FROM_NAME[SBOTERM_NAMES.REACTANT]
+
+        invalid_sbo_terms.loc[
+            invalid_sbo_terms[SBML_DFS.STOICHIOMETRY] > 0, SBML_DFS.SBO_TERM
+        ] = MINI_SBO_FROM_NAME[SBOTERM_NAMES.PRODUCT]
+
+        invalid_sbo_terms.loc[
+            invalid_sbo_terms[SBML_DFS.STOICHIOMETRY] == 0, SBML_DFS.SBO_TERM
+        ] = MINI_SBO_FROM_NAME[SBOTERM_NAMES.STIMULATOR]
+
+        updated_reaction_species = pd.concat(
+            [valid_sbo_terms, invalid_sbo_terms]
+        ).sort_index()
+
+        if self.reaction_species.shape[0] != updated_reaction_species.shape[0]:
+            raise ValueError(
+                f"Trying to overwrite {self.reaction_species.shape[0]} reaction_species with {updated_reaction_species.shape[0]}"
+            )
+        self.reaction_species = updated_reaction_species
+        return
 
     def infer_uncompartmentalized_species_location(self):
         """
@@ -1475,57 +925,6 @@ class SBML_dfs:
         self.compartmentalized_species = updated_compartmentalized_species
         return
 
-    def infer_sbo_terms(self):
-        """
-        Infer SBO Terms
-
-        Define SBO terms based on stoichiometry for reaction_species with missing terms.
-        Modifies the SBML_dfs object in-place.
-
-        Returns
-        -------
-        None (modifies SBML_dfs object in-place)
-        """
-        valid_sbo_terms = self.reaction_species[
-            self.reaction_species[SBML_DFS.SBO_TERM].isin(MINI_SBO_TO_NAME.keys())
-        ]
-
-        invalid_sbo_terms = self.reaction_species[
-            ~self.reaction_species[SBML_DFS.SBO_TERM].isin(MINI_SBO_TO_NAME.keys())
-        ]
-
-        if not all(self.reaction_species[SBML_DFS.SBO_TERM].notnull()):
-            raise ValueError("All reaction_species[SBML_DFS.SBO_TERM] must be not null")
-        if invalid_sbo_terms.shape[0] == 0:
-            logger.info("All sbo_terms were valid; nothing to update.")
-            return
-
-        logger.info(f"Updating {invalid_sbo_terms.shape[0]} reaction_species' sbo_term")
-
-        # add missing/invalid terms based on stoichiometry
-        invalid_sbo_terms.loc[
-            invalid_sbo_terms[SBML_DFS.STOICHIOMETRY] < 0, SBML_DFS.SBO_TERM
-        ] = MINI_SBO_FROM_NAME[SBOTERM_NAMES.REACTANT]
-
-        invalid_sbo_terms.loc[
-            invalid_sbo_terms[SBML_DFS.STOICHIOMETRY] > 0, SBML_DFS.SBO_TERM
-        ] = MINI_SBO_FROM_NAME[SBOTERM_NAMES.PRODUCT]
-
-        invalid_sbo_terms.loc[
-            invalid_sbo_terms[SBML_DFS.STOICHIOMETRY] == 0, SBML_DFS.SBO_TERM
-        ] = MINI_SBO_FROM_NAME[SBOTERM_NAMES.STIMULATOR]
-
-        updated_reaction_species = pd.concat(
-            [valid_sbo_terms, invalid_sbo_terms]
-        ).sort_index()
-
-        if self.reaction_species.shape[0] != updated_reaction_species.shape[0]:
-            raise ValueError(
-                f"Trying to overwrite {self.reaction_species.shape[0]} reaction_species with {updated_reaction_species.shape[0]}"
-            )
-        self.reaction_species = updated_reaction_species
-        return
-
     def name_compartmentalized_species(self):
         """
         Name Compartmentalized Species
@@ -1556,91 +955,566 @@ class SBML_dfs:
         ]
         return
 
-    def export_sbml_dfs(
-        self,
-        model_prefix: str,
-        outdir: str,
-        overwrite: bool = False,
-        dogmatic: bool = True,
-    ) -> None:
+    def reaction_formulas(
+        self, r_ids: Optional[Union[str, list[str]]] = None
+    ) -> pd.Series:
         """
-        Export SBML_dfs
+        Reaction Summary
 
-        Export summaries of species identifiers and each table underlying
-        an SBML_dfs pathway model
+        Return human-readable formulas for reactions.
 
-        Params
-        ------
-        model_prefix: str
-            Label to prepend to all exported files
-        outdir: str
-            Path to an existing directory where results should be saved
-        overwrite: bool
-            Should the directory be overwritten if it already exists?
-        dogmatic: bool
-            If True then treat genes, transcript, and proteins as separate species. If False
-            then treat them interchangeably.
+        Parameters:
+        ----------
+        r_ids: [str], str or None
+            Reaction IDs or None for all reactions
+
+        Returns
+        ----------
+        formula_strs: pd.Series
+        """
+
+        validated_rids = self._validate_r_ids(r_ids)
+
+        matching_reaction_species = self.reaction_species[
+            self.reaction_species.r_id.isin(validated_rids)
+        ].merge(
+            self.compartmentalized_species, left_on=SBML_DFS.SC_ID, right_index=True
+        )
+
+        # split into within compartment and cross-compartment reactions
+        r_id_compartment_counts = matching_reaction_species.groupby(SBML_DFS.R_ID)[
+            SBML_DFS.C_ID
+        ].nunique()
+
+        # identify reactions which work across compartments
+        r_id_cross_compartment = r_id_compartment_counts[r_id_compartment_counts > 1]
+        # there species must be labelled with the sc_name to specify where a species exists
+        if r_id_cross_compartment.shape[0] > 0:
+            rxn_eqtn_cross_compartment = (
+                matching_reaction_species[
+                    matching_reaction_species[SBML_DFS.R_ID].isin(
+                        r_id_cross_compartment.index
+                    )
+                ]
+                .sort_values([SBML_DFS.SC_NAME])
+                .groupby(SBML_DFS.R_ID)
+                .apply(
+                    lambda x: sbml_dfs_utils.construct_formula_string(
+                        x, self.reactions, SBML_DFS.SC_NAME
+                    )
+                )
+                .rename("r_formula_str")
+            )
+        else:
+            rxn_eqtn_cross_compartment = None
+
+        # identify reactions which occur within a single compartment; for these the reaction
+        # can be labelled with the compartment and individual species can receive a more readable s_name
+        r_id_within_compartment = r_id_compartment_counts[r_id_compartment_counts == 1]
+        if r_id_within_compartment.shape[0] > 0:
+            # add s_name
+            augmented_matching_reaction_species = (
+                matching_reaction_species[
+                    matching_reaction_species[SBML_DFS.R_ID].isin(
+                        r_id_within_compartment.index
+                    )
+                ]
+                .merge(self.compartments, left_on=SBML_DFS.C_ID, right_index=True)
+                .merge(self.species, left_on=SBML_DFS.S_ID, right_index=True)
+                .sort_values([SBML_DFS.S_NAME])
+            )
+            # create formulas based on s_names of components
+            rxn_eqtn_within_compartment = augmented_matching_reaction_species.groupby(
+                [SBML_DFS.R_ID, SBML_DFS.C_NAME]
+            ).apply(
+                lambda x: sbml_dfs_utils.construct_formula_string(
+                    x, self.reactions, SBML_DFS.S_NAME
+                )
+            )
+            # add compartment for each reaction
+            rxn_eqtn_within_compartment = pd.Series(
+                [
+                    y + ": " + x
+                    for x, y in zip(
+                        rxn_eqtn_within_compartment,
+                        rxn_eqtn_within_compartment.index.get_level_values(
+                            SBML_DFS.C_NAME
+                        ),
+                    )
+                ],
+                index=rxn_eqtn_within_compartment.index.get_level_values(SBML_DFS.R_ID),
+            ).rename("r_formula_str")
+        else:
+            rxn_eqtn_within_compartment = None
+
+        formula_strs = pd.concat(
+            [rxn_eqtn_cross_compartment, rxn_eqtn_within_compartment]
+        )
+
+        return formula_strs
+
+    def reaction_summaries(
+        self, r_ids: Optional[Union[str, list[str]]] = None
+    ) -> pd.DataFrame:
+        """
+        Reaction Summary
+
+        Return a summary of reactions.
+
+        Parameters:
+        ----------
+        r_ids: [str], str or None
+            Reaction IDs or None for all reactions
+
+        Returns
+        ----------
+        reaction_summaries_df: pd.DataFrame
+            A table with r_id as an index and columns:
+            - r_name: str, name of the reaction
+            - r_formula_str: str, human-readable formula of the reaction
+        """
+
+        validated_rids = self._validate_r_ids(r_ids)
+
+        participating_r_names = self.reactions.loc[validated_rids, SBML_DFS.R_NAME]
+        participating_r_formulas = self.reaction_formulas(r_ids=validated_rids)
+        reaction_summareis_df = pd.concat(
+            [participating_r_names, participating_r_formulas], axis=1
+        )
+
+        return reaction_summareis_df
+
+    def remove_compartmentalized_species(self, sc_ids: Iterable[str]):
+        """
+        Remove compartmentalized species and associated reactions.
+
+        Starting with a set of compartmentalized species, determine which reactions
+        should be removed based on their removal. Then remove these reactions,
+        compartmentalized species, and species.
+
+        Parameters
+        ----------
+        sc_ids : Iterable[str]
+            IDs of compartmentalized species to remove
+        """
+
+        # find reactions which should be totally removed since they are losing critical species
+        removed_reactions = self._find_underspecified_reactions_by_scids(sc_ids)
+        self.remove_reactions(removed_reactions)
+
+        self._remove_compartmentalized_species(sc_ids)
+
+        # remove species (and their associated species data if all their cspecies have been lost)
+        self._remove_unused_species()
+
+    def remove_reactions(self, r_ids: Iterable[str], remove_species: bool = False):
+        """
+        Remove reactions from the model.
+
+        Parameters
+        ----------
+        r_ids : Iterable[str]
+            IDs of reactions to remove
+        remove_species : bool, optional
+            Whether to remove species that are no longer part of any reactions,
+            by default False
+        """
+        # remove corresponding reactions_species
+        self.reaction_species = self.reaction_species.query("r_id not in @r_ids")
+        # remove reactions
+        self.reactions = self.reactions.drop(index=list(r_ids))
+        # remove reactions_data
+        if hasattr(self, "reactions_data"):
+            for k, data in self.reactions_data.items():
+                self.reactions_data[k] = data.drop(index=list(r_ids))
+        # remove species if requested
+        if remove_species:
+            self._remove_unused_cspecies()
+            self._remove_unused_species()
+
+    def remove_reactions_data(self, label: str):
+        """
+        Remove reactions data by label.
+        """
+        self._remove_entity_data(SBML_DFS.REACTIONS, label)
+
+    def remove_species_data(self, label: str):
+        """
+        Remove species data by label.
+        """
+        self._remove_entity_data(SBML_DFS.SPECIES, label)
+
+    def search_by_ids(
+        self,
+        ids: list[str],
+        entity_type: str,
+        identifiers_df: pd.DataFrame,
+        ontologies: None | set[str] = None,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """
+        Find entities and identifiers matching a set of query IDs.
+
+        Parameters
+        ----------
+        ids : List[str]
+            List of identifiers to search for
+        entity_type : str
+            Type of entity to search (e.g., 'species', 'reactions')
+        identifiers_df : pd.DataFrame
+            DataFrame containing identifier mappings
+        ontologies : Optional[Set[str]], optional
+            Set of ontologies to filter by, by default None
 
         Returns
         -------
-        None
+        Tuple[pd.DataFrame, pd.DataFrame]
+            - Matching entities
+            - Matching identifiers
+
+        Raises
+        ------
+        ValueError
+            If entity_type is invalid or ontologies are invalid
+        TypeError
+            If ontologies is not a set
         """
-        if not isinstance(model_prefix, str):
-            raise TypeError(
-                f"model_prefix was a {type(model_prefix)} " "and must be a str"
-            )
-        if not isinstance(self, SBML_dfs):
-            raise TypeError(
-                f"sbml_dfs was a {type(self)} and must" " be an sbml.SBML_dfs"
+        # validate inputs
+        entity_table = self.get_table(entity_type, required_attributes={"id"})
+        entity_pk = self.schema[entity_type]["pk"]
+
+        utils.match_pd_vars(
+            identifiers_df,
+            req_vars={
+                entity_pk,
+                IDENTIFIERS.ONTOLOGY,
+                IDENTIFIERS.IDENTIFIER,
+                IDENTIFIERS.URL,
+                IDENTIFIERS.BQB,
+            },
+            allow_series=False,
+        ).assert_present()
+
+        if ontologies is not None:
+            if not isinstance(ontologies, set):
+                # for clarity this should not be reachable based on type hints
+                raise TypeError(
+                    f"ontologies must be a set, but got {type(ontologies).__name__}"
+                )
+            ALL_VALID_ONTOLOGIES = identifiers_df["ontology"].unique()
+            invalid_ontologies = ontologies.difference(ALL_VALID_ONTOLOGIES)
+            if len(invalid_ontologies) > 0:
+                raise ValueError(
+                    f"The following ontologies are not valid: {', '.join(invalid_ontologies)}.\n"
+                    f"Valid ontologies are {', '.join(ALL_VALID_ONTOLOGIES)}"
+                )
+
+            # fitler to just to identifiers matchign the ontologies of interest
+            identifiers_df = identifiers_df.query("ontology in @ontologies")
+
+        matching_identifiers = identifiers_df.loc[
+            identifiers_df["identifier"].isin(ids)
+        ]
+        entity_subset = entity_table.loc[matching_identifiers[entity_pk].tolist()]
+
+        return entity_subset, matching_identifiers
+
+    def search_by_name(
+        self, name: str, entity_type: str, partial_match: bool = True
+    ) -> pd.DataFrame:
+        """
+        Find entities by exact or partial name match.
+
+        Parameters
+        ----------
+        name : str
+            Name to search for
+        entity_type : str
+            Type of entity to search (e.g., 'species', 'reactions')
+        partial_match : bool, optional
+            Whether to allow partial string matches, by default True
+
+        Returns
+        -------
+        pd.DataFrame
+            Matching entities
+        """
+        entity_table = self.get_table(entity_type, required_attributes={"label"})
+        label_attr = self.schema[entity_type]["label"]
+
+        if partial_match:
+            matches = entity_table.loc[
+                entity_table[label_attr].str.contains(name, case=False)
+            ]
+        else:
+            matches = entity_table.loc[entity_table[label_attr].str.lower() == name]
+        return matches
+
+    def select_species_data(self, species_data_table: str) -> pd.DataFrame:
+        """
+        Select a species data table from the SBML_dfs object.
+
+        Parameters
+        ----------
+        species_data_table : str
+            Name of the species data table to select
+
+        Returns
+        -------
+        pd.DataFrame
+            The selected species data table
+
+        Raises
+        ------
+        ValueError
+            If species_data_table is not found
+        """
+        # Check if species_data_table exists in sbml_dfs.species_data
+        if species_data_table not in self.species_data:
+            raise ValueError(
+                f"species_data_table {species_data_table} not found in sbml_dfs.species_data. "
+                f"Available tables: {self.species_data.keys()}"
             )
 
-        # filter to identifiers which make sense when mapping from ids -> species
-        species_identifiers = self.get_characteristic_species_ids(dogmatic=dogmatic)
+        # Get the species data
+        return self.species_data[species_data_table]
 
-        try:
-            utils.initialize_dir(outdir, overwrite=overwrite)
-        except FileExistsError:
+    def species_status(self, s_id: str) -> pd.DataFrame:
+        """
+        Species Status
+
+        Return all of the reactions a species participates in.
+
+        Parameters:
+        s_id: str
+            A species ID
+
+        Returns:
+        pd.DataFrame, one row per reaction the species participates in
+        with columns:
+        - sc_name: str, name of the compartment the species participates in
+        - stoichiometry: float, stoichiometry of the species in the reaction
+        - r_name: str, name of the reaction
+        - r_formula_str: str, human-readable formula of the reaction
+        """
+
+        if s_id not in self.species.index:
+            raise ValueError(f"{s_id} not found in species table")
+
+        matching_species = self.species.loc[s_id]
+
+        if not isinstance(matching_species, pd.Series):
+            raise ValueError(f"{s_id} did not match a single species")
+
+        # find all rxns species participate in
+        matching_compartmentalized_species = self.compartmentalized_species[
+            self.compartmentalized_species.s_id.isin([s_id])
+        ]
+
+        rxns_participating = self.reaction_species[
+            self.reaction_species.sc_id.isin(matching_compartmentalized_species.index)
+        ]
+
+        # find all participants in these rxns
+        full_rxns_participating = self.reaction_species[
+            self.reaction_species.r_id.isin(rxns_participating[SBML_DFS.R_ID])
+        ].merge(
+            self.compartmentalized_species, left_on=SBML_DFS.SC_ID, right_index=True
+        )
+
+        participating_rids = full_rxns_participating[SBML_DFS.R_ID].unique()
+        reaction_descriptions = self.reaction_summaries(r_ids=participating_rids)
+
+        status = (
+            full_rxns_participating.loc[
+                full_rxns_participating[SBML_DFS.SC_ID].isin(
+                    matching_compartmentalized_species.index.values.tolist()
+                ),
+                [SBML_DFS.SC_NAME, SBML_DFS.STOICHIOMETRY, SBML_DFS.R_ID],
+            ]
+            .merge(reaction_descriptions, left_on=SBML_DFS.R_ID, right_index=True)
+            .reset_index(drop=True)
+            .drop(SBML_DFS.R_ID, axis=1)
+        )
+
+        return status
+
+    def validate(self):
+        """
+        Validate the SBML_dfs structure and relationships.
+
+        Checks:
+        - Schema existence
+        - Required tables presence
+        - Individual table structure
+        - Primary key uniqueness
+        - Foreign key relationships
+        - Optional data table validity
+        - Reaction species validity
+
+        Raises
+        ------
+        ValueError
+            If any validation check fails
+        """
+
+        if not hasattr(self, "schema"):
+            raise ValueError("No schema found")
+
+        required_tables = self._required_entities
+        schema_tables = set(self.schema.keys())
+
+        extra_tables = schema_tables.difference(required_tables)
+        if len(extra_tables) != 0:
+            logger.debug(
+                f"{len(extra_tables)} unexpected tables found: "
+                f"{', '.join(extra_tables)}"
+            )
+
+        missing_tables = required_tables.difference(schema_tables)
+        if len(missing_tables) != 0:
+            raise ValueError(
+                f"Missing {len(missing_tables)} required tables: "
+                f"{', '.join(missing_tables)}"
+            )
+
+        # check individual tables
+        for table in required_tables:
+            self._validate_table(table)
+
+        # check whether pks and fks agree
+        self._check_pk_fk_correspondence()
+
+        # check optional data tables:
+        for k, v in self.species_data.items():
+            try:
+                self._validate_species_data(v)
+            except ValueError as e:
+                raise ValueError(f"species data {k} was invalid.") from e
+
+        for k, v in self.reactions_data.items():
+            try:
+                self._validate_reactions_data(v)
+            except ValueError as e:
+                raise ValueError(f"reactions data {k} was invalid.") from e
+
+        # validate reaction_species sbo_terms and stoi
+        self._validate_reaction_species()
+
+    def validate_and_resolve(self):
+        """
+        Validate and attempt to automatically fix common issues.
+
+        This method iteratively:
+        1. Attempts validation
+        2. If validation fails, tries to resolve the issue
+        3. Repeats until validation passes or issue cannot be resolved
+
+        Raises
+        ------
+        ValueError
+            If validation fails and cannot be automatically resolved
+        """
+
+        current_exception = None
+        validated = False
+
+        while not validated:
+            try:
+                self.validate()
+                validated = True
+            except Exception as e:
+                e_str = str(e)
+                if e_str == current_exception:
+                    logger.warning(
+                        "Automated resolution of an Exception was attempted but failed"
+                    )
+                    raise e
+
+                # try to resolve
+                self._attempt_resolve(e)
+
+    # =============================================================================
+    # PRIVATE METHODS (ALPHABETICAL ORDER)
+    # =============================================================================
+
+    def _attempt_resolve(self, e):
+        str_e = str(e)
+        if str_e == "compartmentalized_species included missing c_id values":
+            logger.warning(str_e)
             logger.warning(
-                f"Directory {outdir} already exists and overwrite is False. "
-                "Files will be added to the existing directory."
+                "Attempting to resolve with infer_uncompartmentalized_species_location()"
             )
-        with open_fs(outdir, writeable=True) as fs:
-            species_identifiers_path = (
-                model_prefix + NAPISTU_STANDARD_OUTPUTS.SPECIES_IDENTIFIERS
+            self.infer_uncompartmentalized_species_location()
+        elif re.search("sbo_terms were not defined", str_e):
+            logger.warning(str_e)
+            logger.warning("Attempting to resolve with infer_sbo_terms()")
+            self.infer_sbo_terms()
+        else:
+            logger.warning(
+                "An error occurred which could not be automatically resolved"
             )
-            with fs.openbin(species_identifiers_path, "w") as f:
-                species_identifiers.drop([SBML_DFS.S_SOURCE], axis=1).to_csv(
-                    f, sep="\t", index=False
+            raise e
+
+    def _check_pk_fk_correspondence(self):
+        """
+        Check whether primary keys and foreign keys agree for all tables in the schema.
+        Raises ValueError if any correspondence fails.
+        """
+
+        pk_df = pd.DataFrame(
+            [{"pk_table": k, "key": v["pk"]} for k, v in self.schema.items()]
+        )
+
+        fk_df = (
+            pd.DataFrame(
+                [
+                    {"fk_table": k, "fk": v["fk"]}
+                    for k, v in self.schema.items()
+                    if "fk" in v.keys()
+                ]
+            )
+            .set_index("fk_table")["fk"]
+            .apply(pd.Series)
+            .reset_index()
+            .melt(id_vars="fk_table")
+            .drop(["variable"], axis=1)
+            .rename(columns={"value": "key"})
+        )
+
+        pk_fk_correspondences = pk_df.merge(fk_df)
+
+        for i in range(0, pk_fk_correspondences.shape[0]):
+            pk_table_keys = set(
+                getattr(self, pk_fk_correspondences["pk_table"][i]).index.tolist()
+            )
+            if None in pk_table_keys:
+                raise ValueError(
+                    f"{pk_fk_correspondences['pk_table'][i]} had "
+                    "missing values in its index"
                 )
 
-            # export jsons
-            species_path = model_prefix + NAPISTU_STANDARD_OUTPUTS.SPECIES
-            reactions_path = model_prefix + NAPISTU_STANDARD_OUTPUTS.REACTIONS
-            reation_species_path = (
-                model_prefix + NAPISTU_STANDARD_OUTPUTS.REACTION_SPECIES
+            fk_table_keys = set(
+                getattr(self, pk_fk_correspondences["fk_table"][i]).loc[
+                    :, pk_fk_correspondences["key"][i]
+                ]
             )
-            compartments_path = model_prefix + NAPISTU_STANDARD_OUTPUTS.COMPARTMENTS
-            compartmentalized_species_path = (
-                model_prefix + NAPISTU_STANDARD_OUTPUTS.COMPARTMENTALIZED_SPECIES
-            )
-            with fs.openbin(species_path, "w") as f:
-                self.species[[SBML_DFS.S_NAME]].to_json(f)
-
-            with fs.openbin(reactions_path, "w") as f:
-                self.reactions[[SBML_DFS.R_NAME]].to_json(f)
-
-            with fs.openbin(reation_species_path, "w") as f:
-                self.reaction_species.to_json(f)
-
-            with fs.openbin(compartments_path, "w") as f:
-                self.compartments[[SBML_DFS.C_NAME]].to_json(f)
-
-            with fs.openbin(compartmentalized_species_path, "w") as f:
-                self.compartmentalized_species.drop(SBML_DFS.SC_SOURCE, axis=1).to_json(
-                    f
+            if None in fk_table_keys:
+                raise ValueError(
+                    f"{pk_fk_correspondences['fk_table'][i]} included "
+                    f"missing {pk_fk_correspondences['key'][i]} values"
                 )
 
-        return None
+            # all foreign keys need to match a primary key
+            extra_fks = fk_table_keys.difference(pk_table_keys)
+            if len(extra_fks) != 0:
+                raise ValueError(
+                    f"{len(extra_fks)} distinct "
+                    f"{pk_fk_correspondences['key'][i]} values were"
+                    f" found in {pk_fk_correspondences['fk_table'][i]} "
+                    f"but missing from {pk_fk_correspondences['pk_table'][i]}."
+                    " All foreign keys must have a matching primary key.\n\n"
+                    f"Extra key are: {', '.join(extra_fks)}"
+                )
 
     def _find_underspecified_reactions_by_scids(
         self, sc_ids: Iterable[str]
@@ -1671,6 +1545,188 @@ class SBML_dfs:
             updated_reaction_species
         )
         return underspecified_reactions
+
+    def _get_unused_cspecies(self) -> set[str]:
+        """Returns a set of compartmentalized species
+        that are not part of any reactions"""
+        sc_ids = set(self.compartmentalized_species.index) - set(
+            self.reaction_species[SBML_DFS.SC_ID]
+        )
+        return sc_ids  # type: ignore
+
+    def _get_unused_species(self) -> set[str]:
+        """Returns a list of species that are not part of any reactions"""
+        s_ids = set(self.species.index) - set(
+            self.compartmentalized_species[SBML_DFS.S_ID]
+        )
+        return s_ids  # type: ignore
+
+    def _remove_compartmentalized_species(self, sc_ids: Iterable[str]):
+        """Removes compartmentalized species from the model
+
+        This should not be directly used by the user, as it can lead to
+        invalid reactions when removing species without a logic to decide
+        if the reaction needs to be removed as well.
+
+        Args:
+            sc_ids (Iterable[str]): the compartmentalized species to remove
+        """
+        # Remove compartmentalized species
+        self.compartmentalized_species = self.compartmentalized_species.drop(
+            index=list(sc_ids)
+        )
+        # remove corresponding reactions_species
+        self.reaction_species = self.reaction_species.query("sc_id not in @sc_ids")
+
+    def _remove_entity_data(self, entity_type: str, label: str) -> None:
+        """
+        Remove data from species_data or reactions_data by table name and label.
+
+        Parameters
+        ----------
+        entity_type : str
+            Name of the table to remove data from ('species' or 'reactions')
+        label : str
+            Label of the data to remove
+
+        Notes
+        -----
+        If the label does not exist, a warning will be logged that includes the existing labels.
+        """
+        if entity_type not in ENTITIES_W_DATA:
+            raise ValueError("table_name must be either 'species' or 'reactions'")
+
+        data_dict = getattr(self, ENTITIES_TO_ENTITY_DATA[entity_type])
+        if label not in data_dict:
+            existing_labels = list(data_dict.keys())
+            logger.warning(
+                f"Label '{label}' not found in {ENTITIES_TO_ENTITY_DATA[entity_type]}. "
+                f"Existing labels: {existing_labels}"
+            )
+            return
+
+        del data_dict[label]
+
+    def _remove_species(self, s_ids: Iterable[str]):
+        """Removes species from the model
+
+        This should not be directly used by the user, as it can lead to
+        invalid reactions when removing species without a logic to decide
+        if the reaction needs to be removed as well.
+
+        This removes the species and corresponding compartmentalized species and
+        reactions_species.
+
+        Args:
+            s_ids (Iterable[str]): the species to remove
+        """
+        sc_ids = self.compartmentalized_species.query("s_id in @s_ids").index.tolist()
+        self._remove_compartmentalized_species(sc_ids)
+        # Remove species
+        self.species = self.species.drop(index=list(s_ids))
+        # remove data
+        for k, data in self.species_data.items():
+            self.species_data[k] = data.drop(index=list(s_ids))
+
+    def _remove_unused_cspecies(self):
+        """Removes compartmentalized species that are no
+        longer part of any reactions"""
+        sc_ids = self._get_unused_cspecies()
+        self._remove_compartmentalized_species(sc_ids)
+
+    def _remove_unused_species(self):
+        """Removes species that are no longer part of any
+        compartmentalized species"""
+        s_ids = self._get_unused_species()
+        self._remove_species(s_ids)
+
+    def _validate_r_ids(self, r_ids: Optional[Union[str, list[str]]]) -> list[str]:
+
+        if isinstance(r_ids, str):
+            r_ids = [r_ids]
+
+        if r_ids is None:
+            return self.reactions.index.tolist()
+        else:
+            if not all(r_id in self.reactions.index for r_id in r_ids):
+                raise ValueError(f"Reaction IDs {r_ids} not found in reactions table")
+
+            return r_ids
+
+    def _validate_reaction_species(self):
+        if not all(self.reaction_species[SBML_DFS.STOICHIOMETRY].notnull()):
+            raise ValueError(
+                "All reaction_species[SBML_DFS.STOICHIOMETRY] must be not null"
+            )
+
+        # test for null SBO terms
+        n_null_sbo_terms = sum(self.reaction_species[SBML_DFS.SBO_TERM].isnull())
+        if n_null_sbo_terms != 0:
+            raise ValueError(
+                f"{n_null_sbo_terms} sbo_terms were None; all terms should be defined"
+            )
+
+        # find invalid SBO terms
+        sbo_counts = self.reaction_species.value_counts(SBML_DFS.SBO_TERM)
+        invalid_sbo_term_counts = sbo_counts[
+            ~sbo_counts.index.isin(MINI_SBO_TO_NAME.keys())
+        ]
+
+        if invalid_sbo_term_counts.shape[0] != 0:
+            invalid_sbo_counts_str = ", ".join(
+                [f"{k} (N={v})" for k, v in invalid_sbo_term_counts.to_dict().items()]
+            )
+            raise ValueError(
+                f"{invalid_sbo_term_counts.shape[0]} sbo_terms were not "
+                f"defined {invalid_sbo_counts_str}"
+            )
+
+    def _validate_reactions_data(self, reactions_data_table: pd.DataFrame):
+        """Validates reactions data attribute
+
+        Args:
+            reactions_data_table (pd.DataFrame): a reactions data table
+
+        Raises:
+            ValueError: r_id not index name
+            ValueError: r_id index contains duplicates
+            ValueError: r_id not in reactions table
+        """
+        sbml_dfs_utils._validate_matching_data(reactions_data_table, self.reactions)
+
+    def _validate_species_data(self, species_data_table: pd.DataFrame):
+        """Validates species data attribute
+
+        Args:
+            species_data_table (pd.DataFrame): a species data table
+
+        Raises:
+            ValueError: s_id not index name
+            ValueError: s_id index contains duplicates
+            ValueError: s_id not in species table
+        """
+        sbml_dfs_utils._validate_matching_data(species_data_table, self.species)
+
+    def _validate_table(self, table_name: str) -> None:
+        """
+        Validate a table in this SBML_dfs object against its schema.
+
+        This is an internal method that validates a table that is part of this SBML_dfs
+        object against the schema stored in self.schema.
+
+        Parameters
+        ----------
+        table : str
+            Name of the table to validate
+
+        Raises
+        ------
+        ValueError
+            If the table does not conform to its schema
+        """
+        table_data = getattr(self, table_name)
+
+        sbml_dfs_utils.validate_sbml_dfs_table(table_data, table_name)
 
 
 def sbml_dfs_from_edgelist(

--- a/src/tests/test_consensus.py
+++ b/src/tests/test_consensus.py
@@ -7,6 +7,7 @@ import pytest
 from napistu import consensus
 from napistu import indices
 from napistu import source
+from napistu import sbml_dfs_core
 from napistu.ingestion import sbml
 from napistu.modify import pathwayannot
 from napistu.constants import SBML_DFS, SBML_DFS_SCHEMA
@@ -250,15 +251,53 @@ def test_consensus_ontology_check():
 def test_report_consensus_merges_reactions(tmp_path):
     # Create two minimal SBML_dfs objects with a single reaction each, same r_id
     r_id = "R00000001"
-    reactions = pd.DataFrame({SBML_DFS.R_NAME: ["rxn1"], SBML_DFS.R_IDENTIFIERS: [None], SBML_DFS.R_SOURCE: [None], SBML_DFS.R_ISREVERSIBLE: [False]}, index=[r_id])
+    reactions = pd.DataFrame(
+        {
+            SBML_DFS.R_NAME: ["rxn1"],
+            SBML_DFS.R_IDENTIFIERS: [None],
+            SBML_DFS.R_SOURCE: [None],
+            SBML_DFS.R_ISREVERSIBLE: [False],
+        },
+        index=[r_id],
+    )
     reactions.index.name = SBML_DFS.R_ID
-    reaction_species = pd.DataFrame({SBML_DFS.R_ID: [r_id], SBML_DFS.SC_ID: ["SC0001"], SBML_DFS.STOICHIOMETRY: [1], SBML_DFS.SBO_TERM: ["SBO:0000459"]}, index=["RSC0001"])
+    reaction_species = pd.DataFrame(
+        {
+            SBML_DFS.R_ID: [r_id],
+            SBML_DFS.SC_ID: ["SC0001"],
+            SBML_DFS.STOICHIOMETRY: [1],
+            SBML_DFS.SBO_TERM: ["SBO:0000459"],
+        },
+        index=["RSC0001"],
+    )
     reaction_species.index.name = SBML_DFS.RSC_ID
-    compartmentalized_species = pd.DataFrame({SBML_DFS.SC_NAME: ["A [cytosol]"], SBML_DFS.S_ID: ["S0001"], SBML_DFS.C_ID: ["C0001"], SBML_DFS.SC_SOURCE: [None]}, index=["SC0001"])
+    compartmentalized_species = pd.DataFrame(
+        {
+            SBML_DFS.SC_NAME: ["A [cytosol]"],
+            SBML_DFS.S_ID: ["S0001"],
+            SBML_DFS.C_ID: ["C0001"],
+            SBML_DFS.SC_SOURCE: [None],
+        },
+        index=["SC0001"],
+    )
     compartmentalized_species.index.name = SBML_DFS.SC_ID
-    species = pd.DataFrame({SBML_DFS.S_NAME: ["A"], SBML_DFS.S_IDENTIFIERS: [None], SBML_DFS.S_SOURCE: [None]}, index=["S0001"])
+    species = pd.DataFrame(
+        {
+            SBML_DFS.S_NAME: ["A"],
+            SBML_DFS.S_IDENTIFIERS: [None],
+            SBML_DFS.S_SOURCE: [None],
+        },
+        index=["S0001"],
+    )
     species.index.name = SBML_DFS.S_ID
-    compartments = pd.DataFrame({SBML_DFS.C_NAME: ["cytosol"], SBML_DFS.C_IDENTIFIERS: [None], SBML_DFS.C_SOURCE: [None]}, index=["C0001"])
+    compartments = pd.DataFrame(
+        {
+            SBML_DFS.C_NAME: ["cytosol"],
+            SBML_DFS.C_IDENTIFIERS: [None],
+            SBML_DFS.C_SOURCE: [None],
+        },
+        index=["C0001"],
+    )
     compartments.index.name = SBML_DFS.C_ID
     sbml_dict = {
         SBML_DFS.COMPARTMENTS: compartments,
@@ -267,18 +306,30 @@ def test_report_consensus_merges_reactions(tmp_path):
         SBML_DFS.REACTIONS: reactions,
         SBML_DFS.REACTION_SPECIES: reaction_species,
     }
-    sbml1 = sbml_dfs_core.SBML_dfs(sbml_dict, validate=False)
-    sbml2 = sbml_dfs_core.SBML_dfs(sbml_dict, validate=False)
+    sbml1 = sbml_dfs_core.SBML_dfs(sbml_dict, validate=False, resolve=False)
+    sbml2 = sbml_dfs_core.SBML_dfs(sbml_dict, validate=False, resolve=False)
     sbml_dfs_dict = {"mod1": sbml1, "mod2": sbml2}
 
     # Create a lookup_table that merges both reactions into a new_id
-    lookup_table = pd.Series(["merged_rid", "merged_rid"], index=pd.MultiIndex.from_tuples([("mod1", r_id), ("mod2", r_id)], names=["model", "r_id"]))
-
+    lookup_table = pd.DataFrame(
+        {
+            "model": ["mod1", "mod2"],
+            "r_id": [r_id, r_id],
+            "new_id": ["merged_rid", "merged_rid"],
+        }
+    )
     # Use the reactions schema
     table_schema = SBML_DFS_SCHEMA.SCHEMA[SBML_DFS.REACTIONS]
 
     # Call the function and check that it runs and the merge_labels are as expected
-    consensus.report_consensus_merges(lookup_table, table_schema, sbml_dfs_dict=sbml_dfs_dict, n_example_merges=1)
+    consensus.report_consensus_merges(
+        lookup_table.set_index(["model", "r_id"])[
+            "new_id"
+        ],  # this is a Series with name 'new_id'
+        table_schema,
+        sbml_dfs_dict=sbml_dfs_dict,
+        n_example_merges=1,
+    )
     # No assertion: this is a smoke test to ensure the Series output is handled without error
 
 

--- a/src/tests/test_consensus.py
+++ b/src/tests/test_consensus.py
@@ -9,6 +9,7 @@ from napistu import indices
 from napistu import source
 from napistu.ingestion import sbml
 from napistu.modify import pathwayannot
+from napistu.constants import SBML_DFS, SBML_DFS_SCHEMA
 
 test_path = os.path.abspath(os.path.join(__file__, os.pardir))
 test_data = os.path.join(test_path, "test_data")
@@ -246,6 +247,41 @@ def test_consensus_ontology_check():
     assert post_shared_onto_sp_set == {"chebi", "reactome", "uniprot"}
 
 
+def test_report_consensus_merges_reactions(tmp_path):
+    # Create two minimal SBML_dfs objects with a single reaction each, same r_id
+    r_id = "R00000001"
+    reactions = pd.DataFrame({SBML_DFS.R_NAME: ["rxn1"], SBML_DFS.R_IDENTIFIERS: [None], SBML_DFS.R_SOURCE: [None], SBML_DFS.R_ISREVERSIBLE: [False]}, index=[r_id])
+    reactions.index.name = SBML_DFS.R_ID
+    reaction_species = pd.DataFrame({SBML_DFS.R_ID: [r_id], SBML_DFS.SC_ID: ["SC0001"], SBML_DFS.STOICHIOMETRY: [1], SBML_DFS.SBO_TERM: ["SBO:0000459"]}, index=["RSC0001"])
+    reaction_species.index.name = SBML_DFS.RSC_ID
+    compartmentalized_species = pd.DataFrame({SBML_DFS.SC_NAME: ["A [cytosol]"], SBML_DFS.S_ID: ["S0001"], SBML_DFS.C_ID: ["C0001"], SBML_DFS.SC_SOURCE: [None]}, index=["SC0001"])
+    compartmentalized_species.index.name = SBML_DFS.SC_ID
+    species = pd.DataFrame({SBML_DFS.S_NAME: ["A"], SBML_DFS.S_IDENTIFIERS: [None], SBML_DFS.S_SOURCE: [None]}, index=["S0001"])
+    species.index.name = SBML_DFS.S_ID
+    compartments = pd.DataFrame({SBML_DFS.C_NAME: ["cytosol"], SBML_DFS.C_IDENTIFIERS: [None], SBML_DFS.C_SOURCE: [None]}, index=["C0001"])
+    compartments.index.name = SBML_DFS.C_ID
+    sbml_dict = {
+        SBML_DFS.COMPARTMENTS: compartments,
+        SBML_DFS.SPECIES: species,
+        SBML_DFS.COMPARTMENTALIZED_SPECIES: compartmentalized_species,
+        SBML_DFS.REACTIONS: reactions,
+        SBML_DFS.REACTION_SPECIES: reaction_species,
+    }
+    sbml1 = sbml_dfs_core.SBML_dfs(sbml_dict, validate=False)
+    sbml2 = sbml_dfs_core.SBML_dfs(sbml_dict, validate=False)
+    sbml_dfs_dict = {"mod1": sbml1, "mod2": sbml2}
+
+    # Create a lookup_table that merges both reactions into a new_id
+    lookup_table = pd.Series(["merged_rid", "merged_rid"], index=pd.MultiIndex.from_tuples([("mod1", r_id), ("mod2", r_id)], names=["model", "r_id"]))
+
+    # Use the reactions schema
+    table_schema = SBML_DFS_SCHEMA.SCHEMA[SBML_DFS.REACTIONS]
+
+    # Call the function and check that it runs and the merge_labels are as expected
+    consensus.report_consensus_merges(lookup_table, table_schema, sbml_dfs_dict=sbml_dfs_dict, n_example_merges=1)
+    # No assertion: this is a smoke test to ensure the Series output is handled without error
+
+
 ################################################
 # __main__
 ################################################
@@ -256,3 +292,4 @@ if __name__ == "__main__":
     test_source_tracking()
     test_passing_entity_data()
     test_consensus_ontology_check()
+    test_report_consensus_merges_reactions()

--- a/src/tests/test_context_filtering.py
+++ b/src/tests/test_context_filtering.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import pytest
 import pandas as pd
-from napistu import sbml_dfs_core
+from napistu import sbml_dfs_utils
 from napistu.constants import SBML_DFS
 from napistu.context.filtering import (
     filter_species_by_attribute,
@@ -208,7 +208,7 @@ def test_filter_reactions_with_disconnected_cspecies(sbml_dfs):
     first_reactions = list(sbml_dfs.reactions.index[:5])
 
     # 2. Find defining species in these reactions
-    reaction_species = sbml_dfs_core.add_sbo_role(sbml_dfs.reaction_species)
+    reaction_species = sbml_dfs_utils.add_sbo_role(sbml_dfs.reaction_species)
     defining_species = (
         reaction_species[reaction_species[SBML_DFS.R_ID].isin(first_reactions)]
         .query("sbo_role == 'DEFINING'")

--- a/src/tests/test_ontologies_genodexito.py
+++ b/src/tests/test_ontologies_genodexito.py
@@ -1,4 +1,6 @@
 import pandas as pd
+from .conftest import skip_on_timeout
+
 from napistu.ontologies.genodexito import Genodexito
 from napistu.ontologies.constants import (
     GENODEXITO_DEFS,
@@ -7,6 +9,7 @@ from napistu.ontologies.constants import (
 )
 
 
+@skip_on_timeout(5)
 def test_genodexito_mapping_operations():
     """Test Genodexito mapping table creation and operations."""
     # Initialize with test mode and Python method to avoid R dependencies

--- a/src/tests/test_ontologies_mygene.py
+++ b/src/tests/test_ontologies_mygene.py
@@ -1,7 +1,9 @@
+from .conftest import skip_on_timeout
 from napistu.ontologies.mygene import create_python_mapping_tables
 from napistu.ontologies.constants import INTERCONVERTIBLE_GENIC_ONTOLOGIES
 
 
+@skip_on_timeout(5)
 def test_create_python_mapping_tables_yeast():
     """Test create_python_mapping_tables with yeast species."""
     # Test with a subset of mappings to keep test runtime reasonable

--- a/src/tests/test_sbml_dfs_core.py
+++ b/src/tests/test_sbml_dfs_core.py
@@ -9,7 +9,6 @@ from napistu import sbml_dfs_core
 from napistu.source import Source
 from napistu.ingestion import sbml
 from napistu.modify import pathwayannot
-from napistu.sbml_dfs_utils import _stub_ids
 
 from napistu import identifiers as napistu_identifiers
 from napistu.constants import (
@@ -29,8 +28,8 @@ def test_data():
     # Test compartments
     compartments_df = pd.DataFrame(
         [
-            {"c_name": "nucleus", "c_Identifiers": _stub_ids([])},
-            {"c_name": "cytoplasm", "c_Identifiers": _stub_ids([])},
+            {"c_name": "nucleus", "c_Identifiers": None},
+            {"c_name": "cytoplasm", "c_Identifiers": None},
         ]
     )
 
@@ -39,13 +38,13 @@ def test_data():
         [
             {
                 "s_name": "TP53",
-                "s_Identifiers": _stub_ids([]),
+                "s_Identifiers": None,
                 "gene_type": "tumor_suppressor",
             },
-            {"s_name": "MDM2", "s_Identifiers": _stub_ids([]), "gene_type": "oncogene"},
+            {"s_name": "MDM2", "s_Identifiers": None, "gene_type": "oncogene"},
             {
                 "s_name": "CDKN1A",
-                "s_Identifiers": _stub_ids([]),
+                "s_Identifiers": None,
                 "gene_type": "cell_cycle",
             },
         ]
@@ -61,7 +60,7 @@ def test_data():
                 "downstream_compartment": "nucleus",
                 "r_name": "TP53_activates_CDKN1A",
                 "sbo_term": "SBO:0000459",
-                "r_Identifiers": _stub_ids([]),
+                "r_Identifiers": None,
                 "r_isreversible": False,
                 "confidence": 0.95,
             },
@@ -72,7 +71,7 @@ def test_data():
                 "downstream_compartment": "nucleus",
                 "r_name": "MDM2_inhibits_TP53",
                 "sbo_term": "SBO:0000020",
-                "r_Identifiers": _stub_ids([]),
+                "r_Identifiers": None,
                 "r_isreversible": False,
                 "confidence": 0.87,
             },
@@ -282,17 +281,6 @@ def test_read_sbml_with_invalid_ids():
     # invalid identifiers still create a valid sbml_dfs
     sbml_w_bad_ids = sbml.SBML(sbml_w_bad_ids_path)
     assert isinstance(sbml_dfs_core.SBML_dfs(sbml_w_bad_ids), sbml_dfs_core.SBML_dfs)
-
-
-def test_stubbed_compartment():
-    compartment = sbml_dfs_core._stub_compartments()
-
-    assert compartment["c_Identifiers"].iloc[0].ids[0] == {
-        "ontology": "go",
-        "identifier": "GO:0005575",
-        "url": "https://www.ebi.ac.uk/QuickGO/term/GO:0005575",
-        "bqb": "BQB_IS",
-    }
 
 
 def test_get_table(sbml_dfs):
@@ -535,12 +523,12 @@ def test_get_characteristic_species_ids():
         "reactions": reactions,
         "reaction_species": reaction_species,
     }
-    sbml = SBML_dfs(sbml_dict, validate=False, resolve=False)
+    sbml_dfs = SBML_dfs(sbml_dict, validate=False, resolve=False)
 
     # Test dogmatic case (default)
     expected_bqbs = BQB_DEFINING_ATTRS + [BQB.HAS_PART]  # noqa: F841
-    with patch.object(sbml, "get_identifiers", return_value=mock_species_ids):
-        dogmatic_result = sbml.get_characteristic_species_ids()
+    with patch.object(sbml_dfs, "get_identifiers", return_value=mock_species_ids):
+        dogmatic_result = sbml_dfs.get_characteristic_species_ids()
         expected_dogmatic = mock_species_ids.query("bqb in @expected_bqbs")
         pd.testing.assert_frame_equal(
             dogmatic_result, expected_dogmatic, check_like=True
@@ -548,8 +536,8 @@ def test_get_characteristic_species_ids():
 
     # Test non-dogmatic case
     expected_bqbs = BQB_DEFINING_ATTRS_LOOSE + [BQB.HAS_PART]  # noqa: F841
-    with patch.object(sbml, "get_identifiers", return_value=mock_species_ids):
-        non_dogmatic_result = sbml.get_characteristic_species_ids(dogmatic=False)
+    with patch.object(sbml_dfs, "get_identifiers", return_value=mock_species_ids):
+        non_dogmatic_result = sbml_dfs.get_characteristic_species_ids(dogmatic=False)
         expected_non_dogmatic = mock_species_ids.query("bqb in @expected_bqbs")
         pd.testing.assert_frame_equal(
             non_dogmatic_result, expected_non_dogmatic, check_like=True

--- a/src/tests/test_sbml_dfs_core.py
+++ b/src/tests/test_sbml_dfs_core.py
@@ -367,9 +367,19 @@ def test_species_status(sbml_dfs):
     assert select_species.shape[0] == 1
 
     status = sbml_dfs_core.species_status(select_species.index[0], sbml_dfs)
+
+    # expected columns
+    expected_columns = [
+        SBML_DFS.SC_NAME,
+        SBML_DFS.STOICHIOMETRY,
+        SBML_DFS.R_NAME,
+        "r_formula_str",
+    ]
+    assert all(col in status.columns for col in expected_columns)
+
     assert (
         status["r_formula_str"][0]
-        == "4.0 H+ + OxyHbA + 4.0 CO2 -> 4.0 O2 + Protonated Carbamino DeoxyHbA [cytosol]"
+        == "cytosol: 4.0 CO2 + 4.0 H+ + OxyHbA -> 4.0 O2 + Protonated Carbamino DeoxyHbA"
     )
 
 

--- a/src/tests/test_sbml_dfs_core.py
+++ b/src/tests/test_sbml_dfs_core.py
@@ -274,26 +274,6 @@ def test_sbml_dfs_remove_reactions_check_species(sbml_dfs):
     sbml_dfs.validate()
 
 
-def test_formula(sbml_dfs):
-    # create a formula string
-
-    an_r_id = sbml_dfs.reactions.index[0]
-
-    reaction_species_df = sbml_dfs.reaction_species[
-        sbml_dfs.reaction_species["r_id"] == an_r_id
-    ].merge(sbml_dfs.compartmentalized_species, left_on="sc_id", right_index=True)
-
-    formula_str = sbml_dfs_core.construct_formula_string(
-        reaction_species_df, sbml_dfs.reactions, name_var="sc_name"
-    )
-
-    assert isinstance(formula_str, str)
-    assert (
-        formula_str
-        == "CO2 [extracellular region] -> CO2 [cytosol] ---- modifiers: AQP1 tetramer [plasma membrane]]"
-    )
-
-
 def test_read_sbml_with_invalid_ids():
     SBML_W_BAD_IDS = "R-HSA-166658.sbml"
     test_path = os.path.abspath(os.path.join(__file__, os.pardir))
@@ -366,7 +346,7 @@ def test_species_status(sbml_dfs):
     select_species = species[species["s_name"] == "OxyHbA"]
     assert select_species.shape[0] == 1
 
-    status = sbml_dfs_core.species_status(select_species.index[0], sbml_dfs)
+    status = sbml_dfs.species_status(select_species.index[0])
 
     # expected columns
     expected_columns = [

--- a/src/tests/test_sbml_dfs_utils.py
+++ b/src/tests/test_sbml_dfs_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from napistu import sbml_dfs_core
 from napistu import sbml_dfs_utils
 from napistu.constants import (
     BQB,
@@ -147,7 +146,7 @@ def test_find_underspecified_reactions():
         f"rsc_{i}" for i in range(len(reaction_w_regulators))
     ]
     reaction_w_regulators.set_index(SBML_DFS.RSC_ID, inplace=True)
-    reaction_w_regulators = sbml_dfs_core.add_sbo_role(reaction_w_regulators)
+    reaction_w_regulators = sbml_dfs_utils.add_sbo_role(reaction_w_regulators)
 
     reaction_w_interactors = pd.DataFrame(
         {
@@ -160,7 +159,7 @@ def test_find_underspecified_reactions():
         f"rsc_{i}" for i in range(len(reaction_w_interactors))
     ]
     reaction_w_interactors.set_index(SBML_DFS.RSC_ID, inplace=True)
-    reaction_w_interactors = sbml_dfs_core.add_sbo_role(reaction_w_interactors)
+    reaction_w_interactors = sbml_dfs_utils.add_sbo_role(reaction_w_interactors)
 
     working_reactions = reaction_w_regulators.copy()
     working_reactions["new"] = True
@@ -209,3 +208,14 @@ def test_find_underspecified_reactions():
     working_reactions
     result = sbml_dfs_utils._find_underspecified_reactions(working_reactions)
     assert result == {"baz"}
+
+
+def test_stubbed_compartment():
+    compartment = sbml_dfs_utils.stub_compartments()
+
+    assert compartment["c_Identifiers"].iloc[0].ids[0] == {
+        "ontology": "go",
+        "identifier": "GO:0005575",
+        "url": "https://www.ebi.ac.uk/QuickGO/term/GO:0005575",
+        "bqb": "BQB_IS",
+    }

--- a/src/tests/test_sbml_dfs_utils.py
+++ b/src/tests/test_sbml_dfs_utils.py
@@ -61,3 +61,23 @@ def test_get_characteristic_species_ids():
     pd.testing.assert_frame_equal(
         non_dogmatic_result, expected_non_dogmatic, check_like=True
     )
+
+
+def test_formula(sbml_dfs):
+    # create a formula string
+
+    an_r_id = sbml_dfs.reactions.index[0]
+
+    reaction_species_df = sbml_dfs.reaction_species[
+        sbml_dfs.reaction_species["r_id"] == an_r_id
+    ].merge(sbml_dfs.compartmentalized_species, left_on="sc_id", right_index=True)
+
+    formula_str = sbml_dfs_utils.construct_formula_string(
+        reaction_species_df, sbml_dfs.reactions, name_var="sc_name"
+    )
+
+    assert isinstance(formula_str, str)
+    assert (
+        formula_str
+        == "CO2 [extracellular region] -> CO2 [cytosol] ---- modifiers: AQP1 tetramer [plasma membrane]]"
+    )

--- a/src/tests/test_sbml_dfs_utils.py
+++ b/src/tests/test_sbml_dfs_utils.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pandas as pd
 
 from napistu import sbml_dfs_utils
-from napistu.constants import BQB, BQB_DEFINING_ATTRS, BQB_DEFINING_ATTRS_LOOSE
+from napistu.constants import (
+    BQB,
+    BQB_DEFINING_ATTRS,
+    BQB_DEFINING_ATTRS_LOOSE,
+    SBML_DFS,
+    IDENTIFIERS,
+)
 
 
 def test_id_formatter():
@@ -17,50 +23,85 @@ def test_id_formatter():
     assert list(input_vals) == inv_ids
 
 
-def test_get_characteristic_species_ids():
-    """
-    Test get_characteristic_species_ids function with both dogmatic and non-dogmatic cases.
-    """
-    # Create mock species identifiers data
-    mock_species_ids = pd.DataFrame(
-        {
-            "s_id": ["s1", "s2", "s3", "s4", "s5"],
-            "identifier": ["P12345", "CHEBI:15377", "GO:12345", "P67890", "P67890"],
-            "ontology": ["uniprot", "chebi", "go", "uniprot", "chebi"],
-            "bqb": [
-                "BQB_IS",
-                "BQB_IS",
-                "BQB_HAS_PART",
-                "BQB_HAS_VERSION",
-                "BQB_ENCODES",
-            ],
-        }
+def test_filter_to_characteristic_species_ids():
+
+    species_ids_dict = {
+        SBML_DFS.S_ID: ["large_complex"] * 6
+        + ["small_complex"] * 2
+        + ["proteinA", "proteinB"]
+        + ["proteinC"] * 3
+        + [
+            "promiscuous_complexA",
+            "promiscuous_complexB",
+            "promiscuous_complexC",
+            "promiscuous_complexD",
+            "promiscuous_complexE",
+        ],
+        IDENTIFIERS.ONTOLOGY: ["complexportal"]
+        + ["HGNC"] * 7
+        + ["GO"] * 2
+        + ["ENSG", "ENSP", "pubmed"]
+        + ["HGNC"] * 5,
+        IDENTIFIERS.IDENTIFIER: [
+            "CPX-BIG",
+            "mem1",
+            "mem2",
+            "mem3",
+            "mem4",
+            "mem5",
+            "part1",
+            "part2",
+            "GO:1",
+            "GO:2",
+            "dna_seq",
+            "protein_seq",
+            "my_cool_pub",
+        ]
+        + ["promiscuous_complex"] * 5,
+        IDENTIFIERS.BQB: [BQB.IS]
+        + [BQB.HAS_PART] * 7
+        + [BQB.IS] * 2
+        + [
+            # these are retained if BQB_DEFINING_ATTRS_LOOSE is used
+            BQB.ENCODES,
+            BQB.IS_ENCODED_BY,
+            # this should always be removed
+            BQB.IS_DESCRIBED_BY,
+        ]
+        + [BQB.HAS_PART] * 5,
+    }
+
+    species_ids = pd.DataFrame(species_ids_dict)
+
+    characteristic_ids_narrow = sbml_dfs_utils.filter_to_characteristic_species_ids(
+        species_ids,
+        defining_biological_qualifiers=BQB_DEFINING_ATTRS,
+        max_complex_size=4,
+        max_promiscuity=4,
     )
 
-    # Create mock SBML_dfs object
-    class MockSBML_dfs:
-        def get_identifiers(self, entity_type):
-            return mock_species_ids
+    EXPECTED_IDS = ["CPX-BIG", "GO:1", "GO:2", "part1", "part2"]
+    assert characteristic_ids_narrow[IDENTIFIERS.IDENTIFIER].tolist() == EXPECTED_IDS
 
-    mock_sbml = MockSBML_dfs()
-
-    # Test dogmatic case (default)
-    expected_bqbs = BQB_DEFINING_ATTRS + [BQB.HAS_PART]  # noqa: F841
-    dogmatic_result = sbml_dfs_utils.get_characteristic_species_ids(mock_sbml)
-    expected_dogmatic = mock_species_ids.query("bqb in @expected_bqbs")
-
-    pd.testing.assert_frame_equal(dogmatic_result, expected_dogmatic, check_like=True)
-
-    # Test non-dogmatic case
-    expected_bqbs = BQB_DEFINING_ATTRS_LOOSE + [BQB.HAS_PART]  # noqa: F841
-    non_dogmatic_result = sbml_dfs_utils.get_characteristic_species_ids(
-        mock_sbml, dogmatic=False
+    characteristic_ids_loose = sbml_dfs_utils.filter_to_characteristic_species_ids(
+        species_ids,
+        # include encodes and is_encoded_by as equivalent to is
+        defining_biological_qualifiers=BQB_DEFINING_ATTRS_LOOSE,
+        max_complex_size=4,
+        # expand promiscuity to default value
+        max_promiscuity=20,
     )
-    expected_non_dogmatic = mock_species_ids.query("bqb in @expected_bqbs")
 
-    pd.testing.assert_frame_equal(
-        non_dogmatic_result, expected_non_dogmatic, check_like=True
-    )
+    EXPECTED_IDS = [
+        "CPX-BIG",
+        "GO:1",
+        "GO:2",
+        "dna_seq",
+        "protein_seq",
+        "part1",
+        "part2",
+    ] + ["promiscuous_complex"] * 5
+    assert characteristic_ids_loose[IDENTIFIERS.IDENTIFIER].tolist() == EXPECTED_IDS
 
 
 def test_formula(sbml_dfs):


### PR DESCRIPTION
- `sbml_dfs_core` <> `sbml_dfs_utils` refactor
    - Refactored `sbml_dfs_core.py` so that functions which use `sbml_dfs` are methods instead.
    - Moved most fuctions which don't directly depend on SBML_dfs into sbml_dfs_utils.py
    - Reordered methods and functions so they are alphabetical and public methods precede private ones.
    - Closes #109 
- removed defunct `reaction_summary()` function. Changed the existing `reaction_summaries` function reaction_formulas. Created a new `reaction_summaries` function which is a drop-in replacement for  `reaction_summary`. Closes #93 
- Refactored a utility function out of the validate method which makes the main function much more clear. Closes #3
- In CLI - renamed load -> ingestion. Closes #16
- Pinned fastmcp version to <2.9 since there was a breaking change
- Added a skip_on_timeout() fixture to conftest to flag tests which can be flaky due to external services or internet connectivity.