### PR TITLE
Issue 127 - extended null distributions for network propagation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.4.1
+version = 0.4.2
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/gcs/constants.py
+++ b/src/napistu/gcs/constants.py
@@ -7,7 +7,7 @@ GCS_SUBASSET_NAMES = SimpleNamespace(
     SBML_DFS="sbml_dfs",
     NAPISTU_GRAPH="napistu_graph",
     SPECIES_IDENTIFIERS="species_identifiers",
-    REGULATORY_DISTANCES="regulatory_distances",
+    PRECOMPUTED_DISTANCES="precomputed_distances",
 )
 
 
@@ -15,7 +15,7 @@ GCS_FILETYPES = SimpleNamespace(
     SBML_DFS="sbml_dfs.pkl",
     NAPISTU_GRAPH="napistu_graph.pkl",
     SPECIES_IDENTIFIERS="species_identifiers.tsv",
-    REGULATORY_DISTANCES="regulatory_distances.parquet",
+    PRECOMPUTED_DISTANCES="precomputed_distances.parquet",
 )
 
 
@@ -29,7 +29,7 @@ GCS_ASSETS = SimpleNamespace(
                 GCS_SUBASSET_NAMES.SBML_DFS: GCS_FILETYPES.SBML_DFS,
                 GCS_SUBASSET_NAMES.NAPISTU_GRAPH: GCS_FILETYPES.NAPISTU_GRAPH,
                 GCS_SUBASSET_NAMES.SPECIES_IDENTIFIERS: GCS_FILETYPES.SPECIES_IDENTIFIERS,
-                GCS_SUBASSET_NAMES.REGULATORY_DISTANCES: GCS_FILETYPES.REGULATORY_DISTANCES,
+                GCS_SUBASSET_NAMES.PRECOMPUTED_DISTANCES: GCS_FILETYPES.PRECOMPUTED_DISTANCES,
             },
             "public_url": "https://storage.googleapis.com/shackett-napistu-public/test_pathway.tar.gz",
         },
@@ -48,9 +48,9 @@ GCS_ASSETS = SimpleNamespace(
                 GCS_SUBASSET_NAMES.SBML_DFS: GCS_FILETYPES.SBML_DFS,
                 GCS_SUBASSET_NAMES.NAPISTU_GRAPH: GCS_FILETYPES.NAPISTU_GRAPH,
                 GCS_SUBASSET_NAMES.SPECIES_IDENTIFIERS: GCS_FILETYPES.SPECIES_IDENTIFIERS,
-                GCS_SUBASSET_NAMES.REGULATORY_DISTANCES: GCS_FILETYPES.REGULATORY_DISTANCES,
+                GCS_SUBASSET_NAMES.PRECOMPUTED_DISTANCES: GCS_FILETYPES.PRECOMPUTED_DISTANCES,
             },
