### PR TITLE
Issue 69 - Formatting IntAct molecular interactions as SBML_dfs

### DIFF
--- a/src/napistu/ingestion/constants.py
+++ b/src/napistu/ingestion/constants.py
@@ -177,6 +177,8 @@ DEFAULT_INTACT_RELATIVE_WEIGHTS = {
 
 INTACT_PUBLICATION_SCORE_THRESHOLD = 7
 
+INTACT_REACTIONS_DATA_TBL_NAME = "intact"
+
 PSI_MI_ONTOLOGY_URL = "https://raw.githubusercontent.com/MICommunity/miscore/refs/heads/master/miscore/src/main/resources/psimiOntology.json"
 
 PSI_MI_SCORED_TERMS = SimpleNamespace(
@@ -193,6 +195,7 @@ PSI_MI_SCORED_TERMS = SimpleNamespace(
     POST_TRANSCRIPTIONAL_INTERFERENCE="post transcriptional interference",
     BIOCHEMICAL="biochemical",
     IMAGING_TECHNIQUE="imagining technique",
+    # other
     UNKNOWN="unknown",
 )
 
@@ -209,7 +212,6 @@ INTACT_TERM_SCORES = {
     PSI_MI_SCORED_TERMS.POST_TRANSCRIPTIONAL_INTERFERENCE: 0.10,
     PSI_MI_SCORED_TERMS.BIOCHEMICAL: 1.00,
     PSI_MI_SCORED_TERMS.IMAGING_TECHNIQUE: 0.33,
-    # other
     PSI_MI_SCORED_TERMS.UNKNOWN: 0.05,
 }
 

--- a/src/napistu/ingestion/constants.py
+++ b/src/napistu/ingestion/constants.py
@@ -133,13 +133,85 @@ PSI_MI_REFS = SimpleNamespace(
     PRIMARY_REF_ID="primary_ref_id",
 )
 
-INTACT_ONTOLOGY_CV_LOOKUP = {
-    "uniprotkb": ONTOLOGIES.UNIPROT,
-    # we actually don't want these GO IDs
-    ONTOLOGIES.GO: "ignored_go",
+PSI_MI_STUDY_TABLES = SimpleNamespace(
+    REACTION_SPECIES="reaction_species",
+    SPECIES="species",
+    SPECIES_IDENTIFIERS="species_identifiers",
+    STUDY_LEVEL_DATA="study_level_data",
+)
+
+PSI_MI_STUDY_TABLES_LIST = PSI_MI_STUDY_TABLES.__dict__.values()
+
+PSI_MI_MISSING_VALUE_STR = ""
+
+INTACT_ONTOLOGY_ALIASES = {ONTOLOGIES.UNIPROT: {"uniprotkb"}}
+
+VALID_INTACT_SECONDARY_ONTOLOGIES = {ONTOLOGIES.INTACT}
+
+INTACT_EXPERIMENTAL_ROLES = SimpleNamespace(BAIT="bait", PREY="prey")
+
+VALID_INTACT_EXPERIMENTAL_ROLES = {
+    INTACT_EXPERIMENTAL_ROLES.BAIT,
+    INTACT_EXPERIMENTAL_ROLES.PREY,
 }
 
-INTACT_ONTOLOGY_ENSEMBL_VAGUE = "ensembl"
+# adding scores and consolidating terms for IntAct
+
+INTACT_SCORES = SimpleNamespace(
+    ATTRIBUTE_TYPE="attribute_type",
+    ATTRIBUTE_VALUE="attribute_value",
+    SCORED_TERM="scored_term",
+    RAW_SCORE="raw_score",
+    N_PUBLICATIONS="n_publications",
+    PUBLICATION_SCORE="publication_score",
+    INTERACTION_METHOD_SCORE="interaction_method_score",
+    INTERACTION_TYPE_SCORE="interaction_type_score",
+    MI_SCORE="miscore",
+)
+
+DEFAULT_INTACT_RELATIVE_WEIGHTS = {
+    INTACT_SCORES.PUBLICATION_SCORE: 1.0,
+    INTACT_SCORES.INTERACTION_METHOD_SCORE: 1.0,
+    INTACT_SCORES.INTERACTION_TYPE_SCORE: 1.0,
+}
+
+INTACT_PUBLICATION_SCORE_THRESHOLD = 7
+
+PSI_MI_ONTOLOGY_URL = "https://raw.githubusercontent.com/MICommunity/miscore/refs/heads/master/miscore/src/main/resources/psimiOntology.json"
+
+PSI_MI_SCORED_TERMS = SimpleNamespace(
+    # Interaction types
+    GENETIC_INTERACTION="genetic interaction",
+    COLOCALIZATION="colocalization",
+    ASSOCIATION="association",
+    PHYSICAL_ASSOCIATION="physical association",
+    DIRECT_INTERACTION="direct interaction",
+    # Detection methods
+    BIOPHYSICAL="biophysical",
+    PROTEIN_COMPLEMENTATION_ASSAY="protein complementation assay",
+    GENETIC_INTERFERENCE="genetic interference",
+    POST_TRANSCRIPTIONAL_INTERFERENCE="post transcriptional interference",
+    BIOCHEMICAL="biochemical",
+    IMAGING_TECHNIQUE="imagining technique",
+    UNKNOWN="unknown",
+)
+
+# from https://github.com/MICommunity/miscore/blob/master/miscore/src/main/resources/scoreCategories.properties
+INTACT_TERM_SCORES = {
+    PSI_MI_SCORED_TERMS.GENETIC_INTERACTION: 0.10,
+    PSI_MI_SCORED_TERMS.COLOCALIZATION: 0.33,
+    PSI_MI_SCORED_TERMS.ASSOCIATION: 0.33,
+    PSI_MI_SCORED_TERMS.PHYSICAL_ASSOCIATION: 0.66,
+    PSI_MI_SCORED_TERMS.DIRECT_INTERACTION: 1.00,
+    PSI_MI_SCORED_TERMS.BIOPHYSICAL: 1.00,
+    PSI_MI_SCORED_TERMS.PROTEIN_COMPLEMENTATION_ASSAY: 0.66,
+    PSI_MI_SCORED_TERMS.GENETIC_INTERFERENCE: 0.10,
+    PSI_MI_SCORED_TERMS.POST_TRANSCRIPTIONAL_INTERFERENCE: 0.10,
+    PSI_MI_SCORED_TERMS.BIOCHEMICAL: 1.00,
+    PSI_MI_SCORED_TERMS.IMAGING_TECHNIQUE: 0.33,
+    # other
+    PSI_MI_SCORED_TERMS.UNKNOWN: 0.05,
+}
 
 # REACTOME
 REACTOME_SMBL_URL = "https://reactome.org/download/current/all_species.3.1.sbml.tgz"

--- a/src/napistu/ingestion/constants.py
+++ b/src/napistu/ingestion/constants.py
@@ -194,7 +194,7 @@ PSI_MI_SCORED_TERMS = SimpleNamespace(
     GENETIC_INTERFERENCE="genetic interference",
     POST_TRANSCRIPTIONAL_INTERFERENCE="post transcriptional interference",
     BIOCHEMICAL="biochemical",
-    IMAGING_TECHNIQUE="imagining technique",
+    IMAGING_TECHNIQUE="imaging technique",
     # other
     UNKNOWN="unknown",
 )

--- a/src/napistu/ingestion/intact.py
+++ b/src/napistu/ingestion/intact.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 import os
 import logging
+from typing import Dict, Set
 
 import igraph as ig
 import numpy as np
@@ -22,6 +24,7 @@ from napistu.ingestion.constants import (
     DEFAULT_INTACT_RELATIVE_WEIGHTS,
     INTACT_EXPERIMENTAL_ROLES,
     INTACT_PUBLICATION_SCORE_THRESHOLD,
+    INTACT_REACTIONS_DATA_TBL_NAME,
     INTACT_SCORES,
     INTACT_ONTOLOGY_ALIASES,
     INTACT_TERM_SCORES,
@@ -53,12 +56,17 @@ def download_intact_xmls(
 
     Parameters
     ----------
-    output_dir_path (str):
+    output_dir_path : str
         Local directory to create an unzip files into
-    latin_species (str):
-        The species name (Genus species) to work with
-    overwrite (bool):
-        Overwrite an existing output directory. Default: False
+    latin_species : str
+        The species name (e.g., "Homo sapiens") to work with
+    overwrite : bool, optional
+        Overwrite an existing output directory, by default False
+
+    Returns
+    -------
+    None
+        Files are downloaded and extracted to the specified directory
     """
 
     intact_species_basename = _get_intact_species_basename(latin_species)
@@ -92,7 +100,17 @@ def intact_to_sbml_dfs(
 
     Returns
     -------
-    sbml_dfs: sbml_dfs_core.SBML_dfs
+    sbml_dfs : sbml_dfs_core.SBML_dfs
+        SBML_dfs object containing the converted IntAct data
+
+    Raises
+    ------
+    ValueError
+        If intact_summaries does not contain the required tables
+    ValueError
+        If the provided species is not supported by IntAct
+    ValueError
+        If ontologies listed as valid secondary references are not in the Napistu controlled vocabulary
     """
 
     if set(intact_summaries.keys()) != set(PSI_MI_STUDY_TABLES_LIST):
@@ -141,12 +159,16 @@ def intact_to_sbml_dfs(
     scored_attribute_counts = _count_studies_with_scored_attributes(
         standardized_interaction_attrs
     )
-    # calculate publication, method, and type scores and weight them for the composite score
-    interaction_scores = _calculate_all_scores_vectorized(scored_attribute_counts)
 
     # create r_Identifiers objects and count citations and attributes
     interaction_edgelist_df_ids_and_counts = _define_edgelist_df_ids_and_counts(
         edgelist_w_study_metadata, alias_mapping, scored_attribute_counts
+    )
+
+    # calculate publication, method, and type scores and weight them for the composite score
+    interaction_scores = _calculate_all_scores_vectorized(
+        scored_attribute_counts,
+        interaction_edgelist_df_ids_and_counts[INTACT_SCORES.N_PUBLICATIONS],
     )
 
     interactions_edgelist = (
@@ -193,7 +215,7 @@ def intact_to_sbml_dfs(
             INTERACTION_EDGELIST_DEFS.DOWNSTREAM_SBO_TERM_NAME: SBOTERM_NAMES.INTERACTOR,
             SBML_DFS.R_ISREVERSIBLE: True,
         },
-        keep_reactions_data=True,
+        keep_reactions_data=INTACT_REACTIONS_DATA_TBL_NAME,
     )
 
     return sbml_dfs
@@ -222,6 +244,11 @@ def create_species_df(
         A lookup table mapping study_id and interactor_id to the molecular species name.
     species_df : pd.DataFrame
         The molecular species dataframe.
+
+    Raises
+    ------
+    ValueError
+        If the provided species is not supported by IntAct
     """
 
     # filter to just matchees within the same species
@@ -284,26 +311,31 @@ def _get_intact_species_basename(latin_species: str) -> str:
 
 
 def _filter_intact_xrefs(
-    intact_summaries: pd.DataFrame,
-    alias_mapping: dict[str, str],
-    valid_secondary_ontologies: set[str] = VALID_INTACT_SECONDARY_ONTOLOGIES,
+    intact_summaries: Dict[str, pd.DataFrame],
+    alias_mapping: Dict[str, str],
+    valid_secondary_ontologies: Set[str] = VALID_INTACT_SECONDARY_ONTOLOGIES,
 ) -> pd.DataFrame:
     """
     Filter IntAct species identifiers to only those which should be added as s_Identifiers.
 
     Parameters
     ----------
-    intact_summaries : pd.DataFrame
+    intact_summaries : Dict[str, pd.DataFrame]
         The IntAct summaries table.
-    alias_mapping : dict[str, str]
+    alias_mapping : Dict[str, str]
         A dictionary mapping from ontology aliases to the Napistu controlled vocabulary.
-    valid_secondary_ontologies : set[str], optional
-        A set of ontologies which are valid secondary references.
+    valid_secondary_ontologies : Set[str], optional
+        A set of ontologies which are valid secondary references, by default VALID_INTACT_SECONDARY_ONTOLOGIES
 
     Returns
     -------
     pd.DataFrame
         A DataFrame of IntAct species identifiers which should be added as s_Identifiers.
+
+    Raises
+    ------
+    ValueError
+        If ontologies listed as valid secondary references are not in the Napistu controlled vocabulary
     """
 
     invalid_valid_secondary_ontologies = set(valid_secondary_ontologies) - set(
@@ -366,7 +398,9 @@ def _filter_intact_xrefs(
     return valid_xrefs
 
 
-def _log_invalid_primary_refs(primary_refs: pd.DataFrame, invalid_ontologies: set):
+def _log_invalid_primary_refs(
+    primary_refs: pd.DataFrame, invalid_ontologies: Set[str]
+) -> None:
 
     invalid_ontologies_counts = primary_refs[
         primary_refs[IDENTIFIERS.ONTOLOGY].isin(invalid_ontologies)
@@ -387,19 +421,19 @@ def _log_invalid_primary_refs(primary_refs: pd.DataFrame, invalid_ontologies: se
 
 
 def _create_basic_edgelist(
-    intact_summaries: dict[str, pd.DataFrame], lookup_table: pd.Series
+    intact_summaries: Dict[str, pd.DataFrame], lookup_table: pd.Series
 ) -> pd.DataFrame:
     """
     Create a basic edgelist from the IntAct summaries and lookup table.
 
     The edgelist is created by merging the IntAct summaries and lookup table on the study id and interaction id.
     The edgelist is then filtered to only include interactions where the bait is present and the prey is present.
-    The edgelist is then pivoted to based on the hub and spoke model usecd by IntAct, where a single bait is connected
+    The edgelist is then pivoted based on the hub and spoke model used by IntAct, where a single bait is connected
     to one or more prey.
 
     Parameters
     ----------
-    intact_summaries : dict[str, pd.DataFrame]
+    intact_summaries : Dict[str, pd.DataFrame]
         A dictionary of IntAct summaries, keyed by study id.
     lookup_table : pd.Series
         A lookup table of interaction ids and their corresponding interaction names.
@@ -413,6 +447,18 @@ def _create_basic_edgelist(
         - interaction_name : the name of the interaction
         - study_id : the id of the study
         - interaction_type : the type of interaction
+
+    Notes
+    -----
+    The convention of associating each bait to many prey follows conventions set by
+    yeast 2 hybrid screens but it is applied across the board even for technologies
+    when bait-prey relationships are not appropriate (e.g., purifying a whole complex).
+    In these cases IntAct chooses a random component to serve as the prey. This will make
+    it more closely related in a network sense than its interactors than they would be
+    to one another. This could be addressed by expanding interactions but this would  be
+    quite tricky because some interactions have 100s of prey and (N choose 2) would be
+    cumbersome. This could be done for just certain types of annotations but it seems
+    like a big headache for very little practical gain.
     """
 
     interactions = (
@@ -557,7 +603,7 @@ def _standardize_interaction_attrs(
     return tall_standardized_interaction_attrs
 
 
-def _build_psi_mi_ontology_graph(ontology_url: str = PSI_MI_ONTOLOGY_URL):
+def _build_psi_mi_ontology_graph(ontology_url: str = PSI_MI_ONTOLOGY_URL) -> ig.Graph:
     """Parse MI ontology JSON from URL and build igraph directed graph."""
     # Fetch JSON from URL
     response = requests.get(ontology_url)
@@ -593,8 +639,8 @@ def _build_psi_mi_ontology_graph(ontology_url: str = PSI_MI_ONTOLOGY_URL):
 
 
 def _get_intact_term_with_score(
-    ontology_graph: ig.Graph, scored_terms: dict[str, float]
-) -> dict[str, str]:
+    ontology_graph: ig.Graph, scored_terms: Dict[str, float]
+) -> Dict[str, str]:
     """Build lookup mapping all terms to their scored ancestor names."""
     term_lookup = {}
 
@@ -628,7 +674,7 @@ def _get_intact_term_with_score(
     return term_lookup
 
 
-def _get_intact_scored_term(term_name: str, term_lookup: dict[str, str]) -> str:
+def _get_intact_scored_term(term_name: str, term_lookup: Dict[str, str]) -> str:
     """Get the scored ancestor term name for a given term."""
     return term_lookup.get(term_name, PSI_MI_SCORED_TERMS.UNKNOWN)
 
@@ -641,7 +687,7 @@ def _count_studies_with_scored_attributes(
 
     Parameters
     ----------
-    df_long : pd.DataFrame
+    standardized_interaction_attrs : pd.DataFrame
         Long-form dataframe with columns: upstream_name, downstream_name,
         study_id, attribute_type, scored_term, score
 
@@ -681,11 +727,42 @@ def _count_studies_with_scored_attributes(
 
 
 def _calculate_all_scores_vectorized(
-    counts_df,
-    max_pubs=INTACT_PUBLICATION_SCORE_THRESHOLD,
-    weights: dict[str, float] = DEFAULT_INTACT_RELATIVE_WEIGHTS,
-):
-    """Calculate all MIscore components using vectorized operations."""
+    counts_df: pd.DataFrame,
+    n_publications_series: pd.Series,
+    max_pubs: int = INTACT_PUBLICATION_SCORE_THRESHOLD,
+    weights: Dict[str, float] = DEFAULT_INTACT_RELATIVE_WEIGHTS,
+) -> pd.DataFrame:
+    """
+    Calculate all MIscore components using vectorized operations.
+
+    Note: This implementation follows the MIscore mathematical formulas from
+    Villaveces et al. (2015), but has not been validated against published
+    IntAct scores due to lack of detailed worked examples showing:
+    - Specific interaction evidence (X studies of type Y using method Z)
+    - The resulting component scores
+    - The final MIscore
+
+    Parameters
+    ----------
+    counts_df : pd.DataFrame
+        DataFrame containing interaction counts and scores
+    n_publications_series : pd.Series
+        Series containing publication counts for each interaction
+    max_pubs : int, optional
+        Maximum publication threshold for scoring, by default INTACT_PUBLICATION_SCORE_THRESHOLD
+    weights : dict[str, float], optional
+        Dictionary of weights for different score components, by default DEFAULT_INTACT_RELATIVE_WEIGHTS
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing all calculated scores for each interaction
+
+    Raises
+    ------
+    ValueError
+        If the weights dictionary does not contain the expected keys
+    """
 
     expected_weighted_keys = DEFAULT_INTACT_RELATIVE_WEIGHTS.keys()
     if set(weights.keys()) != set(expected_weighted_keys):
@@ -701,8 +778,16 @@ def _calculate_all_scores_vectorized(
         ]
     ].drop_duplicates()
 
-    # Calculate publication scores
-    pub_scores = calculate_publication_scores_vectorized(counts_df, max_pubs)
+    # Calculate publication scores from the Series
+    pub_scores = n_publications_series.to_frame(
+        INTACT_SCORES.N_PUBLICATIONS
+    ).reset_index()
+    pub_scores[INTACT_SCORES.PUBLICATION_SCORE] = np.where(
+        pub_scores[INTACT_SCORES.N_PUBLICATIONS] > max_pubs,
+        1.0,
+        np.log(pub_scores[INTACT_SCORES.N_PUBLICATIONS] + 1) / np.log(max_pubs + 1),
+    )
+    pub_scores = pub_scores.drop(columns=[INTACT_SCORES.N_PUBLICATIONS])
 
     # Calculate method scores
     method_scores = calculate_category_scores_vectorized(
@@ -715,34 +800,34 @@ def _calculate_all_scores_vectorized(
     )
 
     # Merge all scores together
-    result = interactions
-    result = result.merge(
-        pub_scores,
-        on=[
-            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
-            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
-        ],
-        how="left",
+    result = (
+        interactions.merge(
+            pub_scores,
+            on=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ],
+            how="left",
+        )
+        .merge(
+            method_scores,
+            on=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ],
+            how="left",
+        )
+        .merge(
+            type_scores,
+            on=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ],
+            how="left",
+        )
+        # Fill missing scores with 0
+        .fillna(0.0)
     )
-    result = result.merge(
-        method_scores,
-        on=[
-            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
-            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
-        ],
-        how="left",
-    )
-    result = result.merge(
-        type_scores,
-        on=[
-            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
-            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
-        ],
-        how="left",
-    )
-
-    # Fill missing scores with 0
-    result = result.fillna(0.0)
 
     # Calculate final MIscore
     total_weight = sum(weights.values())
@@ -759,20 +844,43 @@ def _calculate_all_scores_vectorized(
 
 
 def calculate_publication_scores_vectorized(
-    counts_df, max_pubs=INTACT_PUBLICATION_SCORE_THRESHOLD
-):
-    """Calculate publication scores for all interactions using vectorized operations."""
-    # Sum counts by interaction to get total publications per interaction
+    counts_df: pd.DataFrame, max_pubs: int = INTACT_PUBLICATION_SCORE_THRESHOLD
+) -> pd.DataFrame:
+    """
+    Calculate publication scores for all interactions using vectorized operations.
+
+    Parameters
+    ----------
+    counts_df : pd.DataFrame
+        DataFrame containing interaction data
+    max_pubs : int, optional
+        Maximum publication threshold for scoring, by default uses the published value of 7.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing publication scores for each interaction
+    """
+    # Drop duplicates to get unique studies per interaction
+    unique_studies_w_interaction = counts_df[
+        [
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            PSI_MI_DEFS.STUDY_ID,
+        ]
+    ].drop_duplicates()
+
+    # Count unique studies (publications) per interaction
     pub_counts = (
-        counts_df.groupby(
+        unique_studies_w_interaction.groupby(
             [
                 INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
                 INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
             ]
-        )["count"]
-        .sum()
+        )
+        .size()
         .reset_index()
-        .rename(columns={"count": INTACT_SCORES.N_PUBLICATIONS})
+        .rename(columns={0: INTACT_SCORES.N_PUBLICATIONS})
     )
 
     # Vectorized publication score calculation: log(n+1) / log(b+1)
@@ -791,8 +899,24 @@ def calculate_publication_scores_vectorized(
     ]
 
 
-def calculate_category_scores_vectorized(counts_df, attribute_type):
-    """Calculate method or type scores for all interactions using vectorized operations."""
+def calculate_category_scores_vectorized(
+    counts_df: pd.DataFrame, attribute_type: str
+) -> pd.DataFrame:
+    """
+    Calculate method or type scores for all interactions using vectorized operations.
+
+    Parameters
+    ----------
+    counts_df : pd.DataFrame
+        DataFrame containing interaction data
+    attribute_type : str
+        Type of attribute to calculate scores for (e.g., 'interaction_method', 'interaction_type')
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing category scores for each interaction
+    """
     # Filter to specific attribute type
     filtered_df = counts_df[
         counts_df[INTACT_SCORES.ATTRIBUTE_TYPE] == attribute_type
@@ -872,7 +996,7 @@ def calculate_category_scores_vectorized(counts_df, attribute_type):
 
 def _define_edgelist_df_ids_and_counts(
     edgelist_w_study_metadata: pd.DataFrame,
-    alias_mapping: dict[str, str],
+    alias_mapping: Dict[str, str],
     scored_attribute_counts: pd.DataFrame,
 ) -> pd.DataFrame:
     """
@@ -965,6 +1089,9 @@ def _create_r_identifiers(group_data: pd.DataFrame) -> Identifiers:
         A dataframe with the study metadata.
 
     Returns
+    -------
+    Identifiers
+        An Identifiers object containing the interaction identifiers
     """
 
     interaction_dict = [

--- a/src/napistu/ingestion/intact.py
+++ b/src/napistu/ingestion/intact.py
@@ -1,15 +1,41 @@
 import os
 import logging
 
+import igraph as ig
+import numpy as np
 import pandas as pd
+import requests
 
 from napistu import utils
+from napistu import sbml_dfs_core
+from napistu import sbml_dfs_utils
+from napistu.ontologies import renaming
 from napistu.identifiers import Identifiers
-from napistu.constants import IDENTIFIERS, SBML_DFS
+from napistu.constants import (
+    BQB,
+    IDENTIFIERS,
+    ONTOLOGIES_LIST,
+    SBML_DFS,
+    SBOTERM_NAMES,
+)
 from napistu.ingestion.constants import (
+    DEFAULT_INTACT_RELATIVE_WEIGHTS,
+    INTACT_EXPERIMENTAL_ROLES,
+    INTACT_PUBLICATION_SCORE_THRESHOLD,
+    INTACT_SCORES,
+    INTACT_ONTOLOGY_ALIASES,
+    INTACT_TERM_SCORES,
+    INTERACTION_EDGELIST_DEFS,
     PSI_MI_DEFS,
     PSI_MI_INTACT_FTP_URL,
     PSI_MI_INTACT_SPECIES_TO_BASENAME,
+    PSI_MI_MISSING_VALUE_STR,
+    PSI_MI_ONTOLOGY_URL,
+    PSI_MI_SCORED_TERMS,
+    PSI_MI_STUDY_TABLES,
+    PSI_MI_STUDY_TABLES_LIST,
+    VALID_INTACT_EXPERIMENTAL_ROLES,  # noqa: F401
+    VALID_INTACT_SECONDARY_ONTOLOGIES,
 )
 
 logger = logging.getLogger(__name__)
@@ -49,6 +75,128 @@ def download_intact_xmls(
         download_method="ftp",
         overwrite=overwrite,
     )
+
+
+def intact_to_sbml_dfs(
+    intact_summaries: dict[str, pd.DataFrame], latin_species: str
+) -> sbml_dfs_core.SBML_dfs:
+    """
+    Convert IntAct summaries to SBML_dfs
+
+    Parameters
+    ----------
+    intact_summaries : dict[str, pd.DataFrame]
+        A dictionary of IntAct summaries.
+    latin_species : str
+        The latin species name (e.g. "Homo sapiens") pertaining to the IntAct interactions
+
+    Returns
+    -------
+    sbml_dfs: sbml_dfs_core.SBML_dfs
+    """
+
+    if set(intact_summaries.keys()) != set(PSI_MI_STUDY_TABLES_LIST):
+        raise ValueError(
+            f"IntAct summaries must contain the following tables: {PSI_MI_STUDY_TABLES_LIST}"
+        )
+
+    aliases = renaming.OntologySet(ontologies=INTACT_ONTOLOGY_ALIASES).ontologies
+    alias_mapping = renaming._create_alias_mapping(aliases)
+
+    valid_intact_xrefs = _filter_intact_xrefs(
+        intact_summaries, alias_mapping, VALID_INTACT_SECONDARY_ONTOLOGIES
+    )
+
+    # filter to entries with valid xrefs
+    valid_interactors = intact_summaries[PSI_MI_STUDY_TABLES.SPECIES].merge(
+        valid_intact_xrefs[
+            [PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTOR_ID]
+        ].drop_duplicates(),
+        how="inner",
+    )
+
+    lookup_table, species_df = create_species_df(
+        valid_interactors, valid_intact_xrefs, latin_species
+    )
+
+    # turn reaction_species into a bait <-> prey edgelist
+    basic_edgelist = _create_basic_edgelist(intact_summaries, lookup_table)
+
+    edgelist_w_study_metadata = basic_edgelist.merge(
+        intact_summaries[PSI_MI_STUDY_TABLES.STUDY_LEVEL_DATA][
+            [
+                PSI_MI_DEFS.STUDY_ID,
+                PSI_MI_DEFS.INTERACTION_METHOD,
+                IDENTIFIERS.ONTOLOGY,
+                IDENTIFIERS.IDENTIFIER,
+            ]
+        ]
+    )
+
+    # convert from specified attributes to standardized attributes with associated scores
+    standardized_interaction_attrs = _standardize_interaction_attrs(
+        edgelist_w_study_metadata
+    )
+    # deduplicate and count the number of studies with scored attributes
+    scored_attribute_counts = _count_studies_with_scored_attributes(
+        standardized_interaction_attrs
+    )
+    # calculate publication, method, and type scores and weight them for the composite score
+    interaction_scores = _calculate_all_scores_vectorized(scored_attribute_counts)
+
+    # create r_Identifiers objects and count citations and attributes
+    interaction_edgelist_df_ids_and_counts = _define_edgelist_df_ids_and_counts(
+        edgelist_w_study_metadata, alias_mapping, scored_attribute_counts
+    )
+
+    interactions_edgelist = (
+        edgelist_w_study_metadata[
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+                PSI_MI_DEFS.INTERACTION_NAME,
+            ]
+        ]
+        .rename(columns={PSI_MI_DEFS.INTERACTION_NAME: SBML_DFS.R_NAME})
+        .groupby(
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ]
+        )
+        .first()
+        .reset_index()
+        .merge(
+            interaction_scores,
+            on=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ],
+            how="left",
+        )
+        .merge(
+            interaction_edgelist_df_ids_and_counts,
+            on=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ],
+            how="left",
+        )
+    )
+
+    sbml_dfs = sbml_dfs_core.sbml_dfs_from_edgelist(
+        interactions_edgelist,
+        species_df,
+        compartments_df=sbml_dfs_utils.stub_compartments(),
+        interaction_edgelist_defaults={
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_SBO_TERM_NAME: SBOTERM_NAMES.INTERACTOR,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_SBO_TERM_NAME: SBOTERM_NAMES.INTERACTOR,
+            SBML_DFS.R_ISREVERSIBLE: True,
+        },
+        keep_reactions_data=True,
+    )
+
+    return sbml_dfs
 
 
 def create_species_df(
@@ -116,9 +264,9 @@ def create_species_df(
         .reset_index()
     )
 
-    lookup_table = valid_species_df.set_index(
-        [PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTOR_ID]
-    )[PSI_MI_DEFS.INTERACTOR_LABEL]
+    lookup_table = valid_species_df.rename(
+        columns={PSI_MI_DEFS.INTERACTOR_LABEL: SBML_DFS.S_NAME}
+    ).set_index([PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTOR_ID])[SBML_DFS.S_NAME]
 
     return lookup_table, species_df
 
@@ -133,3 +281,699 @@ def _get_intact_species_basename(latin_species: str) -> str:
         )
 
     return PSI_MI_INTACT_SPECIES_TO_BASENAME[latin_species]
+
+
+def _filter_intact_xrefs(
+    intact_summaries: pd.DataFrame,
+    alias_mapping: dict[str, str],
+    valid_secondary_ontologies: set[str] = VALID_INTACT_SECONDARY_ONTOLOGIES,
+) -> pd.DataFrame:
+    """
+    Filter IntAct species identifiers to only those which should be added as s_Identifiers.
+
+    Parameters
+    ----------
+    intact_summaries : pd.DataFrame
+        The IntAct summaries table.
+    alias_mapping : dict[str, str]
+        A dictionary mapping from ontology aliases to the Napistu controlled vocabulary.
+    valid_secondary_ontologies : set[str], optional
+        A set of ontologies which are valid secondary references.
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame of IntAct species identifiers which should be added as s_Identifiers.
+    """
+
+    invalid_valid_secondary_ontologies = set(valid_secondary_ontologies) - set(
+        ONTOLOGIES_LIST
+    )
+    if len(invalid_valid_secondary_ontologies) > 0:
+        raise ValueError(
+            f"The following ontologies are listed as valid secondary references but they are not in the Napistu controlled vocabulary (ONTOLOGIES_LIST): {invalid_valid_secondary_ontologies}"
+        )
+
+    # pull out the raw species identifiers table
+    standardized_intact_xrefs = intact_summaries[
+        PSI_MI_STUDY_TABLES.SPECIES_IDENTIFIERS
+    ]
+
+    # drop entries which are missing either their ontology or identifiers
+    valid_xref_mask = (
+        standardized_intact_xrefs[IDENTIFIERS.ONTOLOGY] != PSI_MI_MISSING_VALUE_STR
+    ) & (standardized_intact_xrefs[IDENTIFIERS.IDENTIFIER] != PSI_MI_MISSING_VALUE_STR)
+
+    if sum(~valid_xref_mask) > 0:
+        logger.warning(
+            f"Dropping {sum(~valid_xref_mask)} species identifiers which are missing either their ontology or identifier."
+        )
+
+    standardized_intact_xrefs = standardized_intact_xrefs[valid_xref_mask]
+
+    # convert ontologies into the Napistu controlled vocabulary
+    standardized_intact_xrefs[IDENTIFIERS.ONTOLOGY] = standardized_intact_xrefs[
+        IDENTIFIERS.ONTOLOGY
+    ].map(lambda x: alias_mapping.get(x, x))
+
+    # format primary references
+    primary_refs = standardized_intact_xrefs[
+        standardized_intact_xrefs[PSI_MI_DEFS.REF_TYPE] == PSI_MI_DEFS.PRIMARY
+    ]
+    # all entries in primary refs should have a valid ontology
+    invalid_ontologies = set(primary_refs[IDENTIFIERS.ONTOLOGY]) - set(ONTOLOGIES_LIST)
+    if len(invalid_ontologies) > 0:
+        _log_invalid_primary_refs(primary_refs, invalid_ontologies)
+        primary_refs = primary_refs[
+            ~primary_refs[IDENTIFIERS.ONTOLOGY].isin(invalid_ontologies)
+        ]
+
+    # only look at a subset of the secondary references
+    # including additional ontologies to this set results in (rediculous) overmerging of species
+    # when creating consensus models where species are defined by their s_Identifiers
+    secondary_refs = standardized_intact_xrefs[
+        standardized_intact_xrefs[PSI_MI_DEFS.REF_TYPE] == PSI_MI_DEFS.SECONDARY
+    ].query("ontology in @VALID_INTACT_SECONDARY_ONTOLOGIES")
+    # drop entries which are missing their primary ref
+    secondary_refs = secondary_refs.merge(
+        primary_refs[[PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTOR_ID]], how="inner"
+    )
+
+    valid_xrefs = pd.concat([primary_refs, secondary_refs]).assign(
+        **{IDENTIFIERS.BQB: BQB.IS}
+    )
+
+    return valid_xrefs
+
+
+def _log_invalid_primary_refs(primary_refs: pd.DataFrame, invalid_ontologies: set):
+
+    invalid_ontologies_counts = primary_refs[
+        primary_refs[IDENTIFIERS.ONTOLOGY].isin(invalid_ontologies)
+    ].value_counts(IDENTIFIERS.ONTOLOGY)
+
+    invalid_ontologies_str = ", ".join(
+        [
+            f"{ontology} (N={count})"
+            for ontology, count in invalid_ontologies_counts.items()
+        ]
+    )
+
+    logger.warning(
+        "The following ontologies are listed as primary species references but they are not\n"
+        "in the Napistu controlled vocabulary (ONTOLOGIES_LIST). These species and their interactions will be ignored:\n"
+        f"{invalid_ontologies_str}"
+    )
+
+
+def _create_basic_edgelist(
+    intact_summaries: dict[str, pd.DataFrame], lookup_table: pd.Series
+) -> pd.DataFrame:
+    """
+    Create a basic edgelist from the IntAct summaries and lookup table.
+
+    The edgelist is created by merging the IntAct summaries and lookup table on the study id and interaction id.
+    The edgelist is then filtered to only include interactions where the bait is present and the prey is present.
+    The edgelist is then pivoted to based on the hub and spoke model usecd by IntAct, where a single bait is connected
+    to one or more prey.
+
+    Parameters
+    ----------
+    intact_summaries : dict[str, pd.DataFrame]
+        A dictionary of IntAct summaries, keyed by study id.
+    lookup_table : pd.Series
+        A lookup table of interaction ids and their corresponding interaction names.
+
+    Returns
+    -------
+    edgelist_df : pd.DataFrame
+        A dataframe of the edgelist with the following columns:
+        - upstream_name : the name of the upstream node
+        - downstream_name : the name of the downstream node
+        - interaction_name : the name of the interaction
+        - study_id : the id of the study
+        - interaction_type : the type of interaction
+    """
+
+    interactions = (
+        intact_summaries[PSI_MI_STUDY_TABLES.REACTION_SPECIES]
+        .merge(
+            lookup_table,
+            on=[PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTOR_ID],
+            how="inner",
+        )
+        .query("experimental_role in @VALID_INTACT_EXPERIMENTAL_ROLES")
+    )
+
+    # the hub and spoke model connects a single bait to 1 or more prey
+    # following the conventions yeast 2 hybrid screens
+    valid_interactions_structure = (
+        interactions.value_counts(
+            [
+                PSI_MI_DEFS.STUDY_ID,
+                PSI_MI_DEFS.INTERACTION_NAME,
+                PSI_MI_DEFS.EXPERIMENTAL_ROLE,
+            ]
+        )
+        .to_frame()
+        .pivot_table(
+            index=[PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTION_NAME],
+            columns=PSI_MI_DEFS.EXPERIMENTAL_ROLE,
+            values="count",  # or whatever your count column is called
+            fill_value=0,  # fill missing values with 0
+        )
+        .query(
+            f"{INTACT_EXPERIMENTAL_ROLES.PREY} >= 1 & {INTACT_EXPERIMENTAL_ROLES.BAIT} == 1"
+        )
+    )
+
+    valid_reaction_species = interactions.merge(
+        valid_interactions_structure,
+        left_on=[PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTION_NAME],
+        right_index=True,
+    ).drop(columns=[INTACT_EXPERIMENTAL_ROLES.BAIT, INTACT_EXPERIMENTAL_ROLES.PREY])
+
+    all_prey = (
+        valid_reaction_species.query(
+            "experimental_role == @INTACT_EXPERIMENTAL_ROLES.PREY"
+        ).rename(columns={SBML_DFS.S_NAME: INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME})
+    )[
+        [
+            PSI_MI_DEFS.STUDY_ID,
+            PSI_MI_DEFS.INTERACTION_NAME,
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+        ]
+    ]
+
+    all_bait = (
+        valid_reaction_species.query(
+            "experimental_role == @INTACT_EXPERIMENTAL_ROLES.BAIT"
+        ).rename(columns={SBML_DFS.S_NAME: INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME})
+    )[
+        [
+            PSI_MI_DEFS.STUDY_ID,
+            PSI_MI_DEFS.INTERACTION_NAME,
+            PSI_MI_DEFS.INTERACTION_TYPE,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ]
+    ]
+
+    edgelist_df = all_prey.merge(
+        all_bait, on=[PSI_MI_DEFS.STUDY_ID, PSI_MI_DEFS.INTERACTION_NAME], how="left"
+    )
+    edgelist_df = edgelist_df[
+        [
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            PSI_MI_DEFS.INTERACTION_NAME,
+            PSI_MI_DEFS.STUDY_ID,
+            PSI_MI_DEFS.INTERACTION_TYPE,
+        ]
+    ]
+
+    # flip upstream and downstream names if needed so
+    # upstream name alphanumerically comes before downstream name
+
+    from_orig = edgelist_df[INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME].copy()
+    to_orig = edgelist_df[INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME].copy()
+
+    # Create mask and assign
+    needs_flip = from_orig > to_orig
+    edgelist_df[INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME] = np.where(
+        needs_flip, to_orig, from_orig
+    )
+    edgelist_df[INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME] = np.where(
+        needs_flip, from_orig, to_orig
+    )
+
+    return edgelist_df
+
+
+def _standardize_interaction_attrs(
+    edgelist_w_study_metadata: pd.DataFrame,
+    ontology_url: str = PSI_MI_ONTOLOGY_URL,
+) -> pd.DataFrame:
+
+    # read ontology hierarchy from the IntAct github
+    psi_mi_ontology_graph = _build_psi_mi_ontology_graph(ontology_url)
+    # map from recognized terms in the ontology to terms with an explicit score
+    # (other entries will be assigned unknown and receive its score)
+    intact_term_lookup = _get_intact_term_with_score(
+        psi_mi_ontology_graph, INTACT_TERM_SCORES
+    )
+
+    tall_interaction_attrs = pd.melt(
+        edgelist_w_study_metadata,
+        id_vars=[
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            PSI_MI_DEFS.INTERACTION_NAME,
+            PSI_MI_DEFS.STUDY_ID,
+        ],
+        value_vars=[PSI_MI_DEFS.INTERACTION_TYPE, PSI_MI_DEFS.INTERACTION_METHOD],
+        var_name=INTACT_SCORES.ATTRIBUTE_TYPE,
+        value_name=INTACT_SCORES.ATTRIBUTE_VALUE,
+    )
+
+    attribute_scores = (
+        tall_interaction_attrs[INTACT_SCORES.ATTRIBUTE_VALUE]
+        .drop_duplicates()
+        .reset_index(drop=True)
+        .to_frame()
+    )
+
+    # map to an appropraite term with a score
+    attribute_scores[INTACT_SCORES.SCORED_TERM] = attribute_scores[
+        INTACT_SCORES.ATTRIBUTE_VALUE
+    ].apply(lambda x: _get_intact_scored_term(x, intact_term_lookup))
+    attribute_scores[INTACT_SCORES.RAW_SCORE] = attribute_scores[
+        INTACT_SCORES.SCORED_TERM
+    ].apply(lambda x: INTACT_TERM_SCORES[x])
+
+    tall_standardized_interaction_attrs = tall_interaction_attrs.merge(
+        attribute_scores, on=INTACT_SCORES.ATTRIBUTE_VALUE, how="left"
+    )
+
+    return tall_standardized_interaction_attrs
+
+
+def _build_psi_mi_ontology_graph(ontology_url: str = PSI_MI_ONTOLOGY_URL):
+    """Parse MI ontology JSON from URL and build igraph directed graph."""
+    # Fetch JSON from URL
+    response = requests.get(ontology_url)
+    response.raise_for_status()
+    ontology_json = response.json()
+
+    # Collect all nodes and edges
+    nodes = []
+    edges = []
+
+    def parse_node(node, parent_name=None):
+        name = node["name"]
+        nodes.append(name)
+
+        # Add edge from parent to child (directed)
+        if parent_name:
+            edges.append((parent_name, name))
+
+        # Recursively parse children
+        for child in node.get("children", []):
+            parse_node(child, parent_name=name)
+
+    # Parse the root node
+    parse_node(ontology_json)
+
+    # Create igraph
+    g = ig.Graph.TupleList(edges, directed=True)
+    # Add any isolated nodes
+    for node in set(nodes) - set(g.vs["name"]):
+        g.add_vertex(node)
+
+    return g
+
+
+def _get_intact_term_with_score(
+    ontology_graph: ig.Graph, scored_terms: dict[str, float]
+) -> dict[str, str]:
+    """Build lookup mapping all terms to their scored ancestor names."""
+    term_lookup = {}
+
+    for vertex in ontology_graph.vs:
+        term_name = vertex["name"]
+
+        # Check if term has explicit score
+        if term_name in scored_terms:
+            term_lookup[term_name] = term_name  # Maps to itself
+        else:
+            # Get all ancestors (nodes reachable via incoming edges)
+            ancestors_idx = ontology_graph.subcomponent(vertex.index, mode="in")
+            ancestors = [
+                ontology_graph.vs[idx]["name"]
+                for idx in ancestors_idx
+                if idx != vertex.index
+            ]
+
+            # Find highest scoring ancestor
+            scored_ancestors = [
+                (ancestor, scored_terms[ancestor])
+                for ancestor in ancestors
+                if ancestor in scored_terms
+            ]
+
+            if scored_ancestors:
+                # Map to the name of the highest scoring ancestor
+                best_ancestor = max(scored_ancestors, key=lambda x: x[1])[0]
+                term_lookup[term_name] = best_ancestor
+
+    return term_lookup
+
+
+def _get_intact_scored_term(term_name: str, term_lookup: dict[str, str]) -> str:
+    """Get the scored ancestor term name for a given term."""
+    return term_lookup.get(term_name, PSI_MI_SCORED_TERMS.UNKNOWN)
+
+
+def _count_studies_with_scored_attributes(
+    standardized_interaction_attrs: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Count the number of studies which report an interaction based on scored attributes.
+
+    Parameters
+    ----------
+    df_long : pd.DataFrame
+        Long-form dataframe with columns: upstream_name, downstream_name,
+        study_id, attribute_type, scored_term, score
+
+    Returns
+    -------
+    scored_attribute_counts : pd.DataFrame
+        The number of studies and score for each interaction-attribute_type-scored_term combination.
+    """
+
+    scored_attribute_counts = (
+        standardized_interaction_attrs[
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+                PSI_MI_DEFS.STUDY_ID,
+                INTACT_SCORES.ATTRIBUTE_TYPE,
+                INTACT_SCORES.SCORED_TERM,
+                INTACT_SCORES.RAW_SCORE,
+            ]
+        ]
+        .drop_duplicates()
+        # Count studies for each interaction-attribute_type-scored_term combination
+        .groupby(
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+                INTACT_SCORES.ATTRIBUTE_TYPE,
+                INTACT_SCORES.SCORED_TERM,
+                INTACT_SCORES.RAW_SCORE,  # Include score in groupby to preserve it
+            ]
+        )
+        .size()
+        .reset_index(name="count")
+    )
+
+    return scored_attribute_counts
+
+
+def _calculate_all_scores_vectorized(
+    counts_df,
+    max_pubs=INTACT_PUBLICATION_SCORE_THRESHOLD,
+    weights: dict[str, float] = DEFAULT_INTACT_RELATIVE_WEIGHTS,
+):
+    """Calculate all MIscore components using vectorized operations."""
+
+    expected_weighted_keys = DEFAULT_INTACT_RELATIVE_WEIGHTS.keys()
+    if set(weights.keys()) != set(expected_weighted_keys):
+        raise ValueError(
+            f"The weights dictionary must contain the following keys: {expected_weighted_keys}"
+        )
+
+    # Get all unique interactions
+    interactions = counts_df[
+        [
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ]
+    ].drop_duplicates()
+
+    # Calculate publication scores
+    pub_scores = calculate_publication_scores_vectorized(counts_df, max_pubs)
+
+    # Calculate method scores
+    method_scores = calculate_category_scores_vectorized(
+        counts_df, PSI_MI_DEFS.INTERACTION_METHOD
+    )
+
+    # Calculate type scores
+    type_scores = calculate_category_scores_vectorized(
+        counts_df, PSI_MI_DEFS.INTERACTION_TYPE
+    )
+
+    # Merge all scores together
+    result = interactions
+    result = result.merge(
+        pub_scores,
+        on=[
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ],
+        how="left",
+    )
+    result = result.merge(
+        method_scores,
+        on=[
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ],
+        how="left",
+    )
+    result = result.merge(
+        type_scores,
+        on=[
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ],
+        how="left",
+    )
+
+    # Fill missing scores with 0
+    result = result.fillna(0.0)
+
+    # Calculate final MIscore
+    total_weight = sum(weights.values())
+    result[INTACT_SCORES.MI_SCORE] = (
+        weights[INTACT_SCORES.PUBLICATION_SCORE]
+        * result[INTACT_SCORES.PUBLICATION_SCORE]
+        + weights[INTACT_SCORES.INTERACTION_METHOD_SCORE]
+        * result[INTACT_SCORES.INTERACTION_METHOD_SCORE]
+        + weights[INTACT_SCORES.INTERACTION_TYPE_SCORE]
+        * result[INTACT_SCORES.INTERACTION_TYPE_SCORE]
+    ) / total_weight
+
+    return result
+
+
+def calculate_publication_scores_vectorized(
+    counts_df, max_pubs=INTACT_PUBLICATION_SCORE_THRESHOLD
+):
+    """Calculate publication scores for all interactions using vectorized operations."""
+    # Sum counts by interaction to get total publications per interaction
+    pub_counts = (
+        counts_df.groupby(
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ]
+        )["count"]
+        .sum()
+        .reset_index()
+        .rename(columns={"count": INTACT_SCORES.N_PUBLICATIONS})
+    )
+
+    # Vectorized publication score calculation: log(n+1) / log(b+1)
+    pub_counts[INTACT_SCORES.PUBLICATION_SCORE] = np.where(
+        pub_counts[INTACT_SCORES.N_PUBLICATIONS] > max_pubs,
+        1.0,
+        np.log(pub_counts[INTACT_SCORES.N_PUBLICATIONS] + 1) / np.log(max_pubs + 1),
+    )
+
+    return pub_counts[
+        [
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            INTACT_SCORES.PUBLICATION_SCORE,
+        ]
+    ]
+
+
+def calculate_category_scores_vectorized(counts_df, attribute_type):
+    """Calculate method or type scores for all interactions using vectorized operations."""
+    # Filter to specific attribute type
+    filtered_df = counts_df[
+        counts_df[INTACT_SCORES.ATTRIBUTE_TYPE] == attribute_type
+    ].copy()
+
+    if len(filtered_df) == 0:
+        # Return empty dataframe with expected structure
+        return pd.DataFrame(
+            columns=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+                f"{attribute_type}_score",
+            ]
+        )
+
+    # Calculate a = sum(score * count) for each interaction
+    filtered_df["score_x_count"] = (
+        filtered_df[INTACT_SCORES.RAW_SCORE] * filtered_df["count"]
+    )
+    a_values = (
+        filtered_df.groupby(
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ]
+        )["score_x_count"]
+        .sum()
+        .reset_index()
+        .rename(columns={"score_x_count": "a"})
+    )
+
+    # Calculate max count by score group for each interaction
+    max_by_score_group = (
+        filtered_df.groupby(
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+                INTACT_SCORES.RAW_SCORE,
+            ]
+        )["count"]
+        .max()
+        .reset_index()
+        .groupby(
+            [
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ]
+        )["count"]
+        .sum()
+        .reset_index()
+        .rename(columns={"count": "max_sum"})
+    )
+
+    # Merge a and max_sum
+    merged = a_values.merge(
+        max_by_score_group,
+        on=[
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ],
+    )
+    merged["b"] = merged["a"] + merged["max_sum"]
+
+    # Calculate category score: log(a+1) / log(b+1)
+    merged[f"{attribute_type}_score"] = np.where(
+        merged["a"] == 0, 0.0, np.log(merged["a"] + 1) / np.log(merged["b"] + 1)
+    )
+
+    return merged[
+        [
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            f"{attribute_type}_score",
+        ]
+    ]
+
+
+def _define_edgelist_df_ids_and_counts(
+    edgelist_w_study_metadata: pd.DataFrame,
+    alias_mapping: dict[str, str],
+    scored_attribute_counts: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Add attributes to the edgelist.
+
+    Parameters
+    ----------
+    edgelist_w_study_metadata : pd.DataFrame
+        The edgelist with study metadata.
+    alias_mapping : dict[str, str]
+        A dictionary mapping from ontology aliases to the Napistu controlled vocabulary.
+    scored_attribute_counts : pd.DataFrame
+        A dataframe with the number of studies with each attribute.
+
+    Returns
+    -------
+    pd.DataFrame
+        A dataframe with the edgelist, citation counts, and identifiers.
+    """
+
+    # rename ontologies
+    tmp_edgelist_w_study_metadata = edgelist_w_study_metadata.copy()
+    tmp_edgelist_w_study_metadata[IDENTIFIERS.ONTOLOGY] = tmp_edgelist_w_study_metadata[
+        IDENTIFIERS.ONTOLOGY
+    ].replace(alias_mapping)
+
+    unrecognized_ontologies = set(
+        tmp_edgelist_w_study_metadata[IDENTIFIERS.ONTOLOGY]
+    ) - set(ONTOLOGIES_LIST)
+    if len(unrecognized_ontologies) > 0:
+        logger.warning(
+            f"The following ontologies were primary references for interactions but they are not part of the  Napistu controlled vocabulary (ONTOLOGIES): {unrecognized_ontologies} "
+        )
+
+    track_citations = edgelist_w_study_metadata[
+        [
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            PSI_MI_DEFS.STUDY_ID,
+            IDENTIFIERS.ONTOLOGY,
+            IDENTIFIERS.IDENTIFIER,
+        ]
+    ].drop_duplicates()
+
+    edgelist_groups = track_citations.groupby(
+        [
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ]
+    )
+
+    # count the # of citations
+    edgelist_citation_counts = edgelist_groups.size().rename(
+        INTACT_SCORES.N_PUBLICATIONS
+    )
+    edgelist_identifiers = edgelist_groups.apply(_create_r_identifiers).rename(
+        SBML_DFS.R_IDENTIFIERS
+    )
+
+    # create a wide output with one column per interaction attribute
+    tmp_scored_attribute_counts = scored_attribute_counts.copy()
+    tmp_scored_attribute_counts["composite_attribute"] = (
+        tmp_scored_attribute_counts["attribute_type"]
+        + "_"
+        + tmp_scored_attribute_counts["scored_term"]
+    )
+    wide_attribute_counts = tmp_scored_attribute_counts.pivot_table(
+        index=[
+            INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+            INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+        ],
+        columns="composite_attribute",
+        values="count",
+        aggfunc="sum",
+        fill_value=0,
+    )
+
+    return pd.concat(
+        [edgelist_citation_counts, edgelist_identifiers, wide_attribute_counts], axis=1
+    )
+
+
+def _create_r_identifiers(group_data: pd.DataFrame) -> Identifiers:
+    """
+    Create a list of identifiers for an experiment's interactions.
+
+    Parameters
+    ----------
+    group_data : pd.DataFrame
+        A dataframe with the study metadata.
+
+    Returns
+    """
+
+    interaction_dict = [
+        {
+            IDENTIFIERS.ONTOLOGY: x[IDENTIFIERS.ONTOLOGY],
+            IDENTIFIERS.IDENTIFIER: x[IDENTIFIERS.IDENTIFIER],
+            IDENTIFIERS.BQB: BQB.IS_DESCRIBED_BY,
+        }
+        for x in group_data.to_dict("records")
+    ]
+
+    return Identifiers(interaction_dict)

--- a/src/napistu/ingestion/psi_mi.py
+++ b/src/napistu/ingestion/psi_mi.py
@@ -5,29 +5,128 @@ import os
 import xml.etree.ElementTree as ET
 from typing import Any
 
-from napistu.constants import (
-    BQB,
-    IDENTIFIERS,
-    ONTOLOGIES,
-    ONTOLOGIES_LIST,
-)
-from napistu.identifiers import Identifiers
-from napistu.identifiers import parse_ensembl_id
-from napistu.constants import SBML_DFS
 import pandas as pd
+
+from napistu.constants import IDENTIFIERS
 from napistu.ingestion.constants import (
-    INTACT_ONTOLOGY_CV_LOOKUP,
-    INTACT_ONTOLOGY_ENSEMBL_VAGUE,
     PSI_MI_INTACT_XML_NAMESPACE,
     PSI_MI_DEFS,
+    PSI_MI_MISSING_VALUE_STR,
     PSI_MI_RAW_ATTRS,
-    PSI_MI_REFS,
+    PSI_MI_STUDY_TABLES,
+    PSI_MI_STUDY_TABLES_LIST,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def format_psi(
+def format_psi_mis(
+    intact_xml_dir: str,
+    xml_namespace: str = PSI_MI_INTACT_XML_NAMESPACE,
+    verbose: bool = False,
+    files_to_process: int = -1,
+) -> list[dict[str, Any]]:
+    """
+    Format PSI-MI XML files
+
+    Format PSI-MI XML files into a list of dictionaries.
+
+    Parameters
+    ----------
+    intact_xml_dir (str):
+        Path to the directory containing the PSI-MI XML files
+    xml_namespace (str):
+        Namespace for the xml file
+    verbose (bool):
+        Whether to print verbose output
+
+    Returns
+    -------
+    formatted_psi_mis (list): a list containing molecular interaction entry dicts of the format:
+        - source : dict containing the database that interactions were drawn from.
+        - experiment : a simple summary of the experimental design and the publication.
+        - interactor_list : list containing dictionaries annotating the molecules
+        (defined by their "interactor_id") involved in interactions.
+    """
+
+    if not os.path.isdir(intact_xml_dir):
+        raise FileNotFoundError(f"The directory {intact_xml_dir} does not exist")
+
+    xml_files = os.listdir(intact_xml_dir)
+    if len(xml_files) == 0:
+        raise FileNotFoundError(f"No files found in {intact_xml_dir}")
+
+    if files_to_process > 0:
+        logger.info(f"Processing only the first {files_to_process} files")
+        xml_files = xml_files[:files_to_process]
+
+    logger.info(f"Formatting {len(xml_files)} PSI-MI XML files")
+
+    formatted_psi_mis = []
+    for xml_file in xml_files:
+        if verbose:
+            logger.info(f"Formatting {xml_file}")
+        xml_path = os.path.join(intact_xml_dir, xml_file)
+        formatted_psi_mis.append(format_psi_mi(xml_path, xml_namespace, verbose))
+
+    return formatted_psi_mis
+
+
+def aggregate_psi_mis(formatted_psi_mis: dict[str, Any]) -> dict[str, pd.DataFrame]:
+    """
+    Aggregate PSI-MI molecular interactions and study metadata and format results as a dictionary of dataframes.
+
+    Parameters
+    ----------
+    formatted_psi_mis : dict[str, Any]
+        A dictionary of PSI-MI files, where the keys are the study IDs and the values are the PSI-MI files. As returned by `napistu.ingestion.psi_mi.format_psi_mis`.
+
+    Returns
+    -------
+    dict[str, pd.DataFrame]
+        A dictionary of dataframes, where the keys are the study IDs and the values are:
+        - `reaction_species` : A dataframe of reaction species, where the columns are the reaction species and the rows are the study IDs.
+        - `species` : A dataframe of species, where the columns are the species and the rows are the study IDs.
+        - `species_identifiers` : A dataframe of species identifiers, where the columns are the species identifiers and the rows are the study IDs.
+        - `study_level_data` : A dataframe of study level data, where the columns are the study level data and the rows are the study IDs.
+
+    """
+    # reaction sources get the pubmed id of the study
+    all_studies = list()
+    for file in formatted_psi_mis:
+
+        for study in file:
+            # autoincrement study id
+            study_id = len(all_studies) + 100000
+
+            species_df, species_ids = _create_species_df(study)
+
+            study_tables = {
+                PSI_MI_STUDY_TABLES.REACTION_SPECIES: _create_reaction_species_df(
+                    study
+                ).assign(study_id=study_id),
+                PSI_MI_STUDY_TABLES.SPECIES: species_df.assign(study_id=study_id),
+                PSI_MI_STUDY_TABLES.SPECIES_IDENTIFIERS: species_ids.assign(
+                    study_id=study_id
+                ),
+                PSI_MI_STUDY_TABLES.STUDY_LEVEL_DATA: _format_study_level_data(
+                    study
+                ).assign(study_id=study_id),
+            }
+
+            all_studies.append(study_tables)
+
+    # transpose results so a list of dicts of tables becomes a dict of tables
+    all_study_tables = dict()
+    for tbl in PSI_MI_STUDY_TABLES_LIST:
+        all_study_tables[tbl] = pd.concat([x[tbl] for x in all_studies]).reset_index(
+            drop=True
+        )
+
+    return all_study_tables
+
+
+def format_psi_mi(
     xml_path: str,
     xml_namespace: str = PSI_MI_INTACT_XML_NAMESPACE,
     verbose: bool = False,
@@ -79,58 +178,6 @@ def format_psi(
     ]
 
     return formatted_entries
-
-
-def format_psi_mis(
-    intact_xml_dir: str,
-    xml_namespace: str = PSI_MI_INTACT_XML_NAMESPACE,
-    verbose: bool = False,
-    files_to_process: int = -1,
-) -> list[dict[str, Any]]:
-    """
-    Format PSI-MI XML files
-
-    Format PSI-MI XML files into a list of dictionaries.
-
-    Parameters
-    ----------
-    intact_xml_dir (str):
-        Path to the directory containing the PSI-MI XML files
-    xml_namespace (str):
-        Namespace for the xml file
-    verbose (bool):
-        Whether to print verbose output
-
-    Returns
-    -------
-    formatted_psi_mis (list): a list containing molecular interaction entry dicts of the format:
-        - source : dict containing the database that interactions were drawn from.
-        - experiment : a simple summary of the experimental design and the publication.
-        - interactor_list : list containing dictionaries annotating the molecules
-        (defined by their "interactor_id") involved in interactions.
-    """
-
-    if not os.path.isdir(intact_xml_dir):
-        raise FileNotFoundError(f"The directory {intact_xml_dir} does not exist")
-
-    xml_files = os.listdir(intact_xml_dir)
-    if len(xml_files) == 0:
-        raise FileNotFoundError(f"No files found in {intact_xml_dir}")
-
-    if files_to_process > 0:
-        logger.info(f"Processing only the first {files_to_process} files")
-        xml_files = xml_files[:files_to_process]
-
-    logger.info(f"Formatting {len(xml_files)} PSI-MI XML files")
-
-    formatted_psi_mis = []
-    for xml_file in xml_files:
-        if verbose:
-            logger.info(f"Formatting {xml_file}")
-        xml_path = os.path.join(intact_xml_dir, xml_file)
-        formatted_psi_mis.append(format_psi(xml_path, xml_namespace, verbose))
-
-    return formatted_psi_mis
 
 
 def _format_entry(an_entry, xml_namespace: str) -> dict[str, Any]:
@@ -191,12 +238,12 @@ def _format_entry_experiment(an_entry, xml_namespace: str) -> dict[str, str]:
             experiment_info,
             f".{xml_namespace}interactionDetectionMethod/{xml_namespace}names/{xml_namespace}fullName",
         ),
-        PSI_MI_REFS.PRIMARY_REF_DB: _get_optional_attribute(
+        IDENTIFIERS.ONTOLOGY: _get_optional_attribute(
             experiment_info,
             f".{xml_namespace}bibref/{xml_namespace}xref/{xml_namespace}primaryRef",
             PSI_MI_RAW_ATTRS.DB,
         ),
-        PSI_MI_REFS.PRIMARY_REF_ID: _get_optional_attribute(
+        IDENTIFIERS.IDENTIFIER: _get_optional_attribute(
             experiment_info,
             f".{xml_namespace}bibref/{xml_namespace}xref/{xml_namespace}primaryRef",
             PSI_MI_RAW_ATTRS.ID,
@@ -276,9 +323,8 @@ def _format_entry_interactor_xrefs(
             PSI_MI_DEFS.REF_TYPE: x.tag.endswith(PSI_MI_RAW_ATTRS.PRIMARY_REF)
             and PSI_MI_DEFS.PRIMARY
             or PSI_MI_DEFS.SECONDARY,
-            PSI_MI_RAW_ATTRS.TAG: x.tag,
-            PSI_MI_RAW_ATTRS.DB: x.attrib.get(PSI_MI_RAW_ATTRS.DB, ""),
-            PSI_MI_RAW_ATTRS.ID: x.attrib.get(PSI_MI_RAW_ATTRS.ID, ""),
+            IDENTIFIERS.ONTOLOGY: x.attrib.get(PSI_MI_RAW_ATTRS.DB, ""),
+            IDENTIFIERS.IDENTIFIER: x.attrib.get(PSI_MI_RAW_ATTRS.ID, ""),
         }
         for x in xref_nodes
     ]
@@ -369,76 +415,8 @@ def _format_entry_interaction_participants(
     return out
 
 
-def _sanitize_intact_identifiers(
-    identifier: str,
-    ontology: str,
-    include_unmatched: bool = False,
-    ensembl_vague: str = INTACT_ONTOLOGY_ENSEMBL_VAGUE,
-    ontology_cv_lookup: dict = INTACT_ONTOLOGY_CV_LOOKUP,
-) -> dict:
-    """
-    Sanitize an IntAct identifier.
-
-    Parameters
-    ----------
-    identifier (str):
-        The identifier to sanitize
-    ontology (str):
-        The ontology of the identifier
-    include_unmatched (bool):
-        Whether to include ontologies that are not in ONTOLOGIES_LIST
-    ensembl_vague (str):
-        The vague ontology to use for Ensembl identifiers. This will be used to distinguish
-        ENSG, ENST and ENSP identifiers.
-    ontology_cv_lookup (dict):
-        A dictionary mapping IntAct ontologies to entries in the Napistu ONTOLOGIES CV.
-
-    Returns
-    -------
-    dict:
-        A dictionary containing the sanitized identifier, ontology, and URL.
-    """
-
-    if ontology in ontology_cv_lookup.keys():
-        ontology = ontology_cv_lookup[ontology]
-
-    if ontology == ensembl_vague:
-        try:
-            identifier, ontology, _ = parse_ensembl_id(identifier)
-        except Exception:
-            # these are mostly obscure orthologues
-            return {}
-
-    if ontology not in ONTOLOGIES_LIST:
-        if not include_unmatched:
-            return {}
-        else:
-            logger.warning(f"Ontology {ontology} not in ONTOLOGIES_LIST")
-
-    return {
-        IDENTIFIERS.ONTOLOGY: ontology,
-        IDENTIFIERS.IDENTIFIER: identifier,
-        IDENTIFIERS.BQB: BQB.IS,
-    }
-
-
 def _format_study_level_data(one_study):
-
-    study_data = one_study[PSI_MI_DEFS.EXPERIMENT]
-    reaction_id = _sanitize_intact_identifiers(
-        ontology=study_data[PSI_MI_REFS.PRIMARY_REF_DB],
-        identifier=study_data[PSI_MI_REFS.PRIMARY_REF_ID],
-    )
-
-    out = {
-        PSI_MI_DEFS.EXPERIMENT_NAME: study_data[PSI_MI_DEFS.EXPERIMENT_NAME],
-        PSI_MI_DEFS.INTERACTION_METHOD: study_data[PSI_MI_DEFS.INTERACTION_METHOD],
-        SBML_DFS.R_IDENTIFIERS: Identifiers(
-            [reaction_id] if reaction_id is not None else []
-        ),
-    }
-
-    return pd.DataFrame(out, index=[0])
+    return pd.DataFrame(one_study[PSI_MI_DEFS.EXPERIMENT], index=[0])
 
 
 def _create_reaction_species_df(one_study):
@@ -466,27 +444,12 @@ def _create_species_df(one_study: dict[str, Any]) -> pd.DataFrame:
     species_identifiers = list()
     for spec in one_study[PSI_MI_DEFS.INTERACTOR_LIST]:
 
-        valid_xrefs = [
-            x
-            for x in spec[PSI_MI_DEFS.INTERACTOR_XREFS]
-            if x[PSI_MI_DEFS.REF_TYPE] == PSI_MI_DEFS.PRIMARY
-            or x[PSI_MI_RAW_ATTRS.DB] == ONTOLOGIES.INTACT
+        # Add interactor_id to each cross-reference
+        spec_identifiers = [
+            {**xref, PSI_MI_DEFS.INTERACTOR_ID: spec[PSI_MI_DEFS.INTERACTOR_ID]}
+            for xref in spec[PSI_MI_DEFS.INTERACTOR_XREFS]
         ]
-
-        # new ids dict entries
-        ids = [
-            {
-                **_sanitize_intact_identifiers(
-                    x[PSI_MI_RAW_ATTRS.ID],
-                    x[PSI_MI_RAW_ATTRS.DB],
-                    include_unmatched=False,
-                ),
-                PSI_MI_DEFS.INTERACTOR_ID: spec[PSI_MI_DEFS.INTERACTOR_ID],
-            }
-            for x in valid_xrefs
-        ]
-
-        species_identifiers.append(ids)
+        species_identifiers.append(spec_identifiers)
 
         spec_summary = {
             PSI_MI_DEFS.INTERACTOR_ID: spec[PSI_MI_DEFS.INTERACTOR_ID],
@@ -503,7 +466,9 @@ def _create_species_df(one_study: dict[str, Any]) -> pd.DataFrame:
     return species_df, species_identifiers
 
 
-def _get_optional_text(element, xpath: str, default: str = "") -> str:
+def _get_optional_text(
+    element, xpath: str, default: str = PSI_MI_MISSING_VALUE_STR
+) -> str:
     """
     Safely extract text from an optional XML element.
 
@@ -528,7 +493,7 @@ def _get_optional_text(element, xpath: str, default: str = "") -> str:
 
 
 def _get_optional_attribute(
-    element, xpath: str, attribute: str, default: str = ""
+    element, xpath: str, attribute: str, default: str = PSI_MI_MISSING_VALUE_STR
 ) -> str:
     """
     Safely extract an attribute from an optional XML element.

--- a/src/napistu/source.py
+++ b/src/napistu/source.py
@@ -566,7 +566,7 @@ def _select_top_pathway_by_enrichment(
     pathway_members = pathway_members.loc[pathway_members >= min_pw_size]
     if pathway_members.shape[0] == 0:
         return None
-    
+
     source_total_counts = _ensure_source_total_counts(source_total_counts)
     if source_total_counts is None:
         raise ValueError("`source_total_counts` is empty or invalid.")
@@ -637,7 +637,7 @@ def _update_unaccounted_for_members(
 def _ensure_source_total_counts(
     source_total_counts: Optional[pd.Series | pd.DataFrame], verbose: bool = False
 ) -> Optional[pd.Series]:
-    
+
     if source_total_counts is None:
         return None
 
@@ -667,18 +667,26 @@ def _ensure_source_total_counts(
     # Ensure the Series has the correct name and index name
     if source_total_counts.name != CONTINGENCY_TABLE.TOTAL_COUNTS:
         if verbose:
-            logger.warning(f"source_total_counts has name '{source_total_counts.name}' but expected '{CONTINGENCY_TABLE.TOTAL_COUNTS}'. Renaming to '{CONTINGENCY_TABLE.TOTAL_COUNTS}'.")
+            logger.warning(
+                f"source_total_counts has name '{source_total_counts.name}' but expected '{CONTINGENCY_TABLE.TOTAL_COUNTS}'. Renaming to '{CONTINGENCY_TABLE.TOTAL_COUNTS}'."
+            )
         source_total_counts = source_total_counts.rename(CONTINGENCY_TABLE.TOTAL_COUNTS)
 
     if source_total_counts.index.name != SOURCE_SPEC.PATHWAY_ID:
         if verbose:
-            logger.warning(f"source_total_counts has index name '{source_total_counts.index.name}' but expected '{SOURCE_SPEC.PATHWAY_ID}'. Renaming to '{SOURCE_SPEC.PATHWAY_ID}'.")
+            logger.warning(
+                f"source_total_counts has index name '{source_total_counts.index.name}' but expected '{SOURCE_SPEC.PATHWAY_ID}'. Renaming to '{SOURCE_SPEC.PATHWAY_ID}'."
+            )
         source_total_counts.index.name = SOURCE_SPEC.PATHWAY_ID
 
     # index should be character and values should be integerish
-    if not source_total_counts.index.dtype == 'object':
-        raise ValueError(f"source_total_counts index must be a string, but got {source_total_counts.index.dtype}")
+    if not source_total_counts.index.dtype == "object":
+        raise ValueError(
+            f"source_total_counts index must be a string, but got {source_total_counts.index.dtype}"
+        )
     if not np.issubdtype(source_total_counts.values.dtype, np.number):
-        raise ValueError(f"source_total_counts values must be numeric, but got {source_total_counts.values.dtype}")
+        raise ValueError(
+            f"source_total_counts values must be numeric, but got {source_total_counts.values.dtype}"
+        )
 
     return source_total_counts

--- a/src/tests/test_ingestion_intact.py
+++ b/src/tests/test_ingestion_intact.py
@@ -1,0 +1,186 @@
+import pandas as pd
+import numpy as np
+
+from napistu.ingestion import intact
+from napistu.ingestion.constants import (
+    INTACT_SCORES,
+    INTACT_TERM_SCORES,
+    INTERACTION_EDGELIST_DEFS,
+    PSI_MI_DEFS,
+    PSI_MI_SCORED_TERMS,
+)
+
+
+def test_miscore_calculation():
+    """
+    Test MIscore calculation with synthetic input data and expected output.
+
+    Note: This is a unit test to verify implementation correctness against the
+    MIscore mathematical formulas. It does NOT validate against published IntAct
+    scores due to lack of detailed worked examples showing:
+    - Specific interaction evidence (X studies of type Y using method Z)
+    - The resulting component scores
+    - The final MIscore
+
+    This test uses synthetic data to verify the algorithm implementation matches
+    the formulas from Villaveces et al. (2015).
+    """
+
+    # Test case 1: Aggregated evidence counts
+    counts_df = pd.DataFrame(
+        [
+            {
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME: "protein_A",
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME: "protein_B",
+                INTACT_SCORES.ATTRIBUTE_TYPE: PSI_MI_DEFS.INTERACTION_TYPE,
+                INTACT_SCORES.SCORED_TERM: PSI_MI_SCORED_TERMS.DIRECT_INTERACTION,
+                INTACT_SCORES.RAW_SCORE: 1.0,
+                "count": 2,
+            },
+            {
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME: "protein_A",
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME: "protein_B",
+                INTACT_SCORES.ATTRIBUTE_TYPE: PSI_MI_DEFS.INTERACTION_METHOD,
+                INTACT_SCORES.SCORED_TERM: PSI_MI_SCORED_TERMS.BIOCHEMICAL,
+                INTACT_SCORES.RAW_SCORE: 1.0,
+                "count": 2,
+            },
+        ]
+    )
+
+    # Publication counts (as Series with MultiIndex)
+    n_publications = pd.Series(
+        [2],
+        index=pd.MultiIndex.from_tuples(
+            [("protein_A", "protein_B")],
+            names=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ],
+        ),
+        name=INTACT_SCORES.N_PUBLICATIONS,
+    )
+
+    # Calculate scores using the implementation
+    result_1 = intact._calculate_all_scores_vectorized(counts_df, n_publications)
+
+    # Hand-calculated expected values based on MIscore formulas:
+    # Publication score: n=2 publications, max=7 -> log(3)/log(8) ≈ 0.528
+    expected_pub_score = np.log(3) / np.log(8)
+
+    # Method score: a=2*1.0=2, b=2+2=4 -> log(3)/log(5) ≈ 0.683
+    expected_method_score = np.log(3) / np.log(5)
+
+    # Type score: Same calculation as method score ≈ 0.683
+    expected_type_score = np.log(3) / np.log(5)
+
+    # Final MIscore: weighted average with equal weights (1.0 each)
+    expected_miscore = (
+        expected_pub_score + expected_method_score + expected_type_score
+    ) / 3
+
+    # Assertions with tolerance for floating point precision
+    assert (
+        abs(result_1[INTACT_SCORES.PUBLICATION_SCORE].iloc[0] - expected_pub_score)
+        < 0.001
+    ), f"Publication score mismatch: {result_1[INTACT_SCORES.PUBLICATION_SCORE].iloc[0]} vs {expected_pub_score}"
+
+    assert (
+        abs(
+            result_1[INTACT_SCORES.INTERACTION_METHOD_SCORE].iloc[0]
+            - expected_method_score
+        )
+        < 0.001
+    ), f"Method score mismatch: {result_1[INTACT_SCORES.INTERACTION_METHOD_SCORE].iloc[0]} vs {expected_method_score}"
+
+    assert (
+        abs(
+            result_1[INTACT_SCORES.INTERACTION_TYPE_SCORE].iloc[0] - expected_type_score
+        )
+        < 0.001
+    ), f"Type score mismatch: {result_1[INTACT_SCORES.INTERACTION_TYPE_SCORE].iloc[0]} vs {expected_type_score}"
+
+    assert (
+        abs(result_1[INTACT_SCORES.MI_SCORE].iloc[0] - expected_miscore) < 0.001
+    ), f"MIscore mismatch: {result_1[INTACT_SCORES.MI_SCORE].iloc[0]} vs {expected_miscore}"
+
+    # Test case 2: Single publication, lower-scoring evidence (edge case)
+    counts_df_2 = pd.DataFrame(
+        [
+            {
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME: "protein_C",
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME: "protein_D",
+                INTACT_SCORES.ATTRIBUTE_TYPE: PSI_MI_DEFS.INTERACTION_TYPE,
+                INTACT_SCORES.SCORED_TERM: PSI_MI_SCORED_TERMS.ASSOCIATION,
+                INTACT_SCORES.RAW_SCORE: 0.33,
+                "count": 1,
+            },
+            {
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME: "protein_C",
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME: "protein_D",
+                INTACT_SCORES.ATTRIBUTE_TYPE: PSI_MI_DEFS.INTERACTION_METHOD,
+                INTACT_SCORES.SCORED_TERM: PSI_MI_SCORED_TERMS.GENETIC_INTERFERENCE,
+                INTACT_SCORES.RAW_SCORE: 0.10,
+                "count": 1,
+            },
+        ]
+    )
+
+    n_publications_2 = pd.Series(
+        [1],
+        index=pd.MultiIndex.from_tuples(
+            [("protein_C", "protein_D")],
+            names=[
+                INTERACTION_EDGELIST_DEFS.UPSTREAM_NAME,
+                INTERACTION_EDGELIST_DEFS.DOWNSTREAM_NAME,
+            ],
+        ),
+        name=INTACT_SCORES.N_PUBLICATIONS,
+    )
+
+    result_2 = intact._calculate_all_scores_vectorized(counts_df_2, n_publications_2)
+
+    # All scores should be between 0 and 1
+    assert 0 <= result_2[INTACT_SCORES.PUBLICATION_SCORE].iloc[0] <= 1
+    assert 0 <= result_2[INTACT_SCORES.INTERACTION_METHOD_SCORE].iloc[0] <= 1
+    assert 0 <= result_2[INTACT_SCORES.INTERACTION_TYPE_SCORE].iloc[0] <= 1
+    assert 0 <= result_2[INTACT_SCORES.MI_SCORE].iloc[0] <= 1
+
+
+def test_ontology_term_scoring():
+    """
+    Test ontology parsing and term scoring with spot checks.
+
+    Tests the complete pipeline from ontology parsing to term score assignment,
+    including explicit scores, inherited scores, and fallback to unknown.
+    """
+
+    # Build ontology graph and term lookup
+    psi_mi_ontology_graph = intact._build_psi_mi_ontology_graph()
+    intact_term_lookup = intact._get_intact_term_with_score(
+        psi_mi_ontology_graph, INTACT_TERM_SCORES
+    )
+
+    # Test case 1: Term with explicit score
+    explicit_term = "direct interaction"
+    explicit_result = intact._get_intact_scored_term(explicit_term, intact_term_lookup)
+    assert (
+        explicit_result == "direct interaction"
+    ), f"Explicit term should map to itself: {explicit_result}"
+
+    # Test case 2: Term that inherits score by propagation
+    # (This assumes there's a child term of a scored parent in the ontology)
+    inherited_term = "enzymatic reaction"  # Should inherit from "direct interaction"
+    inherited_result = intact._get_intact_scored_term(
+        inherited_term, intact_term_lookup
+    )
+    assert (
+        inherited_result == "direct interaction"
+    ), f"Child term should inherit parent score: {inherited_result}"
+
+    # Test case 3: Missing/unknown term
+    missing_term = "foo"
+    missing_result = intact._get_intact_scored_term(missing_term, intact_term_lookup)
+    assert (
+        missing_result == "unknown"
+    ), f"Missing term should default to unknown: {missing_result}"

--- a/src/tests/test_source.py
+++ b/src/tests/test_source.py
@@ -37,8 +37,16 @@ def test_source():
 
     alt_source_df = pd.DataFrame(
         [
-            {SOURCE_SPEC.MODEL: "fun", "identifier": "baz", SOURCE_SPEC.PATHWAY_ID: "fun"},
-            {SOURCE_SPEC.MODEL: "fun", "identifier": "baz", SOURCE_SPEC.PATHWAY_ID: "fun"},
+            {
+                SOURCE_SPEC.MODEL: "fun",
+                "identifier": "baz",
+                SOURCE_SPEC.PATHWAY_ID: "fun",
+            },
+            {
+                SOURCE_SPEC.MODEL: "fun",
+                "identifier": "baz",
+                SOURCE_SPEC.PATHWAY_ID: "fun",
+            },
         ]
     )
     alt_source_obj = source.Source(alt_source_df)
@@ -88,7 +96,9 @@ def test_source_set_coverage(sbml_dfs_metabolism):
 
 def test_source_set_coverage_enrichment(sbml_dfs_metabolism):
 
-    source_total_counts = sbml_dfs_metabolism.get_source_total_counts(SBML_DFS.REACTIONS)
+    source_total_counts = sbml_dfs_metabolism.get_source_total_counts(
+        SBML_DFS.REACTIONS
+    )
 
     source_df = source.unnest_sources(sbml_dfs_metabolism.reactions).head(40)
 
@@ -108,7 +118,9 @@ def test_source_set_coverage_missing_pathway_ids(sbml_dfs_metabolism):
     source_df = source.unnest_sources(sbml_dfs_metabolism.reactions)
 
     # Get the source_total_counts
-    source_total_counts = sbml_dfs_metabolism.get_source_total_counts(SBML_DFS.REACTIONS)
+    source_total_counts = sbml_dfs_metabolism.get_source_total_counts(
+        SBML_DFS.REACTIONS
+    )
 
     # Create a modified source_total_counts that's missing some pathway_ids
     # that are present in source_df
@@ -144,13 +156,13 @@ def test_ensure_source_total_counts():
     Test that _ensure_source_total_counts properly validates and fixes source_total_counts structure.
     """
     # Test with a malformed Series
-    malformed_series = pd.Series([10, 20], index=['path1', 'path2'], name='wrong_name')
-    
+    malformed_series = pd.Series([10, 20], index=["path1", "path2"], name="wrong_name")
+
     # Test that this gets fixed by _ensure_source_total_counts
     fixed_series = source._ensure_source_total_counts(malformed_series)
-    
+
     # Verify the Series is properly formatted
     assert fixed_series.name == CONTINGENCY_TABLE.TOTAL_COUNTS
     assert fixed_series.index.name == SOURCE_SPEC.PATHWAY_ID
-    assert list(fixed_series.index) == ['path1', 'path2']
+    assert list(fixed_series.index) == ["path1", "path2"]
     assert list(fixed_series.values) == [10, 20]


### PR DESCRIPTION
Cleaned up documentation and use of constants in `psi_mi.py`. Removed specific mentions of IntAct so the functions may be repurposed if we run into additional sources using these formats.

Completed the `intact.py` containing specific formatting of intact data. The main function is `intact_to_sbml_dfs` which formats interactions as an SBML_dfs object.

IntAct reactions are associated with an `interaction_type` (physical, genetics, ...) and `interaction_method` (biophyscial, biochemical, ... I rederived IntAct's scoring method based on how they score individual types of evidence and how they aggregate them across studies.  This aggregate molecular interaction score (miscore) is included along with its components (publication_score, interaction_method_score, and interaction_type_score) as well as the counts of each method and type as `reactions_data`.

Tested with yeast and humans and everything looks good. Closes #69 

```python
from napistu.ingestion import intact
from napistu.ingestion import psi_mi

latin_species = "Saccharomyces cerevisiae"
intact_xml_dir = "/tmp/intact_tmp_yeast"
# intact.download_intact_xmls(intact_xml_dir, latin_species)

formatted_psi_mis = psi_mi.format_psi_mis(intact_xml_dir, files_to_process = 20)
intact_summaries = psi_mi.aggregate_psi_mis(formatted_psi_mis)
sbml_dfs = intact.intact_to_sbml_dfs(intact_summaries, latin_species)
```