### PR TITLE
Issue 136 - more details about network null distributions + switched to midrank for handling ties when calculating quantiles

### DIFF
--- a/src/napistu/network/constants.py
+++ b/src/napistu/network/constants.py
@@ -207,7 +207,7 @@ NET_PROPAGATION_DEFS = SimpleNamespace(PERSONALIZED_PAGERANK="personalized_pager
 NULL_STRATEGIES = SimpleNamespace(
     UNIFORM="uniform",
     PARAMETRIC="parametric",
-    NODE_PERMUTATION="node_permutation",
+    VERTEX_PERMUTATION="vertex_permutation",
     EDGE_PERMUTATION="edge_permutation",
 )
 

--- a/src/napistu/network/ig_utils.py
+++ b/src/napistu/network/ig_utils.py
@@ -494,7 +494,7 @@ def _get_attribute_masks(
 
 def _ensure_valid_attribute(graph: ig.Graph, attribute: str, non_negative: bool = True):
     """
-    Ensure a vertex attribute is present, numeric, and optionally non-negative for all vertices.
+    Ensure a vertex attribute is present, numeric, finite, and optionally non-negative for all vertices.
 
     This utility checks that the specified vertex attribute exists, is numeric, and (optionally) non-negative
     for all vertices in the graph. Missing or None values are treated as 0. Raises ValueError
@@ -542,5 +542,9 @@ def _ensure_valid_attribute(graph: ig.Graph, attribute: str, non_negative: bool 
         )
     if non_negative and np.any(arr < 0):
         raise ValueError(f"Attribute '{attribute}' contains negative values.")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(
+            f"Attribute '{attribute}' contains non-finite values (NaN or inf)."
+        )
 
     return arr

--- a/src/napistu/network/net_propagation.py
+++ b/src/napistu/network/net_propagation.py
@@ -50,6 +50,43 @@ def network_propagation_with_null(
     2. Generates null distribution using specified strategy
     3. Compares observed vs null using quantiles (for sampled nulls) or ratios (for uniform)
 
+    Null Strategy Selection
+    ----------------------
+    Two main approaches are used in network biology:
+
+    **Node permutation** ('node_permutation'): Permutes node labels/attributes while
+    preserving network topology. This tests whether individual nodes are significant
+    given the network structure. Standard approach for gene prioritization and
+    network-based gene set enrichment analysis.
+    Reference: Schulte-Sasse et al. (2019) BMC Bioinformatics 20:587
+
+    **Edge permutation** ('edge_permutation'): Rewires network edges while preserving
+    degree distribution. This tests whether network topology itself is significant.
+    Used when testing subnetwork patterns or connectivity significance.
+    Reference: Leiserson et al. (2015) Nature Genetics (HotNet2 methodology)
+
+    For vertex-level significance testing (gene prioritization), node permutation
+    is the appropriate null model as it preserves network structure while
+    randomizing signal assignment.
+
+    Other supported null strategies:
+
+    **Uniform ('uniform'):** A quick, qualitative readout. Generates a uniform null distribution over masked nodes and
+    takes the ratio of observed network propagation score.
+
+    **Parametric ('parametric'):** Similar to node permutation but rather than sampling observed values sample
+    draws from a distribution fit to the observed values. First fits a parametric distribution to the observed scores
+    and then samples `n_samples` null samples for each vertex to compare observed to null quantiles.
+
+    Creating Masks
+    --------------
+    Most null strategies benefit from including a mask which indicates which nodes are being tested.
+    For vertex permutation the parametric null only masked nodes will be considered for sampling.
+    Using a mask with uniform null strategy means that numeric reset probabilities will be compared to
+    constant ones by default. Masking is an important consideration for mitigating ascertainment bias.
+    If we are only sampling a subset of vertices like metabolites, we'll only consider those as sources
+    of signals in the null.
+
     Parameters
     ----------
     graph : ig.Graph

--- a/src/napistu/network/net_propagation.py
+++ b/src/napistu/network/net_propagation.py
@@ -34,12 +34,13 @@ class PropagationMethod:
 def network_propagation_with_null(
     graph: ig.Graph,
     attributes: List[str],
-    null_strategy: str = NULL_STRATEGIES.NODE_PERMUTATION,
+    null_strategy: str = NULL_STRATEGIES.VERTEX_PERMUTATION,
     propagation_method: Union[
         str, PropagationMethod
     ] = NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK,
     additional_propagation_args: Optional[dict] = None,
     n_samples: int = 100,
+    verbose: bool = False,
     **null_kwargs,
 ) -> pd.DataFrame:
     """
@@ -54,7 +55,7 @@ def network_propagation_with_null(
     ----------------------
     Two main approaches are used in network biology:
 
-    **Node permutation** ('node_permutation'): Permutes node labels/attributes while
+    **Vertex permutation** ('vertex_permutation'): Permutes node labels/attributes while
     preserving network topology. This tests whether individual nodes are significant
     given the network structure. Standard approach for gene prioritization and
     network-based gene set enrichment analysis.
@@ -94,13 +95,15 @@ def network_propagation_with_null(
     attributes : List[str]
         Attribute names to propagate and test.
     null_strategy : str
-        Null distribution strategy. One of: 'uniform', 'parametric', 'node_permutation', 'edge_permutation'.
+        Null distribution strategy. One of: 'uniform', 'parametric', 'vertex_permutation', 'edge_permutation'.
     propagation_method : str or PropagationMethod
         Network propagation method to apply.
     additional_propagation_args : dict, optional
         Additional arguments to pass to the network propagation method.
     n_samples : int
         Number of null samples to generate (ignored for uniform null).
+    verbose : bool, optional
+        Extra reporting. Default is False.
     **null_kwargs
         Additional arguments to pass to the null generator (e.g., mask, burn_in_ratio, etc.).
 
@@ -116,7 +119,7 @@ def network_propagation_with_null(
     >>> # Node permutation test with custom mask
     >>> result = network_propagation_with_null(
     ...     graph, ['gene_score'],
-    ...     null_strategy='node_permutation',
+    ...     null_strategy='vertex_permutation',
     ...     n_samples=1000,
     ...     mask='measured_genes'
     ... )
@@ -163,6 +166,7 @@ def network_propagation_with_null(
             propagation_method=propagation_method,
             additional_propagation_args=additional_propagation_args,
             n_samples=n_samples,
+            verbose=verbose,
             **null_kwargs,
         )
 
@@ -236,6 +240,7 @@ def uniform_null(
     ] = NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK,
     additional_propagation_args: Optional[dict] = None,
     mask: Optional[Union[str, np.ndarray, List, Dict]] = MASK_KEYWORDS.ATTR,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generate uniform null distribution over masked nodes and apply propagation method.
@@ -252,6 +257,8 @@ def uniform_null(
         Additional arguments to pass to the network propagation method.
     mask : str, np.ndarray, List, Dict, or None
         Mask specification. Default is "attr" (use each attribute as its own mask).
+    verbose : bool, optional
+        Extra reporting. Default is False.
 
     Returns
     -------
@@ -265,7 +272,7 @@ def uniform_null(
     _validate_vertex_attributes(graph, attributes, propagation_method)
 
     # Parse mask input
-    mask_specs = _parse_mask_input(mask, attributes)
+    mask_specs = _parse_mask_input(mask, attributes, verbose=verbose)
     masks = _get_attribute_masks(graph, mask_specs)
 
     # Create null graph with uniform attributes
@@ -310,6 +317,7 @@ def parametric_null(
     mask: Optional[Union[str, np.ndarray, List, Dict]] = MASK_KEYWORDS.ATTR,
     n_samples: int = 100,
     fit_kwargs: Optional[dict] = None,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generate parametric null distribution by fitting scipy.stats distribution to observed values.
@@ -337,6 +345,8 @@ def parametric_null(
         Common examples:
         - For gamma: {'floc': 0} to fix location at 0
         - For beta: {'floc': 0, 'fscale': 1} to fix support to [0,1]
+    verbose : bool, optional
+        Extra reporting. Default is False.
 
     Returns
     -------
@@ -372,7 +382,7 @@ def parametric_null(
     _validate_vertex_attributes(graph, attributes, propagation_method)
 
     # Parse mask input and get masks
-    mask_specs = _parse_mask_input(mask, attributes)
+    mask_specs = _parse_mask_input(mask, attributes, verbose=verbose)
     masks = _get_attribute_masks(graph, mask_specs)
 
     # Fit distribution parameters for each attribute
@@ -412,7 +422,7 @@ def parametric_null(
     return pd.DataFrame(all_data, index=full_index, columns=attributes)
 
 
-def node_permutation_null(
+def vertex_permutation_null(
     graph: ig.Graph,
     attributes: List[str],
     propagation_method: Union[
@@ -422,9 +432,10 @@ def node_permutation_null(
     mask: Optional[Union[str, np.ndarray, List, Dict]] = MASK_KEYWORDS.ATTR,
     replace: bool = False,
     n_samples: int = 100,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generate null distribution by permuting node attribute values and apply propagation method.
+    Generate null distribution by permuting vertex attribute values and apply propagation method.
 
     Parameters
     ----------
@@ -442,6 +453,8 @@ def node_permutation_null(
         Whether to sample with replacement.
     n_samples : int
         Number of null samples to generate.
+    verbose : bool, optional
+        Extra reporting. Default is False.
 
     Returns
     -------
@@ -454,7 +467,7 @@ def node_permutation_null(
     _validate_vertex_attributes(graph, attributes, propagation_method)
 
     # Parse mask input
-    mask_specs = _parse_mask_input(mask, attributes)
+    mask_specs = _parse_mask_input(mask, attributes, verbose=verbose)
     masks = _get_attribute_masks(graph, mask_specs)
 
     # Get original attribute values
@@ -522,6 +535,7 @@ def edge_permutation_null(
     burn_in_ratio: float = 10,
     sampling_ratio: float = 0.1,
     n_samples: int = 100,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generate null distribution by edge rewiring and apply propagation method.
@@ -542,6 +556,8 @@ def edge_permutation_null(
         Proportion of edges to rewire between samples.
     n_samples : int
         Number of null samples to generate.
+    verbose : bool, optional
+        Extra reporting. Default is False.
 
     Returns
     -------
@@ -593,7 +609,7 @@ def edge_permutation_null(
 NULL_GENERATORS = {
     NULL_STRATEGIES.UNIFORM: uniform_null,
     NULL_STRATEGIES.PARAMETRIC: parametric_null,
-    NULL_STRATEGIES.NODE_PERMUTATION: node_permutation_null,
+    NULL_STRATEGIES.VERTEX_PERMUTATION: vertex_permutation_null,
     NULL_STRATEGIES.EDGE_PERMUTATION: edge_permutation_null,
 }
 

--- a/src/tests/test_network_ig_utils.py
+++ b/src/tests/test_network_ig_utils.py
@@ -190,3 +190,11 @@ def test_ensure_nonnegative_vertex_attribute():
     # Test 5: Missing attribute
     with pytest.raises(ValueError, match="missing for all vertices"):
         ig_utils._ensure_valid_attribute(graph, "nonexistent_attr")
+
+    # Test 6: Non-finite values (NaN and inf)
+    graph.vs["nan_attr"] = [1.0, np.nan, 2.0, 0.0]
+    graph.vs["inf_attr"] = [1.0, np.inf, 2.0, 0.0]
+    with pytest.raises(ValueError, match="non-finite values"):
+        ig_utils._ensure_valid_attribute(graph, "nan_attr")
+    with pytest.raises(ValueError, match="non-finite values"):
+        ig_utils._ensure_valid_attribute(graph, "inf_attr")

--- a/src/tests/test_network_net_propagation.py
+++ b/src/tests/test_network_net_propagation.py
@@ -6,7 +6,7 @@ from napistu.network.net_propagation import (
     net_propagate_attributes,
     uniform_null,
     parametric_null,
-    node_permutation_null,
+    vertex_permutation_null,
     edge_permutation_null,
     NULL_GENERATORS,
     network_propagation_with_null,
@@ -47,7 +47,7 @@ def test_network_propagation_with_null():
     result_permutation = network_propagation_with_null(
         graph,
         attributes,
-        null_strategy=NULL_STRATEGIES.NODE_PERMUTATION,
+        null_strategy=NULL_STRATEGIES.VERTEX_PERMUTATION,
         n_samples=10,  # Small for testing
     )
 
@@ -113,7 +113,7 @@ def test_network_propagation_with_null():
     result_masked = network_propagation_with_null(
         graph,
         attributes,
-        null_strategy=NULL_STRATEGIES.NODE_PERMUTATION,
+        null_strategy=NULL_STRATEGIES.VERTEX_PERMUTATION,
         n_samples=5,
         mask=mask_array,
     )
@@ -214,7 +214,7 @@ def test_all_null_generators_structure():
             result = generator_func(graph, attributes, n_samples=n_samples)
             expected_rows = n_samples * 5  # n_samples rows per node
         else:
-            # Gaussian and node_permutation
+            # Gaussian and vertex_permutation
             result = generator_func(graph, attributes, n_samples=n_samples)
             expected_rows = n_samples * 5  # n_samples rows per node
 
@@ -303,7 +303,7 @@ def test_mask_application():
             assert result.shape[0] == 12  # 2 samples * 6 nodes
 
         else:
-            # Gaussian and node_permutation with mask
+            # Gaussian and vertex_permutation with mask
             result = generator_func(graph, attributes, mask=mask_array, n_samples=2)
 
             # Check that structure is maintained
@@ -326,7 +326,7 @@ def test_edge_cases_and_errors():
         parametric_null(graph, ["bad_attr"])
 
     with pytest.raises(ValueError):
-        node_permutation_null(graph, ["bad_attr"])
+        vertex_permutation_null(graph, ["bad_attr"])
 
     with pytest.raises(ValueError):
         edge_permutation_null(graph, ["bad_attr"])
@@ -342,10 +342,12 @@ def test_edge_cases_and_errors():
     assert result.shape == (3, 1)  # Should work
 
     # Test 4: Replace parameter in node permutation
-    result_no_replace = node_permutation_null(
+    result_no_replace = vertex_permutation_null(
         graph, ["attr1"], replace=False, n_samples=2
     )
-    result_replace = node_permutation_null(graph, ["attr1"], replace=True, n_samples=2)
+    result_replace = vertex_permutation_null(
+        graph, ["attr1"], replace=True, n_samples=2
+    )
 
     # Both should have same structure
     assert result_no_replace.shape == result_replace.shape

--- a/src/tests/test_network_net_propagation.py
+++ b/src/tests/test_network_net_propagation.py
@@ -57,8 +57,12 @@ def test_network_propagation_with_null():
     assert list(result_permutation.columns) == attributes
 
     # Should be quantiles (0 to 1)
-    assert (result_permutation.values >= 0).all(), "Quantiles should be >= 0"
-    assert (result_permutation.values <= 1).all(), "Quantiles should be <= 1"
+    # Drop NaNs before checking value range. NaNs can be introduced if a
+    # nodes PPR values with and without the null are all a constant which
+    # can come up in a small sample # testing situation
+    permutation_values = result_permutation.values[~np.isnan(result_permutation.values)]
+    assert (permutation_values >= 0).all(), "Quantiles should be >= 0"
+    assert (permutation_values <= 1).all(), "Quantiles should be <= 1"
 
     # Test 3: Edge permutation null
     result_edge = network_propagation_with_null(
@@ -73,8 +77,12 @@ def test_network_propagation_with_null():
     # Check structure
     assert isinstance(result_edge, pd.DataFrame)
     assert result_edge.shape == (5, 1)
-    assert (result_edge.values >= 0).all()
-    assert (result_edge.values <= 1).all()
+    # Drop NaNs before checking value range. NaNs can be introduced if a
+    # nodes PPR values with and without the null are all a constant which
+    # can come up in a small sample # testing situation
+    edge_values = result_edge.values[~np.isnan(result_edge.values)]
+    assert (edge_values >= 0).all()
+    assert (edge_values <= 1).all()
 
     # Test 4: Gaussian null
     result_parametric = network_propagation_with_null(


### PR DESCRIPTION
- I did some benchmarking of the various null strategies focusing on whether null signals (random Gamma) result in a Unif(0,1) distribution when comparing observed PPR values to null quantiles. I'll link the notebook in the next couple of days.

- this shows that vertex randomization and the parametric distribution (with an appropriate distribution) are both valid null distributions. Edge permutation isn't a great idea when trying to compare genic signals but it may be useful in assessing topology. Added documentation around these methods. Closes #136 

- The benchmarking highlighted that ties needed to be dealt with in a thoughtful way. In a Napistu network there may be many ties because the use of a directed network and masking will mean that  a vertex which doesn't start with signal (and thus is not included in the mask) and lacks ancestors with signal will have many ties. I added midrank scoring of ties which is the standard in R quantile functions. For network propagation, there may be cases where we are comparing zero to a null distribution which is also all zeros. In this case I returned a NaN because the the quantile is undefined (and I think it would kind of be dumb to have a bunch of p-values which are 0.5 disguising this issue).