-            "public_url": "https://storage.googleapis.com/calico-cpr-public/human_consensus_w_distances.tar.gz",
+            "public_url": "https://storage.googleapis.com/shackett-napistu-public/human_consensus_w_distances.tar.gz",
         },
         "reactome_members": {
             "file": "external_pathways/external_pathways_reactome_neo4j_members.csv",

--- a/src/napistu/network/constants.py
+++ b/src/napistu/network/constants.py
@@ -13,7 +13,7 @@ NAPISTU_GRAPH_DIRECTEDNESS = SimpleNamespace(
     DIRECTED="directed", UNDIRECTED="undirected"
 )
 
-NAPISTU_GRAPH_NODES = SimpleNamespace(NAME="name")
+NAPISTU_GRAPH_VERTICES = SimpleNamespace(NAME="name")
 
 NAPISTU_GRAPH_EDGES = SimpleNamespace(
     DIRECTED="directed",
@@ -198,3 +198,18 @@ SCORE_CALIBRATION_POINTS_DICT = {
 }
 
 SOURCE_VARS_DICT = {"string_wt": 10}
+
+# network propagation
+
+NET_PROPAGATION_DEFS = SimpleNamespace(PERSONALIZED_PAGERANK="personalized_pagerank")
+
+VALID_NET_PROPAGATION_METHODS = NET_PROPAGATION_DEFS.__dict__.values()
+
+NULL_GENERATOR_DEFS = SimpleNamespace(
+    UNIFORM="uniform",
+    GAUSSIAN="gaussian",
+    NODE_PERMUTATION="node_permutation",
+    EDGE_PERMUTATION="edge_permutation",
+)
+
+VALID_NULL_GENERATORS = NULL_GENERATOR_DEFS.__dict__.values()

--- a/src/napistu/network/constants.py
+++ b/src/napistu/network/constants.py
@@ -201,19 +201,9 @@ SCORE_CALIBRATION_POINTS_DICT = {
 SOURCE_VARS_DICT = {"string_wt": 10}
 
 # network propagation
-
 NET_PROPAGATION_DEFS = SimpleNamespace(PERSONALIZED_PAGERANK="personalized_pagerank")
 
-VALID_NET_PROPAGATION_METHODS = NET_PROPAGATION_DEFS.__dict__.values()
-
-NET_PROPAGATION_ENGINE_DEFS = SimpleNamespace(NON_NEGATIVE="non-negative")
-
-NET_PROPAGATION_ENGINE_REQS = {
-    NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK: {
-        NET_PROPAGATION_ENGINE_DEFS.NON_NEGATIVE: True
-    }
-}
-
+# null distributions
 NULL_STRATEGIES = SimpleNamespace(
     UNIFORM="uniform",
     PARAMETRIC="parametric",

--- a/src/napistu/network/constants.py
+++ b/src/napistu/network/constants.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+
 from napistu.constants import SBML_DFS
 from napistu.constants import SBOTERM_NAMES
 
@@ -205,11 +206,27 @@ NET_PROPAGATION_DEFS = SimpleNamespace(PERSONALIZED_PAGERANK="personalized_pager
 
 VALID_NET_PROPAGATION_METHODS = NET_PROPAGATION_DEFS.__dict__.values()
 
-NULL_GENERATOR_DEFS = SimpleNamespace(
+NET_PROPAGATION_ENGINE_DEFS = SimpleNamespace(NON_NEGATIVE="non-negative")
+
+NET_PROPAGATION_ENGINE_REQS = {
+    NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK: {
+        NET_PROPAGATION_ENGINE_DEFS.NON_NEGATIVE: True
+    }
+}
+
+NULL_STRATEGIES = SimpleNamespace(
     UNIFORM="uniform",
-    GAUSSIAN="gaussian",
+    PARAMETRIC="parametric",
     NODE_PERMUTATION="node_permutation",
     EDGE_PERMUTATION="edge_permutation",
 )
 
-VALID_NULL_GENERATORS = NULL_GENERATOR_DEFS.__dict__.values()
+VALID_NULL_STRATEGIES = NULL_STRATEGIES.__dict__.values()
+
+PARAMETRIC_NULL_DEFAULT_DISTRIBUTION = "norm"
+
+# masks
+
+MASK_KEYWORDS = SimpleNamespace(
+    ATTR="attr",
+)

--- a/src/napistu/network/ig_utils.py
+++ b/src/napistu/network/ig_utils.py
@@ -488,20 +488,22 @@ def _get_attribute_masks(
     return masks
 
 
-def _ensure_nonnegative_vertex_attribute(graph: ig.Graph, attribute: str):
+def _ensure_valid_attribute(graph: ig.Graph, attribute: str, non_negative: bool = True):
     """
-    Ensure a vertex attribute is present, numeric, and non-negative for all vertices.
+    Ensure a vertex attribute is present, numeric, and optionally non-negative for all vertices.
 
-    This utility checks that the specified vertex attribute exists, is numeric, and non-negative
+    This utility checks that the specified vertex attribute exists, is numeric, and (optionally) non-negative
     for all vertices in the graph. Missing or None values are treated as 0. Raises ValueError
-    if the attribute is missing for all vertices, if all values are zero, or if any value is negative.
+    if the attribute is missing for all vertices, if all values are zero, or if any value is negative (if non_negative=True).
 
     Parameters
     ----------
-    napistu_graph : NapistuGraph or ig.Graph
+    graph : NapistuGraph or ig.Graph
         The input graph (NapistuGraph or igraph.Graph).
     attribute : str
         The name of the vertex attribute to check.
+    non_negative : bool, default True
+        Whether to require all values to be non-negative.
 
     Returns
     -------
@@ -511,7 +513,7 @@ def _ensure_nonnegative_vertex_attribute(graph: ig.Graph, attribute: str):
     Raises
     ------
     ValueError
-        If the attribute is missing for all vertices, all values are zero, or any value is negative.
+        If the attribute is missing for all vertices, all values are zero, or any value is negative (if non_negative=True).
     """
     all_missing = all(
         (attribute not in v.attributes() or v[attribute] is None) for v in graph.vs
@@ -534,7 +536,7 @@ def _ensure_nonnegative_vertex_attribute(graph: ig.Graph, attribute: str):
         raise ValueError(
             f"Vertex attribute '{attribute}' is zero for all vertices; cannot use as reset vector."
         )
-    if np.any(arr < 0):
+    if non_negative and np.any(arr < 0):
         raise ValueError(f"Attribute '{attribute}' contains negative values.")
 
     return arr

--- a/src/napistu/network/ig_utils.py
+++ b/src/napistu/network/ig_utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, List, Dict, Union
 
 import igraph as ig
 import numpy as np
@@ -384,3 +384,157 @@ def _get_top_n_nodes(
     top_node_attrs = [graph.vs[idx].attributes() for idx in top_idxs]
     top_vals = [vals[idx] for idx in top_idxs]
     return [{val_name: val, **node} for val, node in zip(top_vals, top_node_attrs)]
+
+
+def _parse_mask_input(
+    mask_input: Optional[Union[str, np.ndarray, List, Dict]], attributes: List[str]
+) -> Dict[str, Union[str, np.ndarray, List, None]]:
+    """
+    Parse mask input and convert to attribute-specific mask specifications.
+
+    Parameters
+    ----------
+    mask_input : str, np.ndarray, List, Dict, or None
+        Mask specification that can be:
+        - None: use all nodes for all attributes
+        - "attr": use each attribute as its own mask
+        - np.ndarray/List: use same mask for all attributes
+        - Dict: attribute-specific mask specifications
+    attributes : List[str]
+        List of attribute names.
+
+    Returns
+    -------
+    Dict[str, Union[str, np.ndarray, List, None]]
+        Dictionary mapping each attribute to its mask specification.
+    """
+    if mask_input is None:
+        return {attr: None for attr in attributes}
+    elif isinstance(mask_input, str):
+        if mask_input == "attr":
+            return {attr: attr for attr in attributes}
+        else:
+            # Single attribute name used for all
+            return {attr: mask_input for attr in attributes}
+    elif isinstance(mask_input, (np.ndarray, list)):
+        # Same mask for all attributes
+        return {attr: mask_input for attr in attributes}
+    elif isinstance(mask_input, dict):
+        # Validate all attributes are present
+        for attr in attributes:
+            if attr not in mask_input:
+                raise ValueError(f"Attribute '{attr}' not found in mask dictionary")
+        return mask_input
+    else:
+        raise ValueError(f"Invalid mask input type: {type(mask_input)}")
+
+
+def _get_attribute_masks(
+    graph: ig.Graph,
+    attributes: List[str],
+    mask_specs: Dict[str, Union[str, np.ndarray, List, None]],
+) -> Dict[str, np.ndarray]:
+    """
+    Generate boolean masks for each attribute based on specifications.
+
+    Parameters
+    ----------
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        List of attribute names.
+    mask_specs : Dict[str, Union[str, np.ndarray, List, None]]
+        Dictionary mapping each attribute to its mask specification.
+
+    Returns
+    -------
+    Dict[str, np.ndarray]
+        Dictionary mapping each attribute to its boolean mask array.
+    """
+    n_nodes = graph.vcount()
+    masks = {}
+
+    for attr in attributes:
+        mask_spec = mask_specs[attr]
+
+        if mask_spec is None:
+            masks[attr] = np.ones(n_nodes, dtype=bool)
+        elif isinstance(mask_spec, str):
+            attr_values = np.array(graph.vs[mask_spec])
+            masks[attr] = attr_values > 0
+        elif isinstance(mask_spec, np.ndarray):
+            masks[attr] = mask_spec.astype(bool)
+        elif isinstance(mask_spec, list):
+            mask_array = np.zeros(n_nodes, dtype=bool)
+            if isinstance(mask_spec[0], str):
+                # Node names
+                node_names = (
+                    graph.vs["name"] if "name" in graph.vs.attributes() else None
+                )
+                if node_names is None:
+                    raise ValueError("Graph has no 'name' attribute for string mask")
+                for name in mask_spec:
+                    idx = node_names.index(name)
+                    mask_array[idx] = True
+            else:
+                # Node indices
+                mask_array[mask_spec] = True
+            masks[attr] = mask_array
+        else:
+            raise ValueError(
+                f"Invalid mask specification for attribute '{attr}': {type(mask_spec)}"
+            )
+
+    return masks
+
+
+def _ensure_nonnegative_vertex_attribute(graph: ig.Graph, attribute: str):
+    """
+    Ensure a vertex attribute is present, numeric, and non-negative for all vertices.
+
+    This utility checks that the specified vertex attribute exists, is numeric, and non-negative
+    for all vertices in the graph. Missing or None values are treated as 0. Raises ValueError
+    if the attribute is missing for all vertices, if all values are zero, or if any value is negative.
+
+    Parameters
+    ----------
+    napistu_graph : NapistuGraph or ig.Graph
+        The input graph (NapistuGraph or igraph.Graph).
+    attribute : str
+        The name of the vertex attribute to check.
+
+    Returns
+    -------
+    np.ndarray
+        Array of attribute values (with missing/None replaced by 0).
+
+    Raises
+    ------
+    ValueError
+        If the attribute is missing for all vertices, all values are zero, or any value is negative.
+    """
+    all_missing = all(
+        (attribute not in v.attributes() or v[attribute] is None) for v in graph.vs
+    )
+    if all_missing:
+        raise ValueError(f"Vertex attribute '{attribute}' is missing for all vertices.")
+
+    values = [
+        (
+            v[attribute]
+            if (attribute in v.attributes() and v[attribute] is not None)
+            else 0.0
+        )
+        for v in graph.vs
+    ]
+
+    arr = np.array(values, dtype=float)
+
+    if np.all(arr == 0):
+        raise ValueError(
+            f"Vertex attribute '{attribute}' is zero for all vertices; cannot use as reset vector."
+        )
+    if np.any(arr < 0):
+        raise ValueError(f"Attribute '{attribute}' contains negative values.")
+
+    return arr

--- a/src/napistu/network/ig_utils.py
+++ b/src/napistu/network/ig_utils.py
@@ -431,7 +431,6 @@ def _parse_mask_input(
 
 def _get_attribute_masks(
     graph: ig.Graph,
-    attributes: List[str],
     mask_specs: Dict[str, Union[str, np.ndarray, List, None]],
 ) -> Dict[str, np.ndarray]:
     """
@@ -454,7 +453,12 @@ def _get_attribute_masks(
     n_nodes = graph.vcount()
     masks = {}
 
-    for attr in attributes:
+    invalid_attrs = set(mask_specs.keys()).difference(graph.vs.attributes())
+    if invalid_attrs:
+        raise ValueError(f"Attributes {invalid_attrs} not found in graph")
+
+    for attr in mask_specs.keys():
+
         mask_spec = mask_specs[attr]
 
         if mask_spec is None:

--- a/src/napistu/network/net_create.py
+++ b/src/napistu/network/net_create.py
@@ -26,7 +26,7 @@ from napistu.constants import (
 )
 
 from napistu.network.constants import (
-    NAPISTU_GRAPH_NODES,
+    NAPISTU_GRAPH_VERTICES,
     NAPISTU_GRAPH_EDGES,
     NAPISTU_GRAPH_EDGE_DIRECTIONS,
     NAPISTU_GRAPH_NODE_TYPES,
@@ -152,7 +152,7 @@ def create_napistu_graph(
 
     # rename nodes to name since it is treated specially
     network_nodes_df = pd.concat(network_nodes).rename(
-        columns={"node_id": NAPISTU_GRAPH_NODES.NAME}
+        columns={"node_id": NAPISTU_GRAPH_VERTICES.NAME}
     )
 
     logger.info(f"Formatting edges as a {wiring_approach} graph")
@@ -234,7 +234,7 @@ def create_napistu_graph(
         vertices=network_nodes_df.to_dict("records"),
         edges=unique_edges.to_dict("records"),
         directed=directed,
-        vertex_name_attr=NAPISTU_GRAPH_NODES.NAME,
+        vertex_name_attr=NAPISTU_GRAPH_VERTICES.NAME,
         edge_foreign_keys=(NAPISTU_GRAPH_EDGES.FROM, NAPISTU_GRAPH_EDGES.TO),
     )
 

--- a/src/napistu/network/net_propagation.py
+++ b/src/napistu/network/net_propagation.py
@@ -1,146 +1,584 @@
 import inspect
-from typing import Optional, Union
+import logging
+from typing import Optional, Union, List, Dict
 
 import pandas as pd
 import numpy as np
 import igraph as ig
 
-from napistu.network.ng_core import NapistuGraph
+from napistu.network.ig_utils import (
+    _parse_mask_input,
+    _get_attribute_masks,
+    _ensure_nonnegative_vertex_attribute,
+)
+from napistu.statistics.quantiles import calculate_quantiles
+from napistu.network.constants import (
+    NAPISTU_GRAPH_VERTICES,
+    NET_PROPAGATION_DEFS,
+    VALID_NET_PROPAGATION_METHODS,
+)
+
+logger = logging.getLogger(__name__)
 
 
-def personalized_pagerank_by_attribute(
-    napistu_graph: Union[NapistuGraph, ig.Graph],
-    attribute: str,
-    damping: float = 0.85,
-    calculate_uniform_dist: bool = True,
+def network_propagation_with_null(
+    graph: ig.Graph,
+    attributes: List[str],
+    null_strategy: str = "node_permutation",
+    method: str = "personalized_pagerank",
     additional_propagation_args: Optional[dict] = None,
+    n_samples: int = 100,
+    **null_kwargs,
 ) -> pd.DataFrame:
     """
-    Run personalized PageRank with reset probability proportional to a vertex attribute.
-    Optionally computes uniform PPR over nonzero attribute nodes.
+    Apply network propagation to attributes and compare against null distributions.
+
+    This is the main orchestrator function that:
+    1. Calculates observed propagated scores
+    2. Generates null distribution using specified strategy
+    3. Compares observed vs null using quantiles (for sampled nulls) or ratios (for uniform)
 
     Parameters
     ----------
-    napistu_graph : NapistuGraph
-        The input graph (subclass of igraph.Graph).
-    attribute : str
-        The vertex attribute to use for personalization.
-    damping : float, optional
-        Damping factor (default 0.85).
-    calculate_uniform_dist : bool, optional
-        If True, also compute uniform PPR over nonzero attribute nodes.
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        Attribute names to propagate and test.
+    null_strategy : str
+        Null distribution strategy. One of: 'uniform', 'gaussian', 'node_permutation', 'edge_permutation'.
+    method : str
+        Network propagation method to apply.
     additional_propagation_args : dict, optional
-        Additional arguments to pass to igraph's personalized_pagerank. Keys must match the method's signature.
+        Additional arguments to pass to the network propagation method.
+    n_samples : int
+        Number of null samples to generate (ignored for uniform null).
+    **null_kwargs
+        Additional arguments to pass to the null generator (e.g., mask, burn_in_ratio, etc.).
 
     Returns
     -------
     pd.DataFrame
-        DataFrame with columns ['name', 'pagerank_by_attribute', attribute] and optionally 'pagerank_uniform'.
+        DataFrame with same structure as observed scores containing:
+        - For uniform null: observed/uniform ratios
+        - For other nulls: quantiles (proportion of null values <= observed values)
 
-    Example
-    -------
-    >>> import igraph as ig
-    >>> from napistu.network.net_propagation import personalized_pagerank_by_attribute
-    >>> g = ig.Graph.Full(3)
-    >>> g.vs['name'] = ['A', 'B', 'C']
-    >>> g.vs['score'] = [1, 0, 2]
-    >>> df = personalized_pagerank_by_attribute(g, 'score')
-    >>> print(df)
+    Examples
+    --------
+    >>> # Node permutation test with custom mask
+    >>> result = network_propagation_with_null(
+    ...     graph, ['gene_score'],
+    ...     null_strategy='node_permutation',
+    ...     n_samples=1000,
+    ...     mask='measured_genes'
+    ... )
+
+    >>> # Edge permutation test
+    >>> result = network_propagation_with_null(
+    ...     graph, ['pathway_score'],
+    ...     null_strategy='edge_permutation',
+    ...     n_samples=100,
+    ...     burn_in_ratio=10,
+    ...     sampling_ratio=0.1
+    ... )
     """
-    # Validate and extract attribute (missing/None as 0)
-    attr = _ensure_nonnegative_vertex_attribute(napistu_graph, attribute)
+    # 1. Calculate observed propagated scores
+    observed_scores = net_propagate_attributes(
+        graph, attributes, method, additional_propagation_args
+    )
+
+    # 2. Get null generator function
+    null_generator = get_null_generator(null_strategy)
+
+    # 3. Generate null distribution
+    if null_strategy == "uniform":
+        # Uniform null doesn't take n_samples
+        null_distribution = null_generator(
+            graph, attributes, method, additional_propagation_args, **null_kwargs
+        )
+
+        # 4a. For uniform null: calculate observed/uniform ratios
+        # Avoid division by zero by adding small epsilon
+        epsilon = 1e-10
+        ratios = observed_scores / (null_distribution + epsilon)
+        return ratios
+
+    else:
+        # Other nulls take n_samples
+        null_distribution = null_generator(
+            graph,
+            attributes,
+            method,
+            additional_propagation_args,
+            n_samples=n_samples,
+            **null_kwargs,
+        )
+
+        # 4b. For sampled nulls: calculate quantiles
+        return calculate_quantiles(observed_scores, null_distribution)
+
+
+def net_propagate_attributes(
+    graph: ig.Graph,
+    attributes: List[str],
+    method: str = NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK,
+    additional_propagation_args: Optional[dict] = None,
+) -> pd.DataFrame:
+    """
+    Propagate multiple attributes over a network using a network propagation method.
+
+    Parameters
+    ----------
+    graph : ig.Graph
+        The graph to propagate attributes over.
+    attributes : List[str]
+        List of attribute names to propagate.
+    method : str
+        The network propagation method to use (e.g., 'personalized_pagerank').
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to the network propagation method.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with node names as index and attributes as columns,
+        containing the propagated attribute values.
+    """
+    results = []
+    for attr in attributes:
+        attr_data = _ensure_nonnegative_vertex_attribute(graph, attr)
+        additional_propagation_args = _validate_additional_propagation_args(
+            method, additional_propagation_args
+        )
+
+        if method == NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK:
+            pr_attr = graph.personalized_pagerank(
+                reset=attr_data.tolist(), **additional_propagation_args
+            )
+        else:
+            raise ValueError(
+                f"Invalid method: {method}, valid methods are {VALID_NET_PROPAGATION_METHODS}"
+            )
+
+        results.append(pr_attr)
+
+    # Get node names once
+    names = (
+        graph.vs[NAPISTU_GRAPH_VERTICES.NAME]
+        if NAPISTU_GRAPH_VERTICES.NAME in graph.vs.attributes()
+        else list(range(graph.vcount()))
+    )
+
+    return pd.DataFrame(np.column_stack(results), index=names, columns=attributes)
+
+
+def _validate_additional_propagation_args(
+    propagation_method: str, additional_propagation_args: dict
+) -> dict:
+    """
+    Validate additional arguments for a network propagation method.
+
+    Parameters
+    ----------
+    propagation_method : str
+        The network propagation method to validate.
+    additional_propagation_args : dict
+        The additional arguments to validate.
+
+    Returns
+    -------
+    dict
+        The validated additional arguments.
+
+    Raises
+    ------
+    ValueError
+        If the propagation method is invalid or if the additional arguments are invalid.
+    """
+
+    NET_PROPAGATION_FUNCTIONS = {
+        NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK: ig.Graph.personalized_pagerank
+    }
+
+    if propagation_method not in VALID_NET_PROPAGATION_METHODS:
+        raise ValueError(
+            f"Invalid method: {propagation_method}, valid methods are {VALID_NET_PROPAGATION_METHODS}"
+        )
 
     # Validate additional_propagation_args
     if additional_propagation_args is None:
-        additional_propagation_args = {}
+        return {}
     else:
         valid_args = set(
-            inspect.signature(napistu_graph.personalized_pagerank).parameters.keys()
+            inspect.signature(
+                NET_PROPAGATION_FUNCTIONS[propagation_method]
+            ).parameters.keys()
         )
         for k in additional_propagation_args:
             if k not in valid_args:
                 raise ValueError(f"Invalid argument for personalized_pagerank: {k}")
 
-    # Personalized PageRank (no normalization, igraph handles it)
-    pr_attr = napistu_graph.personalized_pagerank(
-        reset=attr.tolist(), damping=damping, **additional_propagation_args
-    )
-
-    # Node names
-    names = (
-        napistu_graph.vs["name"]
-        if "name" in napistu_graph.vs.attributes()
-        else list(range(napistu_graph.vcount()))
-    )
-
-    data = {"name": names, "pagerank_by_attribute": pr_attr, attribute: attr}
-
-    # Uniform PPR over nonzero attribute nodes
-    if calculate_uniform_dist:
-        used_in_uniform = attr > 0
-        n_uniform = used_in_uniform.sum()
-        if n_uniform == 0:
-            raise ValueError("No nonzero attribute values for uniform PPR.")
-        uniform_vec = np.zeros_like(attr, dtype=float)
-        uniform_vec[used_in_uniform] = 1.0 / n_uniform
-        pr_uniform = napistu_graph.personalized_pagerank(
-            reset=uniform_vec.tolist(), damping=damping, **additional_propagation_args
-        )
-        data["pagerank_uniform"] = pr_uniform
-
-    return pd.DataFrame(data)
+        return additional_propagation_args
 
 
-def _ensure_nonnegative_vertex_attribute(
-    napistu_graph: Union[NapistuGraph, ig.Graph], attribute: str
-):
+def uniform_null(
+    graph: ig.Graph,
+    attributes: List[str],
+    method: str = "personalized_pagerank",
+    additional_propagation_args: Optional[dict] = None,
+    mask: Optional[Union[str, np.ndarray, List, Dict]] = "attr",
+) -> pd.DataFrame:
     """
-    Ensure a vertex attribute is present, numeric, and non-negative for all vertices.
-
-    This utility checks that the specified vertex attribute exists, is numeric, and non-negative
-    for all vertices in the graph. Missing or None values are treated as 0. Raises ValueError
-    if the attribute is missing for all vertices, if all values are zero, or if any value is negative.
+    Generate uniform null distribution over masked nodes and apply propagation method.
 
     Parameters
     ----------
-    napistu_graph : NapistuGraph or ig.Graph
-        The input graph (NapistuGraph or igraph.Graph).
-    attribute : str
-        The name of the vertex attribute to check.
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        Attribute names to generate nulls for.
+    method : str
+        Network propagation method to apply.
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to the network propagation method.
+    mask : str, np.ndarray, List, Dict, or None
+        Mask specification. Default is "attr" (use each attribute as its own mask).
 
     Returns
     -------
-    np.ndarray
-        Array of attribute values (with missing/None replaced by 0).
-
-    Raises
-    ------
-    ValueError
-        If the attribute is missing for all vertices, all values are zero, or any value is negative.
+    pd.DataFrame
+        Propagated null sample with uniform distribution over masked nodes.
+        Shape: (n_nodes, n_attributes)
     """
-    all_missing = all(
-        (attribute not in v.attributes() or v[attribute] is None)
-        for v in napistu_graph.vs
+    # Validate attributes
+    for attr in attributes:
+        _ensure_nonnegative_vertex_attribute(graph, attr)
+
+    # Parse mask input
+    mask_specs = _parse_mask_input(mask, attributes)
+    masks = _get_attribute_masks(graph, attributes, mask_specs)
+
+    # Create null graph with uniform attributes
+    null_graph = graph.copy()
+
+    for j, attr in enumerate(attributes):
+        attr_mask = masks[attr]
+        n_masked = attr_mask.sum()
+
+        if n_masked == 0:
+            raise ValueError(f"No nodes in mask for attribute '{attr}'")
+
+        # Check for constant attribute values when mask is the same as attribute
+        if isinstance(mask_specs[attr], str) and mask_specs[attr] == attr:
+            attr_values = np.array(graph.vs[attr])
+            nonzero_values = attr_values[attr_values > 0]
+            if len(np.unique(nonzero_values)) == 1:
+                logger.warning(
+                    f"Attribute '{attr}' has constant non-zero values, uniform null may not be meaningful."
+                )
+
+        # Set uniform values for masked nodes
+        null_attr_values = np.zeros(graph.vcount())
+        null_attr_values[attr_mask] = 1.0 / n_masked
+        null_graph.vs[attr] = null_attr_values.tolist()
+
+    # Apply propagation method to null graph
+    return net_propagate_attributes(
+        null_graph, attributes, method, additional_propagation_args
     )
-    if all_missing:
-        raise ValueError(f"Vertex attribute '{attribute}' is missing for all vertices.")
 
-    values = [
-        (
-            v[attribute]
-            if (attribute in v.attributes() and v[attribute] is not None)
-            else 0.0
+
+def gaussian_null(
+    graph: ig.Graph,
+    attributes: List[str],
+    method: str = "personalized_pagerank",
+    additional_propagation_args: Optional[dict] = None,
+    mask: Optional[Union[str, np.ndarray, List, Dict]] = "attr",
+    n_samples: int = 100,
+) -> pd.DataFrame:
+    """
+    Generate Gaussian null distribution based on observed values and apply propagation method.
+
+    Parameters
+    ----------
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        Attribute names to generate nulls for.
+    method : str
+        Network propagation method to apply.
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to the network propagation method.
+    mask : str, np.ndarray, List, Dict, or None
+        Mask specification. Default is "attr" (use each attribute as its own mask).
+    n_samples : int
+        Number of null samples to generate.
+
+    Returns
+    -------
+    pd.DataFrame
+        Propagated null samples with Gaussian distribution over masked nodes.
+        Shape: (n_samples * n_nodes, n_attributes)
+    """
+    # Validate attributes
+    for attr in attributes:
+        _ensure_nonnegative_vertex_attribute(graph, attr)
+
+    # Parse mask input
+    mask_specs = _parse_mask_input(mask, attributes)
+    masks = _get_attribute_masks(graph, attributes, mask_specs)
+
+    # Calculate mean and std from observed values for each attribute
+    params = {}
+    for attr in attributes:
+        attr_mask = masks[attr]
+        attr_values = np.array(graph.vs[attr])
+        masked_values = attr_values[attr_mask]
+        masked_nonzero = masked_values[masked_values > 0]
+
+        if len(masked_nonzero) == 0:
+            raise ValueError(f"No nonzero values in mask for attribute '{attr}'")
+
+        # Check if data seems non-Gaussian
+        if (
+            np.all(masked_nonzero == masked_nonzero.astype(int))
+            and len(np.unique(masked_nonzero)) < 5
+        ):
+            logger.warning(
+                f"Attribute '{attr}' appears to be integer-valued with <5 distinct values, may not be suitable for Gaussian null."
+            )
+
+        params[attr] = {
+            "mean": np.mean(masked_nonzero),
+            "std": np.std(masked_nonzero),
+            "mask": attr_mask,
+        }
+
+    # Get node names
+    node_names = (
+        graph.vs["name"]
+        if "name" in graph.vs.attributes()
+        else list(range(graph.vcount()))
+    )
+
+    # Pre-allocate for results
+    all_results = []
+
+    # Generate samples
+    for i in range(n_samples):
+        # Create null graph with Gaussian attributes
+        null_graph = graph.copy()
+
+        for j, attr in enumerate(attributes):
+            attr_mask = params[attr]["mask"]
+            mean = params[attr]["mean"]
+            std = params[attr]["std"]
+
+            # Generate Gaussian values for masked nodes
+            null_attr_values = np.zeros(graph.vcount())
+            n_masked = attr_mask.sum()
+            gaussian_values = np.random.normal(mean, std, n_masked)
+            # Ensure non-negative values
+            gaussian_values = np.maximum(gaussian_values, 0)
+            null_attr_values[attr_mask] = gaussian_values
+            null_graph.vs[attr] = null_attr_values.tolist()
+
+        # Apply propagation method to null graph
+        result = net_propagate_attributes(
+            null_graph, attributes, method, additional_propagation_args
         )
-        for v in napistu_graph.vs
-    ]
+        all_results.append(result)
 
-    arr = np.array(values, dtype=float)
+    # Combine all results
+    full_index = node_names * n_samples
+    all_data = np.vstack([result.values for result in all_results])
 
-    if np.all(arr == 0):
+    return pd.DataFrame(all_data, index=full_index, columns=attributes)
+
+
+def node_permutation_null(
+    graph: ig.Graph,
+    attributes: List[str],
+    method: str = "personalized_pagerank",
+    additional_propagation_args: Optional[dict] = None,
+    mask: Optional[Union[str, np.ndarray, List, Dict]] = "attr",
+    replace: bool = False,
+    n_samples: int = 100,
+) -> pd.DataFrame:
+    """
+    Generate null distribution by permuting node attribute values and apply propagation method.
+
+    Parameters
+    ----------
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        Attribute names to permute.
+    method : str
+        Network propagation method to apply.
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to the network propagation method.
+    mask : str, np.ndarray, List, Dict, or None
+        Mask specification. Default is "attr" (use each attribute as its own mask).
+    replace : bool
+        Whether to sample with replacement.
+    n_samples : int
+        Number of null samples to generate.
+
+    Returns
+    -------
+    pd.DataFrame
+        Propagated null samples with permuted attribute values.
+        Shape: (n_samples * n_nodes, n_attributes)
+    """
+    # Validate attributes
+    for attr in attributes:
+        _ensure_nonnegative_vertex_attribute(graph, attr)
+
+    # Parse mask input
+    mask_specs = _parse_mask_input(mask, attributes)
+    masks = _get_attribute_masks(graph, attributes, mask_specs)
+
+    # Get original attribute values
+    original_values = {}
+    for attr in attributes:
+        original_values[attr] = np.array(graph.vs[attr])
+
+    # Get node names
+    node_names = (
+        graph.vs["name"]
+        if "name" in graph.vs.attributes()
+        else list(range(graph.vcount()))
+    )
+
+    # Pre-allocate for results
+    all_results = []
+
+    # Generate samples
+    for i in range(n_samples):
+        # Create null graph with permuted attributes
+        null_graph = graph.copy()
+
+        # Permute values among masked nodes for each attribute
+        for j, attr in enumerate(attributes):
+            attr_mask = masks[attr]
+            masked_indices = np.where(attr_mask)[0]
+            masked_values = original_values[attr][masked_indices]
+
+            # Start with original values
+            null_attr_values = original_values[attr].copy()
+
+            if replace:
+                # Sample with replacement
+                permuted_values = np.random.choice(
+                    masked_values, size=len(masked_values), replace=True
+                )
+            else:
+                # Permute without replacement
+                permuted_values = np.random.permutation(masked_values)
+
+            null_attr_values[masked_indices] = permuted_values
+            null_graph.vs[attr] = null_attr_values.tolist()
+
+        # Apply propagation method to null graph
+        result = net_propagate_attributes(
+            null_graph, attributes, method, additional_propagation_args
+        )
+        all_results.append(result)
+
+    # Combine all results
+    full_index = node_names * n_samples
+    all_data = np.vstack([result.values for result in all_results])
+
+    return pd.DataFrame(all_data, index=full_index, columns=attributes)
+
+
+def edge_permutation_null(
+    graph: ig.Graph,
+    attributes: List[str],
+    method: str = "personalized_pagerank",
+    additional_propagation_args: Optional[dict] = None,
+    burn_in_ratio: int = 10,
+    sampling_ratio: float = 0.1,
+    n_samples: int = 100,
+) -> pd.DataFrame:
+    """
+    Generate null distribution by edge rewiring and apply propagation method.
+
+    Parameters
+    ----------
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        Attribute names to use (values unchanged by rewiring).
+    method : str
+        Network propagation method to apply.
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to the network propagation method.
+    burn_in_ratio : int
+        Multiplier for initial rewiring.
+    sampling_ratio : float
+        Proportion of edges to rewire between samples.
+    n_samples : int
+        Number of null samples to generate.
+
+    Returns
+    -------
+    pd.DataFrame
+        Propagated null samples from rewired network.
+        Shape: (n_samples * n_nodes, n_attributes)
+    """
+    # Validate attributes
+    for attr in attributes:
+        _ensure_nonnegative_vertex_attribute(graph, attr)
+
+    # Setup rewired graph
+    null_graph = graph.copy()
+    n_edges = len(null_graph.es)
+
+    # Initial burn-in
+    null_graph.rewire(n=burn_in_ratio * n_edges)
+
+    # Get node names
+    node_names = (
+        graph.vs["name"]
+        if "name" in graph.vs.attributes()
+        else list(range(graph.vcount()))
+    )
+
+    # Pre-allocate for results
+    all_results = []
+
+    # Generate samples
+    for i in range(n_samples):
+        # Incremental rewiring
+        null_graph.rewire(n=int(sampling_ratio * n_edges))
+
+        # Apply propagation method to rewired graph (attributes unchanged)
+        result = net_propagate_attributes(
+            null_graph, attributes, method, additional_propagation_args
+        )
+        all_results.append(result)
+
+    # Combine all results
+    full_index = node_names * n_samples
+    all_data = np.vstack([result.values for result in all_results])
+
+    return pd.DataFrame(all_data, index=full_index, columns=attributes)
+
+
+# Null generator registry
+NULL_GENERATORS = {
+    "uniform": uniform_null,
+    "gaussian": gaussian_null,
+    "node_permutation": node_permutation_null,
+    "edge_permutation": edge_permutation_null,
+}
+
+
+def get_null_generator(strategy: str):
+    """Get null generator function by name."""
+    if strategy not in NULL_GENERATORS:
         raise ValueError(
-            f"Vertex attribute '{attribute}' is zero for all vertices; cannot use as reset vector."
+            f"Unknown null strategy: {strategy}. Available: {list(NULL_GENERATORS.keys())}"
         )
-    if np.any(arr < 0):
-        raise ValueError(f"Attribute '{attribute}' contains negative values.")
-
-    return arr
+    return NULL_GENERATORS[strategy]

--- a/src/napistu/statistics/__init__.py
+++ b/src/napistu/statistics/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
+
+try:
+    __version__ = version("napistu")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/src/napistu/statistics/quantiles.py
+++ b/src/napistu/statistics/quantiles.py
@@ -1,0 +1,82 @@
+"""Module for comparing observed values to null distributions."""
+
+import logging
+
+import pandas as pd
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_quantiles(
+    observed_df: pd.DataFrame, null_df: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Calculate quantiles of observed scores relative to null distributions using
+    ultra-fast vectorized operations.
+
+    Parameters
+    ----------
+    observed_df : pd.DataFrame
+        DataFrame with features as index and attributes as columns containing
+        observed scores.
+    null_df : pd.DataFrame
+        DataFrame with null scores, features as index (multiple rows per feature)
+        and attributes as columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with same structure as observed_df containing quantiles.
+        Each value represents the proportion of null values <= observed value.
+    """
+
+    if not observed_df.columns.equals(null_df.columns):
+        raise ValueError("Column names must match between observed and null data")
+
+    # Validate all features present
+    missing_features = set(observed_df.index) - set(null_df.index)
+    if missing_features:
+        raise ValueError(f"Missing features in null data: {missing_features}")
+
+    # Check for NaN values
+    if observed_df.isna().any().any():
+        raise ValueError("NaN values found in observed data")
+    if null_df.isna().any().any():
+        raise ValueError("NaN values found in null data")
+
+    # Check for unequal sample sizes and warn
+    null_grouped = null_df.groupby(level=0)
+    sample_counts = {name: len(group) for name, group in null_grouped}
+    if len(set(sample_counts.values())) > 1:
+        logger.warning("Unequal null sample counts per feature may affect results")
+
+    # Convert to numpy arrays for speed
+    observed_values = observed_df.values
+
+    # Group null data and stack into 3D array
+    null_grouped = null_df.groupby(level=0)
+
+    # Get the maximum number of null samples per feature
+    max_null_samples = max(len(group) for _, group in null_grouped)
+
+    # Pre-allocate 3D array: [features, null_samples, attributes]
+    null_array = np.full(
+        (len(observed_df), max_null_samples, len(observed_df.columns)), np.nan
+    )
+
+    # Fill the null array
+    for i, (feature, group) in enumerate(null_grouped):
+        feature_idx = observed_df.index.get_loc(feature)
+        null_array[feature_idx, : len(group)] = group.values
+
+    # Broadcast comparison: observed[features, 1, attributes] vs null[features, samples, attributes]
+    # This creates a boolean array of shape [features, null_samples, attributes]
+    # Less than or equal to is used to calculate the quantile consistent with the R quantile function
+    comparisons = null_array <= observed_values[:, np.newaxis, :]
+
+    # Calculate quantiles by taking mean along the null_samples axis
+    # Use nanmean to handle padded NaN values
+    quantiles = np.nanmean(comparisons, axis=1)
+
+    return pd.DataFrame(quantiles, index=observed_df.index, columns=observed_df.columns)

--- a/src/tests/test_network_ig_utils.py
+++ b/src/tests/test_network_ig_utils.py
@@ -75,7 +75,7 @@ def test_mask_functions_valid_inputs():
     specs = ig_utils._parse_mask_input(None, attributes)
     assert specs == {"attr1": None, "attr2": None}
 
-    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    masks = ig_utils._get_attribute_masks(graph, specs)
     assert np.array_equal(masks["attr1"], np.ones(5, dtype=bool))
     assert np.array_equal(masks["attr2"], np.ones(5, dtype=bool))
 
@@ -83,7 +83,7 @@ def test_mask_functions_valid_inputs():
     specs = ig_utils._parse_mask_input("attr", attributes)
     assert specs == {"attr1": "attr1", "attr2": "attr2"}
 
-    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    masks = ig_utils._get_attribute_masks(graph, specs)
     assert np.array_equal(masks["attr1"], np.array([False, True, True, False, True]))
     assert np.array_equal(masks["attr2"], np.array([True, False, True, True, False]))
 
@@ -94,21 +94,21 @@ def test_mask_functions_valid_inputs():
     # Test 4: Boolean array
     bool_mask = np.array([True, False, True, False, False])
     specs = ig_utils._parse_mask_input(bool_mask, attributes)
-    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    masks = ig_utils._get_attribute_masks(graph, specs)
     assert np.array_equal(masks["attr1"], bool_mask)
     assert np.array_equal(masks["attr2"], bool_mask)
 
     # Test 5: Node indices list
     indices = [0, 2, 4]
     specs = ig_utils._parse_mask_input(indices, attributes)
-    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    masks = ig_utils._get_attribute_masks(graph, specs)
     expected = np.array([True, False, True, False, True])
     assert np.array_equal(masks["attr1"], expected)
 
     # Test 6: Node names list
     names = ["A", "C", "E"]
     specs = ig_utils._parse_mask_input(names, attributes)
-    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    masks = ig_utils._get_attribute_masks(graph, specs)
     assert np.array_equal(masks["attr1"], expected)
 
     # Test 7: Dictionary input
@@ -116,7 +116,7 @@ def test_mask_functions_valid_inputs():
     specs = ig_utils._parse_mask_input(mask_dict, attributes)
     assert specs == mask_dict
 
-    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    masks = ig_utils._get_attribute_masks(graph, specs)
     assert np.array_equal(masks["attr1"], np.array([False, True, True, False, True]))
     assert np.array_equal(masks["attr2"], np.ones(5, dtype=bool))
 
@@ -150,14 +150,14 @@ def test_mask_functions_error_cases():
     with pytest.raises(
         ValueError, match="Graph has no 'name' attribute for string mask"
     ):
-        ig_utils._get_attribute_masks(graph_no_names, ["attr1"], specs)
+        ig_utils._get_attribute_masks(graph_no_names, specs)
 
     # Test 4: Invalid mask specification type in _get_attribute_masks
     specs = {"attr1": 123}  # Invalid type
     with pytest.raises(
         ValueError, match="Invalid mask specification for attribute 'attr1'"
     ):
-        ig_utils._get_attribute_masks(graph, ["attr1"], specs)
+        ig_utils._get_attribute_masks(graph, specs)
 
 
 def test_ensure_nonnegative_vertex_attribute():

--- a/src/tests/test_network_ig_utils.py
+++ b/src/tests/test_network_ig_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import igraph as ig
+import numpy as np
 import pytest
 
 from napistu.network import ig_utils
@@ -57,3 +59,134 @@ def test_filter_to_largest_subgraphs(multi_component_graph):
     # Test invalid top_k
     with pytest.raises(ValueError):
         ig_utils.filter_to_largest_subgraphs(multi_component_graph, top_k=0)
+
+
+def test_mask_functions_valid_inputs():
+    """Test mask functions with various valid input formats."""
+    # Create real graph with attributes
+    graph = ig.Graph(5)
+    graph.vs["attr1"] = [0, 1, 2, 0, 3]
+    graph.vs["attr2"] = [1, 0, 1, 2, 0]
+    graph.vs["name"] = ["A", "B", "C", "D", "E"]
+
+    attributes = ["attr1", "attr2"]
+
+    # Test 1: None input
+    specs = ig_utils._parse_mask_input(None, attributes)
+    assert specs == {"attr1": None, "attr2": None}
+
+    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    assert np.array_equal(masks["attr1"], np.ones(5, dtype=bool))
+    assert np.array_equal(masks["attr2"], np.ones(5, dtype=bool))
+
+    # Test 2: "attr" keyword
+    specs = ig_utils._parse_mask_input("attr", attributes)
+    assert specs == {"attr1": "attr1", "attr2": "attr2"}
+
+    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    assert np.array_equal(masks["attr1"], np.array([False, True, True, False, True]))
+    assert np.array_equal(masks["attr2"], np.array([True, False, True, True, False]))
+
+    # Test 3: Single attribute name
+    specs = ig_utils._parse_mask_input("attr1", attributes)
+    assert specs == {"attr1": "attr1", "attr2": "attr1"}
+
+    # Test 4: Boolean array
+    bool_mask = np.array([True, False, True, False, False])
+    specs = ig_utils._parse_mask_input(bool_mask, attributes)
+    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    assert np.array_equal(masks["attr1"], bool_mask)
+    assert np.array_equal(masks["attr2"], bool_mask)
+
+    # Test 5: Node indices list
+    indices = [0, 2, 4]
+    specs = ig_utils._parse_mask_input(indices, attributes)
+    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    expected = np.array([True, False, True, False, True])
+    assert np.array_equal(masks["attr1"], expected)
+
+    # Test 6: Node names list
+    names = ["A", "C", "E"]
+    specs = ig_utils._parse_mask_input(names, attributes)
+    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    assert np.array_equal(masks["attr1"], expected)
+
+    # Test 7: Dictionary input
+    mask_dict = {"attr1": "attr1", "attr2": None}
+    specs = ig_utils._parse_mask_input(mask_dict, attributes)
+    assert specs == mask_dict
+
+    masks = ig_utils._get_attribute_masks(graph, attributes, specs)
+    assert np.array_equal(masks["attr1"], np.array([False, True, True, False, True]))
+    assert np.array_equal(masks["attr2"], np.ones(5, dtype=bool))
+
+
+def test_mask_functions_error_cases():
+    """Test mask functions with invalid inputs that should raise errors."""
+    # Graph without name attribute
+    graph_no_names = ig.Graph(3)
+    graph_no_names.vs["attr1"] = [1, 2, 3]
+
+    # Graph with names
+    graph = ig.Graph(3)
+    graph.vs["attr1"] = [1, 2, 3]
+    graph.vs["name"] = ["A", "B", "C"]
+
+    attributes = ["attr1", "attr2"]
+
+    # Test 1: Invalid mask type
+    with pytest.raises(ValueError, match="Invalid mask input type"):
+        ig_utils._parse_mask_input(123, attributes)
+
+    # Test 2: Missing attribute in dictionary
+    incomplete_dict = {"attr1": None}  # Missing 'attr2'
+    with pytest.raises(
+        ValueError, match="Attribute 'attr2' not found in mask dictionary"
+    ):
+        ig_utils._parse_mask_input(incomplete_dict, attributes)
+
+    # Test 3: String mask for graph without names
+    specs = {"attr1": ["A", "B"]}
+    with pytest.raises(
+        ValueError, match="Graph has no 'name' attribute for string mask"
+    ):
+        ig_utils._get_attribute_masks(graph_no_names, ["attr1"], specs)
+
+    # Test 4: Invalid mask specification type in _get_attribute_masks
+    specs = {"attr1": 123}  # Invalid type
+    with pytest.raises(
+        ValueError, match="Invalid mask specification for attribute 'attr1'"
+    ):
+        ig_utils._get_attribute_masks(graph, ["attr1"], specs)
+
+
+def test_ensure_nonnegative_vertex_attribute():
+    """Test _ensure_nonnegative_vertex_attribute with various valid and invalid inputs."""
+    # Create test graph
+    graph = ig.Graph(4)
+    graph.vs["good_attr"] = [1.0, 2.0, 0.0, 3.0]
+    graph.vs["zero_attr"] = [0.0, 0.0, 0.0, 0.0]
+    graph.vs["negative_attr"] = [1.0, -1.0, 2.0, 0.0]
+    graph.vs["mixed_attr"] = [1.0, None, 2.0, 0.0]  # Some None values
+
+    # Test 1: Valid attribute
+    result = ig_utils._ensure_nonnegative_vertex_attribute(graph, "good_attr")
+    expected = np.array([1.0, 2.0, 0.0, 3.0])
+    assert np.array_equal(result, expected)
+
+    # Test 2: Attribute with None values (should be replaced with 0)
+    result = ig_utils._ensure_nonnegative_vertex_attribute(graph, "mixed_attr")
+    expected = np.array([1.0, 0.0, 2.0, 0.0])
+    assert np.array_equal(result, expected)
+
+    # Test 3: All zero values
+    with pytest.raises(ValueError, match="zero for all vertices"):
+        ig_utils._ensure_nonnegative_vertex_attribute(graph, "zero_attr")
+
+    # Test 4: Negative values
+    with pytest.raises(ValueError, match="contains negative values"):
+        ig_utils._ensure_nonnegative_vertex_attribute(graph, "negative_attr")
+
+    # Test 5: Missing attribute
+    with pytest.raises(ValueError, match="missing for all vertices"):
+        ig_utils._ensure_nonnegative_vertex_attribute(graph, "nonexistent_attr")

--- a/src/tests/test_network_ig_utils.py
+++ b/src/tests/test_network_ig_utils.py
@@ -161,7 +161,7 @@ def test_mask_functions_error_cases():
 
 
 def test_ensure_nonnegative_vertex_attribute():
-    """Test _ensure_nonnegative_vertex_attribute with various valid and invalid inputs."""
+    """Test _ensure_valid_attribute with various valid and invalid inputs."""
     # Create test graph
     graph = ig.Graph(4)
     graph.vs["good_attr"] = [1.0, 2.0, 0.0, 3.0]
@@ -170,23 +170,23 @@ def test_ensure_nonnegative_vertex_attribute():
     graph.vs["mixed_attr"] = [1.0, None, 2.0, 0.0]  # Some None values
 
     # Test 1: Valid attribute
-    result = ig_utils._ensure_nonnegative_vertex_attribute(graph, "good_attr")
+    result = ig_utils._ensure_valid_attribute(graph, "good_attr")
     expected = np.array([1.0, 2.0, 0.0, 3.0])
     assert np.array_equal(result, expected)
 
     # Test 2: Attribute with None values (should be replaced with 0)
-    result = ig_utils._ensure_nonnegative_vertex_attribute(graph, "mixed_attr")
+    result = ig_utils._ensure_valid_attribute(graph, "mixed_attr")
     expected = np.array([1.0, 0.0, 2.0, 0.0])
     assert np.array_equal(result, expected)
 
     # Test 3: All zero values
     with pytest.raises(ValueError, match="zero for all vertices"):
-        ig_utils._ensure_nonnegative_vertex_attribute(graph, "zero_attr")
+        ig_utils._ensure_valid_attribute(graph, "zero_attr")
 
     # Test 4: Negative values
     with pytest.raises(ValueError, match="contains negative values"):
-        ig_utils._ensure_nonnegative_vertex_attribute(graph, "negative_attr")
+        ig_utils._ensure_valid_attribute(graph, "negative_attr")
 
     # Test 5: Missing attribute
     with pytest.raises(ValueError, match="missing for all vertices"):
-        ig_utils._ensure_nonnegative_vertex_attribute(graph, "nonexistent_attr")
+        ig_utils._ensure_valid_attribute(graph, "nonexistent_attr")

--- a/src/tests/test_network_net_propagation.py
+++ b/src/tests/test_network_net_propagation.py
@@ -1,89 +1,399 @@
 import pytest
-import igraph as ig
 import numpy as np
-from napistu.network.net_propagation import personalized_pagerank_by_attribute
+import pandas as pd
+import igraph as ig
+from napistu.network.net_propagation import (
+    net_propagate_attributes,
+    _validate_additional_propagation_args,
+    uniform_null,
+    gaussian_null,
+    node_permutation_null,
+    edge_permutation_null,
+    NULL_GENERATORS,
+    network_propagation_with_null,
+)
 
 
-def test_personalized_pagerank_by_attribute_basic():
-    g = ig.Graph.Full(3)
-    g.vs["name"] = ["A", "B", "C"]
-    g.vs["score"] = [1, 0, 2]
-    df = personalized_pagerank_by_attribute(g, "score")
-    assert set(df.columns) == {
-        "name",
-        "pagerank_by_attribute",
-        "pagerank_uniform",
-        "score",
-    }
-    assert np.isclose(df["score"].sum(), 3)
-    assert np.isclose(df["pagerank_by_attribute"].sum(), 1)
-    assert np.isclose(df["pagerank_uniform"].sum(), 1)
-    # Uniform should only include A and C
-    assert df.loc[df["name"] == "B", "pagerank_uniform"].values[0] > 0
+def test_network_propagation_with_null():
+    """Test the main orchestrator function with different null strategies."""
+    # Create test graph
+    graph = ig.Graph(5)
+    graph.vs["name"] = ["A", "B", "C", "D", "E"]
+    graph.vs["attr1"] = [1.0, 0.0, 2.0, 0.0, 1.5]  # Non-negative, not all zero
+    graph.add_edges([(0, 1), (1, 2), (2, 3), (3, 4)])
 
+    attributes = ["attr1"]
 
-def test_personalized_pagerank_by_attribute_no_uniform():
-    g = ig.Graph.Full(3)
-    g.vs["score"] = [1, 0, 2]
-    df = personalized_pagerank_by_attribute(g, "score", calculate_uniform_dist=False)
-    assert "pagerank_uniform" not in df.columns
-    assert np.isclose(df["pagerank_by_attribute"].sum(), 1)
-
-
-def test_personalized_pagerank_by_attribute_missing_and_negative():
-    g = ig.Graph.Full(3)
-    g.vs["score"] = [1, None, 2]
-    # None should be treated as 0
-    df = personalized_pagerank_by_attribute(g, "score")
-    assert np.isclose(df["score"].sum(), 3)
-    # Negative values should raise
-    g.vs["score"] = [1, -1, 2]
-    with pytest.raises(ValueError):
-        personalized_pagerank_by_attribute(g, "score")
-
-
-def test_personalized_pagerank_by_attribute_additional_args_directed():
-    # create an asymmetric directed graph to test whether additional_propagation_args is respected
-    g = ig.Graph(directed=True)
-    g.add_vertices(3)
-    g.add_edges([(0, 1), (1, 2)])
-    g.vs["score"] = [1, 0, 2]
-    # Run with directed=False, which should treat the graph as undirected
-    df_directed = personalized_pagerank_by_attribute(
-        g, "score", additional_propagation_args={"directed": True}
+    # Test 1: Uniform null (should return ratios)
+    result_uniform = network_propagation_with_null(
+        graph, attributes, null_strategy="uniform"
     )
-    df_undirected = personalized_pagerank_by_attribute(
-        g, "score", additional_propagation_args={"directed": False}
+
+    # Check structure
+    assert isinstance(result_uniform, pd.DataFrame)
+    assert result_uniform.shape == (5, 1)
+    assert list(result_uniform.columns) == attributes
+    assert list(result_uniform.index) == ["A", "B", "C", "D", "E"]
+
+    # Should be ratios (can be > 1)
+    assert (result_uniform.values > 0).all(), "Ratios should be positive"
+    # Some ratios should be > 1 since observed scores concentrate on fewer nodes
+    assert (result_uniform.values > 1).any(), "Some ratios should be > 1"
+
+    # Test 2: Node permutation null (should return quantiles)
+    result_permutation = network_propagation_with_null(
+        graph,
+        attributes,
+        null_strategy="node_permutation",
+        n_samples=10,  # Small for testing
     )
-    # The results should differ for directed vs undirected
+
+    # Check structure
+    assert isinstance(result_permutation, pd.DataFrame)
+    assert result_permutation.shape == (5, 1)
+    assert list(result_permutation.columns) == attributes
+
+    # Should be quantiles (0 to 1)
+    assert (result_permutation.values >= 0).all(), "Quantiles should be >= 0"
+    assert (result_permutation.values <= 1).all(), "Quantiles should be <= 1"
+
+    # Test 3: Edge permutation null
+    result_edge = network_propagation_with_null(
+        graph,
+        attributes,
+        null_strategy="edge_permutation",
+        n_samples=5,
+        burn_in_ratio=2,  # Small for testing
+        sampling_ratio=0.2,
+    )
+
+    # Check structure
+    assert isinstance(result_edge, pd.DataFrame)
+    assert result_edge.shape == (5, 1)
+    assert (result_edge.values >= 0).all()
+    assert (result_edge.values <= 1).all()
+
+    # Test 4: Gaussian null
+    result_gaussian = network_propagation_with_null(
+        graph, attributes, null_strategy="gaussian", n_samples=8
+    )
+
+    # Check structure
+    assert isinstance(result_gaussian, pd.DataFrame)
+    assert result_gaussian.shape == (5, 1)
+    assert (result_gaussian.values >= 0).all()
+    assert (result_gaussian.values <= 1).all()
+
+    # Test 5: Custom propagation parameters
+    result_custom = network_propagation_with_null(
+        graph,
+        attributes,
+        null_strategy="uniform",
+        additional_propagation_args={"damping": 0.7},
+    )
+
+    # Should be different from default
     assert not np.allclose(
-        df_directed["pagerank_by_attribute"], df_undirected["pagerank_by_attribute"]
-    )
-    # Uniform should also be affected
-    assert not np.allclose(
-        df_directed["pagerank_uniform"], df_undirected["pagerank_uniform"]
+        result_uniform.values, result_custom.values
+    ), "Different propagation parameters should give different results"
+
+    # Test 6: Custom null parameters (mask)
+    mask_array = np.array([True, False, True, False, True])
+    result_masked = network_propagation_with_null(
+        graph,
+        attributes,
+        null_strategy="node_permutation",
+        n_samples=5,
+        mask=mask_array,
     )
 
+    # Should work without error
+    assert isinstance(result_masked, pd.DataFrame)
+    assert result_masked.shape == (5, 1)
 
-def test_personalized_pagerank_by_attribute_additional_args_invalid():
-    g = ig.Graph.Full(3)
-    g.vs["score"] = [1, 0, 2]
-    # Passing an invalid argument should raise ValueError
-    with pytest.raises(ValueError):
-        personalized_pagerank_by_attribute(
-            g, "score", additional_propagation_args={"not_a_real_arg": 123}
+    # Test 7: Error handling - invalid null strategy
+    with pytest.raises(ValueError, match="Unknown null strategy"):
+        network_propagation_with_null(
+            graph, attributes, null_strategy="invalid_strategy"
         )
 
 
-def test_personalized_pagerank_by_attribute_all_missing():
-    g = ig.Graph.Full(3)
-    # No 'score' attribute at all
-    with pytest.raises(ValueError, match="missing for all vertices"):
-        personalized_pagerank_by_attribute(g, "score")
+def test_net_propagate_attributes():
+    """Test net_propagate_attributes with multiple attributes and various scenarios."""
+    # Create test graph with edges for realistic propagation
+    graph = ig.Graph(4)
+    graph.vs["name"] = ["node1", "node2", "node3", "node4"]
+    graph.vs["attr1"] = [1.0, 0.0, 2.0, 0.0]  # Non-negative, not all zero
+    graph.vs["attr2"] = [0.5, 1.5, 0.0, 1.0]  # Non-negative, not all zero
+    graph.add_edges([(0, 1), (1, 2), (2, 3), (0, 3)])  # Create connected graph
 
+    # Test 1: Basic functionality with two attributes
+    result = net_propagate_attributes(graph, ["attr1", "attr2"])
 
-def test_personalized_pagerank_by_attribute_all_zero():
-    g = ig.Graph.Full(3)
-    g.vs["score"] = [0, 0, 0]
+    # Check structure
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape == (4, 2)
+    assert list(result.index) == ["node1", "node2", "node3", "node4"]
+    assert list(result.columns) == ["attr1", "attr2"]
+
+    # Check that values are valid probabilities (PPR returns probabilities)
+    assert np.all(result.values >= 0)
+    assert np.all(result.values <= 1)
+    # Each column should sum to approximately 1 (PPR property)
+    assert np.allclose(result.sum(axis=0), [1.0, 1.0], atol=1e-10)
+
+    # Test 2: Single attribute
+    result_single = net_propagate_attributes(graph, ["attr1"])
+    assert result_single.shape == (4, 1)
+    assert list(result_single.columns) == ["attr1"]
+
+    # Test 3: Graph without names (should use indices)
+    graph_no_names = ig.Graph(3)
+    graph_no_names.vs["attr1"] = [1.0, 2.0, 1.0]
+    graph_no_names.add_edges([(0, 1), (1, 2)])
+
+    result_no_names = net_propagate_attributes(graph_no_names, ["attr1"])
+    assert list(result_no_names.index) == [0, 1, 2]  # Should use integer indices
+
+    # Test 4: Invalid propagation method
+    with pytest.raises(ValueError, match="Invalid method"):
+        net_propagate_attributes(graph, ["attr1"], method="invalid_method")
+
+    # Test 5: Additional arguments (test damping parameter)
+    result_default = net_propagate_attributes(graph, ["attr1"])
+    result_damped = net_propagate_attributes(
+        graph, ["attr1"], additional_propagation_args={"damping": 0.5}  # Lower damping
+    )
+
+    # Results should be different with different damping
+    assert not np.allclose(result_default.values, result_damped.values)
+
+    # Test 6: Invalid attribute (should be caught by internal validation)
+    graph.vs["bad_attr"] = [-1.0, 1.0, 2.0, 0.0]  # Has negative values
+    with pytest.raises(ValueError, match="contains negative values"):
+        net_propagate_attributes(graph, ["bad_attr"])
+
+    # Test 7: Zero attribute (should be caught by internal validation)
+    graph.vs["zero_attr"] = [0.0, 0.0, 0.0, 0.0]
     with pytest.raises(ValueError, match="zero for all vertices"):
-        personalized_pagerank_by_attribute(g, "score")
+        net_propagate_attributes(graph, ["zero_attr"])
+
+
+def test_all_null_generators_structure():
+    """Test all null generators with default options and validate output structure."""
+    # Create test graph with edges for realistic propagation
+    graph = ig.Graph(5)
+    graph.vs["name"] = ["A", "B", "C", "D", "E"]
+    graph.vs["attr1"] = [1.0, 0.0, 2.0, 0.0, 1.5]  # Non-negative, not all zero
+    graph.vs["attr2"] = [0.5, 1.0, 0.0, 2.0, 0.0]  # Non-negative, not all zero
+    graph.add_edges([(0, 1), (1, 2), (2, 3), (3, 4)])
+
+    attributes = ["attr1", "attr2"]
+    n_samples = 3  # Small for testing
+
+    for generator_name, generator_func in NULL_GENERATORS.items():
+        print(f"Testing {generator_name}")
+
+        if generator_name == "uniform":
+            # Uniform null doesn't take n_samples
+            result = generator_func(graph, attributes)
+            expected_rows = 5  # One row per node
+        elif generator_name == "edge_permutation":
+            # Edge permutation has different parameters
+            result = generator_func(graph, attributes, n_samples=n_samples)
+            expected_rows = n_samples * 5  # n_samples rows per node
+        else:
+            # Gaussian and node_permutation
+            result = generator_func(graph, attributes, n_samples=n_samples)
+            expected_rows = n_samples * 5  # n_samples rows per node
+
+        # Validate structure
+        assert isinstance(
+            result, pd.DataFrame
+        ), f"{generator_name} should return DataFrame"
+        assert result.shape == (
+            expected_rows,
+            2,
+        ), f"{generator_name} wrong shape: {result.shape}"
+        assert list(result.columns) == attributes, f"{generator_name} wrong columns"
+
+        # Validate index structure
+        if generator_name == "uniform":
+            assert list(result.index) == [
+                "A",
+                "B",
+                "C",
+                "D",
+                "E",
+            ], f"{generator_name} wrong index"
+        else:
+            expected_index = ["A", "B", "C", "D", "E"] * n_samples
+            assert (
+                list(result.index) == expected_index
+            ), f"{generator_name} wrong repeated index"
+
+        # Validate values are numeric and finite (propagated outputs should be valid probabilities)
+        assert result.isna().sum().sum() == 0, f"{generator_name} contains NaN values"
+        assert np.isfinite(
+            result.values
+        ).all(), f"{generator_name} contains infinite values"
+        assert (result.values >= 0).all(), f"{generator_name} contains negative values"
+        assert (
+            result.values <= 1
+        ).all(), f"{generator_name} should contain probabilities <= 1"
+
+        # Each sample should sum to approximately 1 (PPR property)
+        if generator_name == "uniform":
+            assert np.allclose(
+                result.sum(axis=0), [1.0, 1.0], atol=1e-10
+            ), f"{generator_name} doesn't sum to 1"
+        else:
+            # For multiple samples, each individual sample should sum to 1
+            for i in range(n_samples):
+                start_idx = i * 5
+                end_idx = (i + 1) * 5
+                sample_data = result.iloc[start_idx:end_idx]
+                assert np.allclose(
+                    sample_data.sum(axis=0), [1.0, 1.0], atol=1e-10
+                ), f"{generator_name} sample {i} doesn't sum to 1"
+
+
+def test_mask_application():
+    """Test that masks are correctly applied across all null generators."""
+    # Create test graph
+    graph = ig.Graph(6)
+    graph.vs["name"] = ["A", "B", "C", "D", "E", "F"]
+    graph.vs["attr1"] = [1.0, 0.0, 2.0, 0.0, 1.5, 0.0]  # Nonzero at indices 0, 2, 4
+    graph.vs["attr2"] = [0.0, 1.0, 0.0, 2.0, 0.0, 1.0]  # Nonzero at indices 1, 3, 5
+    graph.add_edges([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)])
+
+    attributes = ["attr1", "attr2"]
+
+    # Test mask that includes nodes with nonzero values for both attributes
+    # Use nodes 0, 1, 2, 3 which covers nonzero values for both attributes
+    mask_array = np.array([True, True, True, True, False, False])  # Nodes 0, 1, 2, 3
+
+    for generator_name, generator_func in NULL_GENERATORS.items():
+        print(f"Testing mask application for {generator_name}")
+
+        if generator_name == "uniform":
+            result = generator_func(graph, attributes, mask=mask_array)
+
+            # For uniform null with mask, verify structure is correct
+            assert result.shape == (6, 2), f"{generator_name} wrong shape with mask"
+            # After propagation, all nodes will have some value due to network effect
+            assert (
+                result.values > 0
+            ).all(), "All nodes should have positive values after propagation"
+
+        elif generator_name == "edge_permutation":
+            # Edge permutation ignores mask, just test it doesn't crash
+            result = generator_func(graph, attributes, n_samples=2)
+            assert result.shape[0] == 12  # 2 samples * 6 nodes
+
+        else:
+            # Gaussian and node_permutation with mask
+            result = generator_func(graph, attributes, mask=mask_array, n_samples=2)
+
+            # Check that structure is maintained
+            assert result.shape == (12, 2)  # 2 samples * 6 nodes
+
+
+def test_edge_cases_and_errors():
+    """Test edge cases and error conditions for null generators."""
+    # Create minimal test graph
+    graph = ig.Graph(3)
+    graph.vs["attr1"] = [1.0, 2.0, 0.0]
+    graph.vs["bad_attr"] = [0.0, 0.0, 0.0]  # All zeros
+    graph.add_edges([(0, 1), (1, 2)])
+
+    # Test 1: All zero attribute should raise error for all generators
+    with pytest.raises(ValueError):
+        uniform_null(graph, ["bad_attr"])
+
+    with pytest.raises(ValueError):
+        gaussian_null(graph, ["bad_attr"])
+
+    with pytest.raises(ValueError):
+        node_permutation_null(graph, ["bad_attr"])
+
+    with pytest.raises(ValueError):
+        edge_permutation_null(graph, ["bad_attr"])
+
+    # Test 2: Empty mask should raise error
+    empty_mask = np.array([False, False, False])
+    with pytest.raises(ValueError, match="No nodes in mask"):
+        uniform_null(graph, ["attr1"], mask=empty_mask)
+
+    # Test 3: Single node mask (edge case)
+    single_mask = np.array([True, False, False])
+    result = uniform_null(graph, ["attr1"], mask=single_mask)
+    assert result.shape == (3, 1)  # Should work
+
+    # Test 4: Replace parameter in node permutation
+    result_no_replace = node_permutation_null(
+        graph, ["attr1"], replace=False, n_samples=2
+    )
+    result_replace = node_permutation_null(graph, ["attr1"], replace=True, n_samples=2)
+
+    # Both should have same structure
+    assert result_no_replace.shape == result_replace.shape
+
+
+def test_propagation_method_parameters():
+    """Test that propagation method and additional arguments are properly passed through."""
+    # Create test graph
+    graph = ig.Graph(4)
+    graph.vs["attr1"] = [1.0, 2.0, 0.0, 1.5]
+    graph.add_edges([(0, 1), (1, 2), (2, 3)])
+
+    # Test different damping parameters produce different results
+    result_default = uniform_null(graph, ["attr1"])
+    result_damped = uniform_null(
+        graph, ["attr1"], additional_propagation_args={"damping": 0.5}
+    )
+
+    # Results should be different with different damping
+    assert not np.allclose(
+        result_default.values, result_damped.values
+    ), "Different damping should produce different results"
+
+    # Test that all generators accept method parameters
+    for generator_name, generator_func in NULL_GENERATORS.items():
+        if generator_name == "uniform":
+            result = generator_func(
+                graph, ["attr1"], additional_propagation_args={"damping": 0.8}
+            )
+        else:
+            result = generator_func(
+                graph,
+                ["attr1"],
+                additional_propagation_args={"damping": 0.8},
+                n_samples=2,
+            )
+
+        # Should produce valid results
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+
+
+def test_validate_additional_propagation_args():
+    """Test _validate_additional_propagation_args with valid and invalid arguments."""
+    # Test 1: None input
+    result = _validate_additional_propagation_args("personalized_pagerank", None)
+    assert result == {}
+
+    # Test 2: Valid arguments (common PPR parameters)
+    valid_args = {"damping": 0.85, "directed": True}
+    result = _validate_additional_propagation_args("personalized_pagerank", valid_args)
+    assert result == valid_args
+
+    # Test 3: Invalid method
+    with pytest.raises(ValueError, match="Invalid method"):
+        _validate_additional_propagation_args("invalid_method", {})
+
+    # Test 4: Invalid argument for PPR
+    with pytest.raises(ValueError, match="Invalid argument for personalized_pagerank"):
+        _validate_additional_propagation_args(
+            "personalized_pagerank", {"invalid_arg": 123}
+        )

--- a/src/tests/test_network_net_propagation.py
+++ b/src/tests/test_network_net_propagation.py
@@ -4,18 +4,15 @@ import pandas as pd
 import igraph as ig
 from napistu.network.net_propagation import (
     net_propagate_attributes,
-    _validate_additional_propagation_args,
     uniform_null,
     parametric_null,
     node_permutation_null,
     edge_permutation_null,
     NULL_GENERATORS,
     network_propagation_with_null,
-    validate_net_propagation_engine_reqs,
 )
 from napistu.network.constants import (
     NAPISTU_GRAPH_VERTICES,
-    NET_PROPAGATION_DEFS,
     NULL_STRATEGIES,
 )
 
@@ -162,7 +159,7 @@ def test_net_propagate_attributes():
     assert list(result_no_names.index) == [0, 1, 2]  # Should use integer indices
 
     # Test 4: Invalid propagation method
-    with pytest.raises(ValueError, match="Invalid method"):
+    with pytest.raises(ValueError, match="Invalid propagation method"):
         net_propagate_attributes(graph, ["attr1"], propagation_method="invalid_method")
 
     # Test 5: Additional arguments (test damping parameter)
@@ -381,33 +378,3 @@ def test_propagation_method_parameters():
         # Should produce valid results
         assert isinstance(result, pd.DataFrame)
         assert not result.empty
-
-
-def test_validate_additional_propagation_args():
-    """Test _validate_additional_propagation_args with valid and invalid arguments."""
-    # Test 1: None input
-    result = _validate_additional_propagation_args(
-        NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK, None
-    )
-    assert result == {}
-
-    # Test 2: Valid arguments (common PPR parameters)
-    valid_args = {"damping": 0.85, "directed": True}
-    result = _validate_additional_propagation_args(
-        NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK, valid_args
-    )
-    assert result == valid_args
-
-    # Test 3: Invalid method
-    with pytest.raises(ValueError, match="Invalid method"):
-        _validate_additional_propagation_args("invalid_method", {})
-
-    # Test 4: Invalid argument for PPR
-    with pytest.raises(ValueError, match="Invalid argument for personalized_pagerank"):
-        _validate_additional_propagation_args(
-            NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK, {"invalid_arg": 123}
-        )
-
-
-def test_net_propagation_engine_reqs_valid():
-    validate_net_propagation_engine_reqs()

--- a/src/tests/test_statistics_quantiles.py
+++ b/src/tests/test_statistics_quantiles.py
@@ -1,0 +1,133 @@
+import pytest
+import numpy as np
+import pandas as pd
+from napistu.statistics import quantiles
+
+
+def test_calculate_quantiles_valid_inputs():
+    """Test calculate_quantiles with valid, well-formed inputs."""
+    # Create observed data: 4 features x 3 attributes
+    observed = pd.DataFrame(
+        [[0.8, 0.3, 0.9], [0.2, 0.7, 0.1], [0.5, 0.5, 0.5], [0.1, 0.9, 0.2]],
+        index=["gene1", "gene2", "gene3", "gene4"],
+        columns=["attr1", "attr2", "attr3"],
+    )
+
+    # Create null data: 2 samples per feature (8 rows total)
+    null_index = ["gene1", "gene2", "gene3", "gene4"] * 2
+    null_data = pd.DataFrame(
+        [
+            [0.1, 0.2, 0.3],  # gene1 sample 1
+            [0.4, 0.5, 0.6],  # gene2 sample 1
+            [0.7, 0.8, 0.9],  # gene3 sample 1
+            [0.0, 0.1, 0.2],  # gene4 sample 1
+            [0.2, 0.3, 0.4],  # gene1 sample 2
+            [0.5, 0.6, 0.7],  # gene2 sample 2
+            [0.8, 0.9, 1.0],  # gene3 sample 2
+            [0.1, 0.2, 0.3],  # gene4 sample 2
+        ],
+        index=null_index,
+        columns=["attr1", "attr2", "attr3"],
+    )
+
+    # Calculate quantiles
+    result = quantiles.calculate_quantiles(observed, null_data)
+
+    # Verify output structure
+    assert result.shape == observed.shape
+    assert list(result.index) == list(observed.index)
+    assert list(result.columns) == list(observed.columns)
+
+    # Check specific quantile calculations
+    # gene1, attr1: observed=0.8, nulls=[0.1, 0.2] -> quantile = 1.0 (100%)
+    assert result.loc["gene1", "attr1"] == 1.0
+
+    # gene2, attr2: observed=0.7, nulls=[0.5, 0.6] -> quantile = 1.0 (100%)
+    assert result.loc["gene2", "attr2"] == 1.0
+
+    # gene3, attr3: observed=0.5, nulls=[0.9, 1.0] -> quantile = 0.0 (0%)
+    assert result.loc["gene3", "attr3"] == 0.0
+
+    # gene4, attr1: observed=0.1, nulls=[0.0, 0.1]
+    # With ≤: 0.0 ≤ 0.1 (True), 0.1 ≤ 0.1 (True) → 2/2 = 1.0
+    assert result.loc["gene4", "attr1"] == 1.0
+
+
+def test_calculate_quantiles_error_cases():
+    """Test calculate_quantiles with invalid inputs that should raise errors or warnings."""
+    # Base observed data
+    observed = pd.DataFrame(
+        [[0.8, 0.3], [0.2, 0.7]], index=["gene1", "gene2"], columns=["attr1", "attr2"]
+    )
+
+    # Test 1: Mismatched columns
+    null_wrong_cols = pd.DataFrame(
+        [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+        index=["gene1", "gene2"],
+        columns=["attr1", "attr2", "attr3"],  # Extra column
+    )
+
+    with pytest.raises((KeyError, ValueError)):
+        quantiles.calculate_quantiles(observed, null_wrong_cols)
+
+    # Test 2: Missing features in null data
+    null_missing_feature = pd.DataFrame(
+        [[0.1, 0.2]], index=["gene1"], columns=["attr1", "attr2"]  # Missing gene2
+    )
+
+    # Current implementation doesn't validate - it will likely fail in groupby or indexing
+    # This test verifies current behavior (may change if validation added)
+    try:
+        result = quantiles.calculate_quantiles(observed, null_missing_feature)
+        # If it succeeds, gene2 quantiles will be invalid/error
+        assert True  # Just check it doesn't crash for now
+    except (KeyError, ValueError, IndexError):
+        assert True  # Expected behavior
+
+    # Test 3: Unequal null samples per feature
+    null_unequal_samples = pd.DataFrame(
+        [
+            [0.1, 0.2],  # gene1 sample 1
+            [0.3, 0.4],  # gene1 sample 2
+            [0.5, 0.6],  # gene2 sample 1 (only 1 sample)
+        ],
+        index=["gene1", "gene1", "gene2"],
+        columns=["attr1", "attr2"],
+    )
+
+    # This should still work but may give different results
+    result = quantiles.calculate_quantiles(observed, null_unequal_samples)
+    assert result.shape == observed.shape
+
+    # Test 4: Empty null data
+    null_empty = pd.DataFrame(columns=["attr1", "attr2"])
+
+    with pytest.raises((ValueError, IndexError)):
+        quantiles.calculate_quantiles(observed, null_empty)
+
+    # Test 5: Single null sample (edge case)
+    null_single = pd.DataFrame(
+        [[0.1, 0.2], [0.5, 0.6]], index=["gene1", "gene2"], columns=["attr1", "attr2"]
+    )
+
+    result = quantiles.calculate_quantiles(observed, null_single)
+    assert result.shape == observed.shape
+    # With single sample, results should be binary (0 or 1)
+    assert all(val in [0.0, 1.0] for val in result.values.flatten())
+
+    # Test 6: NaN values in data
+    observed_with_nan = observed.copy()
+    observed_with_nan.loc["gene1", "attr1"] = np.nan
+
+    null_with_nan = pd.DataFrame(
+        [[np.nan, 0.2], [0.4, 0.5], [0.1, 0.3], [0.6, 0.7]],
+        index=["gene1", "gene2", "gene1", "gene2"],
+        columns=["attr1", "attr2"],
+    )
+
+    # Should raise ValueError for NaN values
+    with pytest.raises(ValueError, match="NaN values found in observed data"):
+        quantiles.calculate_quantiles(observed_with_nan, null_single)
+
+    with pytest.raises(ValueError, match="NaN values found in null data"):
+        quantiles.calculate_quantiles(observed, null_with_nan)


### PR DESCRIPTION
- added 4 null distributions for network propagation.
    - uniform
    - parametric (fit a distribution to the values)
    - vertex permutation
    - edge permutation. Closes #133 

- all of the propagation methods can accept a boolean mask. This can be used to just shuffle the signals in a set of vertices (like measured proteins or metabolites). By default each attribute uses a mask of its non-zero values but this can be changed to create a null over all vertices, or mask one attribute with another (which would be helpful if apply network propagation to binary variables).
- added a performant function for comparing observed statistics to null quantiles.
- I did some testing with the edge permutation method and the implementation is solid but I don't think it will be too useful for the applications in #89.  

- These fixes were aimed to partially combat #131 but the solution to that was more direct.

- Updated artifact names. Closes #127 

Thanks for the feedback @votti ! I was able to address most of it. Closes #135 . One follow-on issue #136 
