### PR TITLE
Issue 174 - filter reaction sources to ensure that vertices, edges, and reaction_sources are consistent

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.5.2
+version = 0.5.3
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import pickle
+import warnings
 from typing import Sequence
 
 import click
@@ -12,6 +13,10 @@ import click_logging
 import napistu
 import igraph as ig
 import pandas as pd
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
+
 from napistu import consensus as napistu_consensus
 from napistu import indices
 from napistu.sbml_dfs_core import SBML_dfs
@@ -42,7 +47,6 @@ from napistu.constants import RESOLVE_MATCHES_AGGREGATORS
 from napistu.ingestion.constants import PROTEINATLAS_SUBCELL_LOC_URL
 from napistu.ingestion.constants import GTEX_RNASEQ_EXPRESSION_URL
 from napistu.network.constants import NAPISTU_GRAPH_EDGES
-from fs import open_fs
 
 logger = logging.getLogger(napistu.__name__)
 click_logging.basic_config(logger)

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -13,6 +13,7 @@ import click_logging
 import napistu
 import igraph as ig
 import pandas as pd
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
     from fs import open_fs

--- a/src/napistu/indices.py
+++ b/src/napistu/indices.py
@@ -4,10 +4,13 @@ import copy
 import os
 import re
 import datetime
+import warnings
 from os import PathLike
 from typing import Iterable
 
-from fs import open_fs
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 import pandas as pd
 
 from napistu.utils import path_exists

--- a/src/napistu/ingestion/bigg.py
+++ b/src/napistu/ingestion/bigg.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 from typing import Iterable
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 
 from napistu import indices
 from napistu import sbml_dfs_core
@@ -12,7 +17,6 @@ from napistu.ontologies.renaming import rename_species_ontologies
 from napistu.ingestion.constants import BIGG_MODEL_KEYS
 from napistu.ingestion.constants import BIGG_MODEL_URLS
 from napistu.ingestion.constants import LATIN_SPECIES_NAMES
-from fs import open_fs
 
 logger = logging.getLogger(__name__)
 

--- a/src/napistu/ingestion/gtex.py
+++ b/src/napistu/ingestion/gtex.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import logging
 import pandas as pd
-from fs import open_fs
-from napistu import utils
+import warnings
 
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
+
+from napistu import utils
 from napistu.constants import ONTOLOGIES
 from napistu.ingestion.constants import GTEX_DEFS, GTEX_RNASEQ_EXPRESSION_URL
 

--- a/src/napistu/ingestion/hpa.py
+++ b/src/napistu/ingestion/hpa.py
@@ -4,6 +4,7 @@ import logging
 import warnings
 
 import pandas as pd
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
     from fs import open_fs

--- a/src/napistu/ingestion/hpa.py
+++ b/src/napistu/ingestion/hpa.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import logging
+import warnings
+
 import pandas as pd
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
+
 from napistu import utils
-from fs import open_fs
 from napistu.constants import ONTOLOGIES
 from napistu.ingestion.constants import PROTEINATLAS_SUBCELL_LOC_URL, PROTEINATLAS_DEFS
 

--- a/src/napistu/ingestion/reactome.py
+++ b/src/napistu/ingestion/reactome.py
@@ -4,11 +4,16 @@ import datetime
 import logging
 import os
 import random
+import warnings
 from io import StringIO
 from typing import Iterable
 
 import pandas as pd
 import requests
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
+
 from napistu import indices
 from napistu import sbml_dfs_core
 from napistu import utils
@@ -18,7 +23,6 @@ from napistu.ingestion.constants import REACTOME_PATHWAY_INDEX_COLUMNS
 from napistu.ingestion.constants import REACTOME_PATHWAY_LIST_COLUMNS
 from napistu.ingestion.constants import REACTOME_PATHWAYS_URL
 from napistu.ingestion.constants import REACTOME_SMBL_URL
-from fs import open_fs
 
 logger = logging.getLogger(__name__)
 

--- a/src/napistu/ingestion/reactome.py
+++ b/src/napistu/ingestion/reactome.py
@@ -10,6 +10,7 @@ from typing import Iterable
 
 import pandas as pd
 import requests
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
     from fs import open_fs

--- a/src/napistu/ingestion/sbml.py
+++ b/src/napistu/ingestion/sbml.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import libsbml
 import pandas as pd
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
     from fs import open_fs

--- a/src/napistu/ingestion/sbml.py
+++ b/src/napistu/ingestion/sbml.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import logging
 import os
 import re
+import warnings
 from typing import Any
 
 import libsbml
 import pandas as pd
-from fs import open_fs
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 from pydantic import field_validator, RootModel
 
 from napistu import consensus

--- a/src/napistu/ingestion/string.py
+++ b/src/napistu/ingestion/string.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 import logging
+import warnings
 
 import pandas as pd
-from fs import open_fs
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 
 from napistu import identifiers
 from napistu import sbml_dfs_core

--- a/src/napistu/ingestion/string.py
+++ b/src/napistu/ingestion/string.py
@@ -3,6 +3,7 @@ import logging
 import warnings
 
 import pandas as pd
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
     from fs import open_fs

--- a/src/napistu/ingestion/trrust.py
+++ b/src/napistu/ingestion/trrust.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import os
+import warnings
 from itertools import chain
 
 import pandas as pd
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
+
 from napistu import identifiers
 from napistu import sbml_dfs_core
 from napistu import source
@@ -23,7 +28,6 @@ from napistu.ingestion.constants import TRRUST_UNIPROT_ID
 from napistu.ingestion.constants import TTRUST_URL_RAW_DATA_HUMAN
 from napistu.ingestion.constants import TRRUST_SIGNS
 from napistu.rpy2 import callr
-from fs import open_fs
 
 
 def download_trrust(target_uri: str) -> None:

--- a/src/napistu/ingestion/trrust.py
+++ b/src/napistu/ingestion/trrust.py
@@ -5,6 +5,7 @@ import warnings
 from itertools import chain
 
 import pandas as pd
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
     from fs import open_fs

--- a/src/napistu/modify/curation.py
+++ b/src/napistu/modify/curation.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import os
+import warnings
 from typing import Any
 
-from fs import open_fs
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 import numpy as np
 import pandas as pd
 

--- a/src/napistu/modify/pathwayannot.py
+++ b/src/napistu/modify/pathwayannot.py
@@ -4,8 +4,11 @@ import copy
 import logging
 import os
 import re
+import warnings
 
-from fs import open_fs
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 import numpy as np
 import pandas as pd
 

--- a/src/napistu/network/constants.py
+++ b/src/napistu/network/constants.py
@@ -51,6 +51,7 @@ NAPISTU_GRAPH_EDGES = SimpleNamespace(
     TO="to",
     UPSTREAM_WEIGHT="upstream_weight",
     WEIGHT="weight",
+    SOURCE_WT="source_wt",
 )
 
 # added during graph wiring

--- a/src/napistu/network/neighborhoods.py
+++ b/src/napistu/network/neighborhoods.py
@@ -9,10 +9,10 @@ from typing import Any
 import igraph as ig
 import numpy as np
 import pandas as pd
+
 from napistu import sbml_dfs_core
 from napistu.network import ng_utils
 from napistu.network import paths
-
 from napistu.constants import (
     MINI_SBO_NAME_TO_POLARITY,
     MINI_SBO_TO_NAME,
@@ -20,7 +20,6 @@ from napistu.constants import (
     ONTOLOGIES,
     SBML_DFS,
 )
-
 from napistu.network.constants import (
     DISTANCES,
     GRAPH_RELATIONSHIPS,
@@ -139,14 +138,6 @@ def find_and_prune_neighborhoods(
     )
 
     pruned_neighborhoods = prune_neighborhoods(neighborhood_dicts, top_n=top_n)
-
-    # Validate each neighborhood for consistency
-    for sc_id, neighborhood in pruned_neighborhoods.items():
-        if (
-            NEIGHBORHOOD_DICT_KEYS.VERTICES in neighborhood
-            and NEIGHBORHOOD_DICT_KEYS.EDGES in neighborhood
-        ):
-            _validate_neighborhood_consistency(neighborhood, sc_id)
 
     return pruned_neighborhoods
 
@@ -364,164 +355,6 @@ def find_neighborhoods(
     return neighborhood_dict
 
 
-def _process_path_information(
-    neighborhood_graph: ig.Graph,
-    one_neighborhood_df: pd.DataFrame,
-    sc_id: str,
-    edges: pd.DataFrame,
-    vertices: pd.DataFrame,
-) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
-    """
-    Process shortest path information and merge with vertices/edges.
-
-    Handles the complex path-finding logic and attribute merging that was
-    cluttering the main function.
-    """
-    # Find paths to neighbors
-    (
-        downstream_path_attrs,
-        downstream_entity_dict,
-        upstream_path_attrs,
-        upstream_entity_dict,
-    ) = _find_neighbors_paths(
-        neighborhood_graph,
-        one_neighborhood_df,
-        sc_id,
-        edges,
-    )
-
-    # Combine upstream and downstream shortest paths
-    vertex_neighborhood_attrs = (
-        pd.concat([downstream_path_attrs, upstream_path_attrs])
-        .sort_values(DISTANCES.PATH_WEIGHT)
-        .groupby("neighbor")
-        .first()
-    )
-    # Label the focal node
-    vertex_neighborhood_attrs.loc[sc_id, "node_orientation"] = GRAPH_RELATIONSHIPS.FOCAL
-
-    # Validate expected attributes are present
-    EXPECTED_VERTEX_ATTRS = {
-        DISTANCES.FINAL_FROM,
-        DISTANCES.FINAL_TO,
-        NET_POLARITY.NET_POLARITY,
-    }
-    missing_vertex_attrs = EXPECTED_VERTEX_ATTRS.difference(
-        set(vertex_neighborhood_attrs.columns.tolist())
-    )
-
-    if len(missing_vertex_attrs) > 0:
-        raise ValueError(
-            f"vertex_neighborhood_attrs did not contain the expected columns: {EXPECTED_VERTEX_ATTRS}."
-            "This is likely because of inconsistencies between the precomputed distances, graph and/or sbml_dfs."
-            "Please try ng_utils.validate_assets() to check for consistency."
-        )
-
-    # Add net_polarity to edges
-    edges = edges.merge(
-        vertex_neighborhood_attrs.reset_index()[
-            [DISTANCES.FINAL_FROM, DISTANCES.FINAL_TO, NET_POLARITY.NET_POLARITY]
-        ].dropna(),
-        left_on=[NAPISTU_GRAPH_EDGES.FROM, NAPISTU_GRAPH_EDGES.TO],
-        right_on=[DISTANCES.FINAL_FROM, DISTANCES.FINAL_TO],
-        how="left",
-    )
-
-    # Merge path attributes with vertices
-    vertices = vertices.merge(
-        vertex_neighborhood_attrs, left_on=NAPISTU_GRAPH_VERTICES.NAME, right_index=True
-    )
-
-    # Package path entities
-    neighborhood_path_entities = {
-        NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM: downstream_entity_dict,
-        NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM: upstream_entity_dict,
-    }
-
-    return vertices, edges, neighborhood_path_entities
-
-
-def _clean_disconnected_components(
-    vertices: pd.DataFrame,
-    edges: pd.DataFrame,
-    reaction_sources: pd.DataFrame | None,
-    sc_id: str,
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame | None]:
-    """
-    Remove disconnected components and filter related data structures.
-
-    Handles the cleanup logic for removing nodes that couldn't be reached
-    from the focal node and updating all related data structures accordingly.
-    """
-
-    # Find disconnected neighbors (path weight = 0, not focal node)
-    disconnected_neighbors = vertices.query(
-        f"(not node_orientation == '{GRAPH_RELATIONSHIPS.FOCAL}') and {DISTANCES.PATH_WEIGHT} == 0"
-    )
-
-    # Filter vertices
-    vertices = vertices[~vertices.index.isin(disconnected_neighbors.index.tolist())]
-
-    # Filter edges to only include those between remaining vertices
-    vertex_names = vertices[NAPISTU_GRAPH_VERTICES.NAME]
-    edges = edges[
-        edges[NAPISTU_GRAPH_EDGES.FROM].isin(vertex_names)
-        & edges[NAPISTU_GRAPH_EDGES.TO].isin(vertex_names)
-    ]
-
-    # Filter reaction sources if present
-    if reaction_sources is not None:
-        reaction_sources = reaction_sources[
-            reaction_sources[SBML_DFS.R_ID].isin(vertex_names)
-        ]
-
-    _validate_neighborhood_consistency(
-        {
-            NEIGHBORHOOD_DICT_KEYS.VERTICES: vertices,
-            NEIGHBORHOOD_DICT_KEYS.EDGES: edges,
-            NEIGHBORHOOD_DICT_KEYS.REACTION_SOURCES: reaction_sources,
-        },
-        sc_id,
-    )
-
-    return vertices, edges, reaction_sources
-
-
-def _build_final_result(
-    vertices: pd.DataFrame,
-    edges: pd.DataFrame,
-    reaction_sources: pd.DataFrame | None,
-    neighborhood_path_entities: dict,
-    napistu_graph: ig.Graph,
-    sbml_dfs,
-) -> dict[str, Any]:
-    """
-    Build the final result dictionary with all required components.
-
-    Handles the final assembly of the neighborhood result, including
-    adding reference URLs and creating the updated graph.
-    """
-    # Add reference urls
-    vertices = add_vertices_uri_urls(vertices, sbml_dfs)
-
-    # Create updated graph with additional vertex and edge attributes
-    updated_napistu_graph = ig.Graph.DictList(
-        vertices=vertices.to_dict("records"),
-        edges=edges.to_dict("records"),
-        directed=napistu_graph.is_directed(),
-        vertex_name_attr=NAPISTU_GRAPH_VERTICES.NAME,
-        edge_foreign_keys=(NAPISTU_GRAPH_EDGES.FROM, NAPISTU_GRAPH_EDGES.TO),
-    )
-
-    return {
-        NEIGHBORHOOD_DICT_KEYS.GRAPH: updated_napistu_graph,
-        NEIGHBORHOOD_DICT_KEYS.VERTICES: vertices,
-        NEIGHBORHOOD_DICT_KEYS.EDGES: edges,
-        NEIGHBORHOOD_DICT_KEYS.REACTION_SOURCES: reaction_sources,
-        NEIGHBORHOOD_DICT_KEYS.NEIGHBORHOOD_PATH_ENTITIES: neighborhood_path_entities,
-    }
-
-
 def create_neighborhood_dict_entry(
     sc_id: str,
     neighborhood_df: pd.DataFrame,
@@ -639,34 +472,6 @@ def create_neighborhood_dict_entry(
     _validate_neighborhood_consistency(outdict, sc_id)
 
     return outdict
-
-
-def _create_neighborhood_dict_entry_logging(
-    sc_id: str, one_neighborhood_df: pd.DataFrame, sbml_dfs: sbml_dfs_core.SBML_dfs
-):
-    df_summary = one_neighborhood_df.copy()
-    df_summary[NAPISTU_GRAPH_VERTICES.NODE_TYPE] = [
-        NAPISTU_GRAPH_NODE_TYPES.SPECIES if x else NAPISTU_GRAPH_NODE_TYPES.REACTION
-        for x in df_summary[NAPISTU_GRAPH_VERTICES.NAME].isin(
-            sbml_dfs.compartmentalized_species.index
-        )
-    ]
-    relationship_counts = df_summary.value_counts(
-        ["relationship", "node_type"]
-    ).sort_index()
-
-    relation_strings = list()
-    for relation in relationship_counts.index.get_level_values(0).unique():
-        relation_str = " and ".join(
-            [
-                f"{relationship_counts[relation][i]} {i}"
-                for i in relationship_counts[relation].index
-            ]
-        )
-        relation_strings.append(f"{relation}: {relation_str}")
-
-    msg = f"{sc_id} neighborhood: {'; '.join(relation_strings)}"
-    logger.info(msg)
 
 
 def add_vertices_uri_urls(
@@ -982,6 +787,562 @@ def plot_neighborhood(
     return ig.plot(neighborhood_graph, **visual_style)
 
 
+# Private utility functions (alphabetical order)
+
+
+def _build_final_result(
+    vertices: pd.DataFrame,
+    edges: pd.DataFrame,
+    reaction_sources: pd.DataFrame | None,
+    neighborhood_path_entities: dict,
+    napistu_graph: ig.Graph,
+    sbml_dfs,
+) -> dict[str, Any]:
+    """
+    Build the final result dictionary with all required components.
+
+    Handles the final assembly of the neighborhood result, including
+    adding reference URLs and creating the updated graph.
+    """
+    # Add reference urls
+    vertices = add_vertices_uri_urls(vertices, sbml_dfs)
+
+    # Create updated graph with additional vertex and edge attributes
+    updated_napistu_graph = ig.Graph.DictList(
+        vertices=vertices.to_dict("records"),
+        edges=edges.to_dict("records"),
+        directed=napistu_graph.is_directed(),
+        vertex_name_attr=NAPISTU_GRAPH_VERTICES.NAME,
+        edge_foreign_keys=(NAPISTU_GRAPH_EDGES.FROM, NAPISTU_GRAPH_EDGES.TO),
+    )
+
+    return {
+        NEIGHBORHOOD_DICT_KEYS.GRAPH: updated_napistu_graph,
+        NEIGHBORHOOD_DICT_KEYS.VERTICES: vertices,
+        NEIGHBORHOOD_DICT_KEYS.EDGES: edges,
+        NEIGHBORHOOD_DICT_KEYS.REACTION_SOURCES: reaction_sources,
+        NEIGHBORHOOD_DICT_KEYS.NEIGHBORHOOD_PATH_ENTITIES: neighborhood_path_entities,
+    }
+
+
+def _build_raw_neighborhood_df(
+    napistu_graph: ig.Graph,
+    compartmentalized_species: list[str],
+    network_type: str,
+    order: int,
+    precomputed_neighbors: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    # report if network_type is not the default and will be ignored due to the network
+    #   being undirected
+    is_directed = napistu_graph.is_directed()
+    if not is_directed and network_type != NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM:
+        logger.warning(
+            "Network is undirected; network_type will be treated as 'downstream'"
+        )
+        network_type = NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM
+
+    # create the "out-network" of descendant nodes
+    if network_type in [
+        NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM,
+        NEIGHBORHOOD_NETWORK_TYPES.HOURGLASS,
+    ]:
+        descendants_df = _find_neighbors(
+            napistu_graph=napistu_graph,
+            compartmentalized_species=compartmentalized_species,
+            relationship=GRAPH_RELATIONSHIPS.DESCENDANTS,
+            order=order,
+            precomputed_neighbors=precomputed_neighbors,
+        )
+
+    # create the "in-network" of ancestor nodes
+    if network_type in [
+        NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM,
+        NEIGHBORHOOD_NETWORK_TYPES.HOURGLASS,
+    ]:
+        ancestors_df = _find_neighbors(
+            napistu_graph=napistu_graph,
+            compartmentalized_species=compartmentalized_species,
+            relationship=GRAPH_RELATIONSHIPS.ANCESTORS,
+            order=order,
+            precomputed_neighbors=precomputed_neighbors,
+        )
+
+    if network_type == NEIGHBORHOOD_NETWORK_TYPES.HOURGLASS:
+        # merge descendants and ancestors
+        neighborhood_df = pd.concat([ancestors_df, descendants_df])
+    elif network_type == NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM:
+        neighborhood_df = descendants_df
+    elif network_type == NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM:
+        neighborhood_df = ancestors_df
+    else:
+        raise NotImplementedError("invalid network_type")
+
+    # add name since this is an easy way to lookup igraph vertices
+    neighborhood_df[NAPISTU_GRAPH_VERTICES.NAME] = [
+        x[NAPISTU_GRAPH_VERTICES.NAME]
+        for x in napistu_graph.vs[neighborhood_df["neighbor"]]
+    ]
+
+    return neighborhood_df
+
+
+def _calculate_path_attrs(
+    neighborhood_paths: list[list],
+    edges: pd.DataFrame,
+    vertices: list,
+    weight_var: str = NAPISTU_GRAPH_EDGES.WEIGHT,
+) -> tuple[pd.DataFrame, dict[Any, set]]:
+    """
+    Calculate Path Attributes
+
+    Return the vertices and path weights (sum of edge weights) for a list of paths.
+
+    Parameters
+    ----------
+    neighborhood_paths: list
+        List of lists of edge indices
+    edges: pd.DataFrame
+        Edges with rows correponding to entries in neighborhood_paths inner lists
+    vertices: list
+        List of vertices correponding to the ordering of neighborhood_paths
+    weights_var: str
+        variable in edges to use for scoring path weights
+
+    Returns
+    -------
+    path_attributes_df: pd.DataFrame
+        A table containing attributes summarizing the path to each neighbor
+    neighborhood_path_entities: dict
+        Dict mapping from each neighbor to the entities connecting it to the focal node
+
+    """
+
+    if not isinstance(neighborhood_paths, list):
+        raise TypeError("neighborhood_paths should be a list of lists of edge indices")
+    if not isinstance(vertices, list):
+        raise TypeError("vertices should be a list of list of vertices")
+    if len(vertices) <= 0:
+        raise ValueError("vertices must have length greater than zero")
+    if len(neighborhood_paths) != len(vertices):
+        raise ValueError("vertices and neighborhood_paths were not the same length")
+
+    if any([len(x) > 0 for x in neighborhood_paths]):
+        all_path_edges = (
+            # create a table of edges traversed to reach each neighbor
+            pd.concat(
+                [
+                    edges.iloc[neighborhood_paths[i]].assign(neighbor=vertices[i])
+                    for i in range(0, len(neighborhood_paths))
+                ]
+            ).groupby("neighbor")
+        )
+
+        # if all_path_edges.ngroups > 0:
+        path_attributes_df = pd.concat(
+            [
+                all_path_edges[weight_var].agg("sum").rename(DISTANCES.PATH_WEIGHT),
+                all_path_edges.agg("size").rename(DISTANCES.PATH_LENGTH),
+                all_path_edges[NET_POLARITY.LINK_POLARITY]
+                .agg(paths._terminal_net_polarity)
+                .rename(NET_POLARITY.NET_POLARITY),
+                # add the final edge since this can be used to add path attributes to edges
+                # i.e., apply net_polarity to an edge
+                all_path_edges["from"].agg("last").rename(DISTANCES.FINAL_FROM),
+                all_path_edges["to"].agg("last").rename(DISTANCES.FINAL_TO),
+            ],
+            axis=1,
+        ).reset_index()
+
+        # create a dict mapping from a neighbor to all mediating nodes
+        neighborhood_path_entities = {
+            group_name: set().union(*[dat["from"], dat["to"]])
+            for group_name, dat in all_path_edges
+        }
+
+    else:
+        # catch case where there are no paths
+        path_attributes_df = pd.DataFrame()
+        neighborhood_path_entities = dict()
+
+    # add entries with no edges
+    edgeless_nodes = [
+        vertices[i]
+        for i in range(0, len(neighborhood_paths))
+        if len(neighborhood_paths[i]) == 0
+    ]
+    edgeles_nodes_df = pd.DataFrame({"neighbor": edgeless_nodes}).assign(
+        **{
+            DISTANCES.PATH_LENGTH: 0,
+            DISTANCES.PATH_WEIGHT: 0,
+            NET_POLARITY.NET_POLARITY: None,
+        }
+    )
+
+    # add edgeless entries as entries in the two outputs
+    path_attributes_df = pd.concat([path_attributes_df, edgeles_nodes_df])
+    neighborhood_path_entities.update({x: {x} for x in edgeless_nodes})
+
+    if path_attributes_df.shape[0] != len(neighborhood_paths):
+        raise ValueError(
+            "path_attributes_df row count must match number of neighborhood_paths"
+        )
+    if len(neighborhood_path_entities) != len(neighborhood_paths):
+        raise ValueError(
+            "neighborhood_path_entities length must match number of neighborhood_paths"
+        )
+
+    return path_attributes_df, neighborhood_path_entities
+
+
+def _clean_disconnected_components(
+    vertices: pd.DataFrame,
+    edges: pd.DataFrame,
+    reaction_sources: pd.DataFrame | None,
+    sc_id: str,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame | None]:
+    """
+    Remove disconnected components and filter related data structures.
+
+    Handles the cleanup logic for removing nodes that couldn't be reached
+    from the focal node and updating all related data structures accordingly.
+    """
+
+    # Find disconnected neighbors (path weight = 0, not focal node)
+    disconnected_neighbors = vertices.query(
+        f"(not node_orientation == '{GRAPH_RELATIONSHIPS.FOCAL}') and {DISTANCES.PATH_WEIGHT} == 0"
+    )
+
+    # Filter vertices
+    vertices = vertices[~vertices.index.isin(disconnected_neighbors.index.tolist())]
+
+    # Filter edges to only include those between remaining vertices
+    vertex_names = vertices[NAPISTU_GRAPH_VERTICES.NAME]
+    edges = edges[
+        edges[NAPISTU_GRAPH_EDGES.FROM].isin(vertex_names)
+        & edges[NAPISTU_GRAPH_EDGES.TO].isin(vertex_names)
+    ]
+
+    # Filter reaction sources if present
+    if reaction_sources is not None:
+        reaction_sources = reaction_sources[
+            reaction_sources[SBML_DFS.R_ID].isin(vertex_names)
+        ]
+
+    _validate_neighborhood_consistency(
+        {
+            NEIGHBORHOOD_DICT_KEYS.VERTICES: vertices,
+            NEIGHBORHOOD_DICT_KEYS.EDGES: edges,
+            NEIGHBORHOOD_DICT_KEYS.REACTION_SOURCES: reaction_sources,
+        },
+        sc_id,
+    )
+
+    return vertices, edges, reaction_sources
+
+
+def _create_neighborhood_dict_entry_logging(
+    sc_id: str, one_neighborhood_df: pd.DataFrame, sbml_dfs: sbml_dfs_core.SBML_dfs
+):
+    df_summary = one_neighborhood_df.copy()
+    df_summary[NAPISTU_GRAPH_VERTICES.NODE_TYPE] = [
+        NAPISTU_GRAPH_NODE_TYPES.SPECIES if x else NAPISTU_GRAPH_NODE_TYPES.REACTION
+        for x in df_summary[NAPISTU_GRAPH_VERTICES.NAME].isin(
+            sbml_dfs.compartmentalized_species.index
+        )
+    ]
+    relationship_counts = df_summary.value_counts(
+        ["relationship", "node_type"]
+    ).sort_index()
+
+    relation_strings = list()
+    for relation in relationship_counts.index.get_level_values(0).unique():
+        relation_str = " and ".join(
+            [
+                f"{relationship_counts[relation][i]} {i}"
+                for i in relationship_counts[relation].index
+            ]
+        )
+        relation_strings.append(f"{relation}: {relation_str}")
+
+    msg = f"{sc_id} neighborhood: {'; '.join(relation_strings)}"
+    logger.info(msg)
+
+
+def _find_neighbors(
+    napistu_graph: ig.Graph,
+    compartmentalized_species: list[str],
+    relationship: str,
+    order: int = 3,
+    precomputed_neighbors: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """
+    Find Neighbors
+
+    Identify the neighbors nearby each of the requested compartmentalized_species
+
+    If 'precomputed_neighbors' are provided, neighbors will be summarized by reformatting
+    this table. Otherwise, neighbors will be found on-the-fly using the igraph.neighborhood() method.
+
+    """
+
+    if isinstance(precomputed_neighbors, pd.DataFrame):
+        # add graph indices to neighbors
+        nodes_to_names = (
+            pd.DataFrame(
+                {
+                    NAPISTU_GRAPH_VERTICES.NAME: napistu_graph.vs[
+                        NAPISTU_GRAPH_VERTICES.NAME
+                    ]
+                }
+            )
+            .reset_index()
+            .rename({"index": "neighbor"}, axis=1)
+        )
+
+        if relationship == GRAPH_RELATIONSHIPS.DESCENDANTS:
+            bait_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
+            target_id = NAPISTU_EDGELIST.SC_ID_DEST
+        elif relationship == GRAPH_RELATIONSHIPS.ANCESTORS:
+            bait_id = NAPISTU_EDGELIST.SC_ID_DEST
+            target_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
+        else:
+            raise ValueError(
+                f"relationship must be 'descendants' or 'ancestors' but was {relationship}"
+            )
+
+        neighbors_df = (
+            precomputed_neighbors[
+                precomputed_neighbors[bait_id].isin(compartmentalized_species)
+            ]
+            .merge(
+                nodes_to_names.rename({NAPISTU_GRAPH_VERTICES.NAME: target_id}, axis=1)
+            )
+            .rename({bait_id: SBML_DFS.SC_ID}, axis=1)
+            .drop([target_id], axis=1)
+            .assign(relationship=relationship)
+        )
+    else:
+        if relationship == GRAPH_RELATIONSHIPS.DESCENDANTS:
+            mode_type = "out"
+        elif relationship == GRAPH_RELATIONSHIPS.ANCESTORS:
+            mode_type = "in"
+        else:
+            raise ValueError(
+                f"relationship must be 'descendants' or 'ancestors' but was {relationship}"
+            )
+
+        neighbors = napistu_graph.neighborhood(
+            # mode = out queries outgoing edges and is ignored if the network is undirected
+            vertices=compartmentalized_species,
+            order=order,
+            mode=mode_type,
+        )
+
+        neighbors_df = pd.concat(
+            [
+                pd.DataFrame({SBML_DFS.SC_ID: c, "neighbor": x}, index=range(0, len(x)))
+                for c, x in zip(compartmentalized_species, neighbors)
+            ]
+        ).assign(relationship=relationship)
+
+    return neighbors_df
+
+
+def _find_neighbors_paths(
+    neighborhood_graph: ig.Graph,
+    one_neighborhood_df: pd.DataFrame,
+    sc_id: str,
+    edges: pd.DataFrame,
+) -> tuple[pd.DataFrame, dict[Any, set], pd.DataFrame, dict[Any, set]]:
+    """
+    Find shortest paths between the focal node and its neighbors in both directions.
+
+    This function calculates shortest paths from the focal node to its descendants
+    (downstream) and ancestors (upstream) using igraph's shortest path algorithms.
+    It uses _calculate_path_attrs to compute path attributes including path weights,
+    lengths, and polarity information.
+
+    Parameters
+    ----------
+    neighborhood_graph: ig.Graph
+        The igraph Graph object representing the neighborhood network
+    one_neighborhood_df: pd.DataFrame
+        DataFrame containing neighborhood information with 'relationship' column
+        indicating 'descendants' or 'ancestors' for each node
+    sc_id: str
+        The compartmentalized species ID of the focal node
+    edges: pd.DataFrame
+        DataFrame containing edge information with columns for 'from', 'to',
+        weights, and link polarity
+
+    Returns
+    -------
+    downstream_path_attrs: pd.DataFrame
+        DataFrame containing path attributes for downstream paths from focal node
+        to descendants. Includes columns: neighbor, path_weight, path_length,
+        net_polarity, final_from, final_to, node_orientation
+    downstream_entity_dict: dict[Any, set]
+        Dictionary mapping each descendant neighbor to the set of entities
+        (nodes) connecting it to the focal node
+    upstream_path_attrs: pd.DataFrame
+        DataFrame containing path attributes for upstream paths from focal node
+        to ancestors. Includes columns: neighbor, path_weight, path_length,
+        net_polarity, final_from, final_to, node_orientation
+    upstream_entity_dict: dict[Any, set]
+        Dictionary mapping each ancestor neighbor to the set of entities
+        (nodes) connecting it to the focal node
+    """
+
+    one_descendants_df = one_neighborhood_df[
+        one_neighborhood_df["relationship"] == GRAPH_RELATIONSHIPS.DESCENDANTS
+    ]
+    descendants_list = list(
+        set(one_descendants_df[NAPISTU_GRAPH_VERTICES.NAME].tolist()).union({sc_id})
+    )
+
+    # hide warnings which are mostly just Dijkstra complaining about not finding neighbors
+    with warnings.catch_warnings():
+        # igraph throws warnings for each pair of unconnected species
+        warnings.simplefilter("ignore")
+
+        neighborhood_paths = neighborhood_graph.get_shortest_paths(
+            # focal node
+            v=sc_id,
+            to=descendants_list,
+            weights=NAPISTU_GRAPH_EDGES.WEIGHT,
+            mode="out",
+            output="epath",
+        )
+
+    downstream_path_attrs, downstream_entity_dict = _calculate_path_attrs(
+        neighborhood_paths,
+        edges,
+        vertices=descendants_list,
+        weight_var=NAPISTU_GRAPH_EDGES.WEIGHT,
+    )
+    downstream_path_attrs = downstream_path_attrs.assign(
+        node_orientation=NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM
+    )
+
+    # ancestors -> focal_node
+
+    one_ancestors_df = one_neighborhood_df[
+        one_neighborhood_df["relationship"] == GRAPH_RELATIONSHIPS.ANCESTORS
+    ]
+    ancestors_list = list(
+        set(one_ancestors_df[NAPISTU_GRAPH_VERTICES.NAME].tolist()).union({sc_id})
+    )
+
+    with warnings.catch_warnings():
+        # igraph throws warnings for each pair of unconnected species
+        warnings.simplefilter("ignore")
+
+        neighborhood_paths = neighborhood_graph.get_shortest_paths(
+            v=sc_id,
+            to=ancestors_list,
+            weights=NAPISTU_GRAPH_EDGES.UPSTREAM_WEIGHT,
+            mode="in",
+            output="epath",
+        )
+
+    upstream_path_attrs, upstream_entity_dict = _calculate_path_attrs(
+        neighborhood_paths,
+        edges,
+        vertices=ancestors_list,
+        weight_var=NAPISTU_GRAPH_EDGES.UPSTREAM_WEIGHT,
+    )
+    upstream_path_attrs = upstream_path_attrs.assign(
+        node_orientation=NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM
+    )
+
+    return (
+        downstream_path_attrs,
+        downstream_entity_dict,
+        upstream_path_attrs,
+        upstream_entity_dict,
+    )
+
+
+def _find_reactions_by_relationship(
+    precomputed_neighbors,
+    compartmentalized_species: list,
+    sbml_dfs: sbml_dfs_core.SBML_dfs,
+    relationship: str,
+) -> pd.DataFrame | None:
+    """
+    Find Reactions by Relationship
+
+    Based on an ancestor-descendant edgelist of compartmentalized species find all reactions which involve 2+ members
+
+    Since we primarily care about paths between species and reactions are more of a means-to-an-end of
+    connecting pairs of species precomputed_distances are generated between just pairs of species
+    this also makes the problem feasible since the number of species is upper bounded at <100K but
+    the number of reactions is unbounded. Having a bound ensures that we can calculate
+    the precomputed_distances efficiently using matrix operations whose memory footprint scales with O(N^2).
+    """
+
+    # if there are no neighboring cspecies then there will be no reactions
+    if precomputed_neighbors.shape[0] == 0:
+        return None
+
+    if relationship == GRAPH_RELATIONSHIPS.DESCENDANTS:
+        bait_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
+        target_id = NAPISTU_EDGELIST.SC_ID_DEST
+    elif relationship == GRAPH_RELATIONSHIPS.ANCESTORS:
+        bait_id = NAPISTU_EDGELIST.SC_ID_DEST
+        target_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
+    else:
+        raise ValueError(
+            f"relationship must be 'descendants' or 'ancestors' but was {relationship}"
+        )
+
+    # index by the bait id to create a series with all relatives of the specified relationship
+    indexed_relatives = (
+        precomputed_neighbors[
+            precomputed_neighbors[bait_id].isin(compartmentalized_species)
+        ]
+        .set_index(bait_id)
+        .sort_index()
+    )
+
+    reaction_relatives = list()
+
+    # loop through compartmentalized species in precomputed_neighbors
+    for uq in indexed_relatives.index.unique():
+        relatives = indexed_relatives.loc[uq, target_id]
+        if isinstance(relatives, str):
+            relatives = [relatives]
+        elif isinstance(relatives, pd.Series):
+            relatives = relatives.tolist()
+        else:
+            raise ValueError("relatives is an unexpected type")
+
+        # add the focal node to the set of relatives
+        relatives_cspecies = {*relatives, *[uq]}
+        # count the number of relative cspecies including each reaction
+        rxn_species_counts = sbml_dfs.reaction_species[
+            sbml_dfs.reaction_species[SBML_DFS.SC_ID].isin(relatives_cspecies)
+        ].value_counts(SBML_DFS.R_ID)
+
+        # retain reactions involving 2+ cspecies.
+        # some of these reactions will be irrelevant and will be excluded when
+        # calculating the shortest paths from/to the focal node from each neighbor
+        # in prune_neighborhoods()
+        neighboring_reactions = rxn_species_counts[
+            rxn_species_counts >= 2
+        ].index.tolist()
+
+        # create new entries for reaction relatives
+        kws = {bait_id: uq}
+        new_entries = pd.DataFrame({target_id: neighboring_reactions}).assign(**kws)
+
+        reaction_relatives.append(new_entries)
+
+    reactions_df = pd.concat(reaction_relatives)
+
+    return reactions_df
+
+
 def _precompute_neighbors(
     compartmentalized_species: list[str],
     precomputed_distances: pd.DataFrame,
@@ -1166,225 +1527,81 @@ def _precompute_neighbors(
     return precomputed_neighbors
 
 
-def _build_raw_neighborhood_df(
-    napistu_graph: ig.Graph,
-    compartmentalized_species: list[str],
-    network_type: str,
-    order: int,
-    precomputed_neighbors: pd.DataFrame | None = None,
-) -> pd.DataFrame:
-    # report if network_type is not the default and will be ignored due to the network
-    #   being undirected
-    is_directed = napistu_graph.is_directed()
-    if not is_directed and network_type != NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM:
-        logger.warning(
-            "Network is undirected; network_type will be treated as 'downstream'"
-        )
-        network_type = NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM
-
-    # create the "out-network" of descendant nodes
-    if network_type in [
-        NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM,
-        NEIGHBORHOOD_NETWORK_TYPES.HOURGLASS,
-    ]:
-        descendants_df = _find_neighbors(
-            napistu_graph=napistu_graph,
-            compartmentalized_species=compartmentalized_species,
-            relationship=GRAPH_RELATIONSHIPS.DESCENDANTS,
-            order=order,
-            precomputed_neighbors=precomputed_neighbors,
-        )
-
-    # create the "in-network" of ancestor nodes
-    if network_type in [
-        NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM,
-        NEIGHBORHOOD_NETWORK_TYPES.HOURGLASS,
-    ]:
-        ancestors_df = _find_neighbors(
-            napistu_graph=napistu_graph,
-            compartmentalized_species=compartmentalized_species,
-            relationship=GRAPH_RELATIONSHIPS.ANCESTORS,
-            order=order,
-            precomputed_neighbors=precomputed_neighbors,
-        )
-
-    if network_type == NEIGHBORHOOD_NETWORK_TYPES.HOURGLASS:
-        # merge descendants and ancestors
-        neighborhood_df = pd.concat([ancestors_df, descendants_df])
-    elif network_type == NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM:
-        neighborhood_df = descendants_df
-    elif network_type == NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM:
-        neighborhood_df = ancestors_df
-    else:
-        raise NotImplementedError("invalid network_type")
-
-    # add name since this is an easy way to lookup igraph vertices
-    neighborhood_df[NAPISTU_GRAPH_VERTICES.NAME] = [
-        x[NAPISTU_GRAPH_VERTICES.NAME]
-        for x in napistu_graph.vs[neighborhood_df["neighbor"]]
-    ]
-
-    return neighborhood_df
-
-
-def _find_neighbors(
-    napistu_graph: ig.Graph,
-    compartmentalized_species: list[str],
-    relationship: str,
-    order: int = 3,
-    precomputed_neighbors: pd.DataFrame | None = None,
-) -> pd.DataFrame:
+def _process_path_information(
+    neighborhood_graph: ig.Graph,
+    one_neighborhood_df: pd.DataFrame,
+    sc_id: str,
+    edges: pd.DataFrame,
+    vertices: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
     """
-    Find Neighbors
+    Process shortest path information and merge with vertices/edges.
 
-    Identify the neighbors nearby each of the requested compartmentalized_species
-
-    If 'precomputed_neighbors' are provided, neighbors will be summarized by reformatting
-    this table. Otherwise, neighbors will be found on-the-fly using the igraph.neighborhood() method.
-
+    Handles the complex path-finding logic and attribute merging that was
+    cluttering the main function.
     """
-
-    if isinstance(precomputed_neighbors, pd.DataFrame):
-        # add graph indices to neighbors
-        nodes_to_names = (
-            pd.DataFrame(
-                {
-                    NAPISTU_GRAPH_VERTICES.NAME: napistu_graph.vs[
-                        NAPISTU_GRAPH_VERTICES.NAME
-                    ]
-                }
-            )
-            .reset_index()
-            .rename({"index": "neighbor"}, axis=1)
-        )
-
-        if relationship == GRAPH_RELATIONSHIPS.DESCENDANTS:
-            bait_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
-            target_id = NAPISTU_EDGELIST.SC_ID_DEST
-        elif relationship == GRAPH_RELATIONSHIPS.ANCESTORS:
-            bait_id = NAPISTU_EDGELIST.SC_ID_DEST
-            target_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
-        else:
-            raise ValueError(
-                f"relationship must be 'descendants' or 'ancestors' but was {relationship}"
-            )
-
-        neighbors_df = (
-            precomputed_neighbors[
-                precomputed_neighbors[bait_id].isin(compartmentalized_species)
-            ]
-            .merge(
-                nodes_to_names.rename({NAPISTU_GRAPH_VERTICES.NAME: target_id}, axis=1)
-            )
-            .rename({bait_id: SBML_DFS.SC_ID}, axis=1)
-            .drop([target_id], axis=1)
-            .assign(relationship=relationship)
-        )
-    else:
-        if relationship == GRAPH_RELATIONSHIPS.DESCENDANTS:
-            mode_type = "out"
-        elif relationship == GRAPH_RELATIONSHIPS.ANCESTORS:
-            mode_type = "in"
-        else:
-            raise ValueError(
-                f"relationship must be 'descendants' or 'ancestors' but was {relationship}"
-            )
-
-        neighbors = napistu_graph.neighborhood(
-            # mode = out queries outgoing edges and is ignored if the network is undirected
-            vertices=compartmentalized_species,
-            order=order,
-            mode=mode_type,
-        )
-
-        neighbors_df = pd.concat(
-            [
-                pd.DataFrame({SBML_DFS.SC_ID: c, "neighbor": x}, index=range(0, len(x)))
-                for c, x in zip(compartmentalized_species, neighbors)
-            ]
-        ).assign(relationship=relationship)
-
-    return neighbors_df
-
-
-def _find_reactions_by_relationship(
-    precomputed_neighbors,
-    compartmentalized_species: list,
-    sbml_dfs: sbml_dfs_core.SBML_dfs,
-    relationship: str,
-) -> pd.DataFrame | None:
-    """
-    Find Reactions by Relationship
-
-    Based on an ancestor-descendant edgelist of compartmentalized species find all reactions which involve 2+ members
-
-    Since we primarily care about paths between species and reactions are more of a means-to-an-end of
-    connecting pairs of species precomputed_distances are generated between just pairs of species
-    this also makes the problem feasible since the number of species is upper bounded at <100K but
-    the number of reactions is unbounded. Having a bound ensures that we can calculate
-    the precomputed_distances efficiently using matrix operations whose memory footprint scales with O(N^2).
-    """
-
-    # if there are no neighboring cspecies then there will be no reactions
-    if precomputed_neighbors.shape[0] == 0:
-        return None
-
-    if relationship == GRAPH_RELATIONSHIPS.DESCENDANTS:
-        bait_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
-        target_id = NAPISTU_EDGELIST.SC_ID_DEST
-    elif relationship == GRAPH_RELATIONSHIPS.ANCESTORS:
-        bait_id = NAPISTU_EDGELIST.SC_ID_DEST
-        target_id = NAPISTU_EDGELIST.SC_ID_ORIGIN
-    else:
-        raise ValueError(
-            f"relationship must be 'descendants' or 'ancestors' but was {relationship}"
-        )
-
-    # index by the bait id to create a series with all relatives of the specified relationship
-    indexed_relatives = (
-        precomputed_neighbors[
-            precomputed_neighbors[bait_id].isin(compartmentalized_species)
-        ]
-        .set_index(bait_id)
-        .sort_index()
+    # Find paths to neighbors
+    (
+        downstream_path_attrs,
+        downstream_entity_dict,
+        upstream_path_attrs,
+        upstream_entity_dict,
+    ) = _find_neighbors_paths(
+        neighborhood_graph,
+        one_neighborhood_df,
+        sc_id,
+        edges,
     )
 
-    reaction_relatives = list()
+    # Combine upstream and downstream shortest paths
+    vertex_neighborhood_attrs = (
+        pd.concat([downstream_path_attrs, upstream_path_attrs])
+        .sort_values(DISTANCES.PATH_WEIGHT)
+        .groupby("neighbor")
+        .first()
+    )
+    # Label the focal node
+    vertex_neighborhood_attrs.loc[sc_id, "node_orientation"] = GRAPH_RELATIONSHIPS.FOCAL
 
-    # loop through compartmentalized species in precomputed_neighbors
-    for uq in indexed_relatives.index.unique():
-        relatives = indexed_relatives.loc[uq, target_id]
-        if isinstance(relatives, str):
-            relatives = [relatives]
-        elif isinstance(relatives, pd.Series):
-            relatives = relatives.tolist()
-        else:
-            raise ValueError("relatives is an unexpected type")
+    # Validate expected attributes are present
+    EXPECTED_VERTEX_ATTRS = {
+        DISTANCES.FINAL_FROM,
+        DISTANCES.FINAL_TO,
+        NET_POLARITY.NET_POLARITY,
+    }
+    missing_vertex_attrs = EXPECTED_VERTEX_ATTRS.difference(
+        set(vertex_neighborhood_attrs.columns.tolist())
+    )
 
-        # add the focal node to the set of relatives
-        relatives_cspecies = {*relatives, *[uq]}
-        # count the number of relative cspecies including each reaction
-        rxn_species_counts = sbml_dfs.reaction_species[
-            sbml_dfs.reaction_species[SBML_DFS.SC_ID].isin(relatives_cspecies)
-        ].value_counts(SBML_DFS.R_ID)
+    if len(missing_vertex_attrs) > 0:
+        raise ValueError(
+            f"vertex_neighborhood_attrs did not contain the expected columns: {EXPECTED_VERTEX_ATTRS}."
+            "This is likely because of inconsistencies between the precomputed distances, graph and/or sbml_dfs."
+            "Please try ng_utils.validate_assets() to check for consistency."
+        )
 
-        # retain reactions involving 2+ cspecies.
-        # some of these reactions will be irrelevant and will be excluded when
-        # calculating the shortest paths from/to the focal node from each neighbor
-        # in prune_neighborhoods()
-        neighboring_reactions = rxn_species_counts[
-            rxn_species_counts >= 2
-        ].index.tolist()
+    # Add net_polarity to edges
+    edges = edges.merge(
+        vertex_neighborhood_attrs.reset_index()[
+            [DISTANCES.FINAL_FROM, DISTANCES.FINAL_TO, NET_POLARITY.NET_POLARITY]
+        ].dropna(),
+        left_on=[NAPISTU_GRAPH_EDGES.FROM, NAPISTU_GRAPH_EDGES.TO],
+        right_on=[DISTANCES.FINAL_FROM, DISTANCES.FINAL_TO],
+        how="left",
+    )
 
-        # create new entries for reaction relatives
-        kws = {bait_id: uq}
-        new_entries = pd.DataFrame({target_id: neighboring_reactions}).assign(**kws)
+    # Merge path attributes with vertices
+    vertices = vertices.merge(
+        vertex_neighborhood_attrs, left_on=NAPISTU_GRAPH_VERTICES.NAME, right_index=True
+    )
 
-        reaction_relatives.append(new_entries)
+    # Package path entities
+    neighborhood_path_entities = {
+        NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM: downstream_entity_dict,
+        NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM: upstream_entity_dict,
+    }
 
-    reactions_df = pd.concat(reaction_relatives)
-
-    return reactions_df
+    return vertices, edges, neighborhood_path_entities
 
 
 def _prune_vertex_set(one_neighborhood: dict, top_n: int) -> pd.DataFrame:
@@ -1458,229 +1675,6 @@ def _prune_vertex_set(one_neighborhood: dict, top_n: int) -> pd.DataFrame:
     return pruned_vertices
 
 
-def _calculate_path_attrs(
-    neighborhood_paths: list[list],
-    edges: pd.DataFrame,
-    vertices: list,
-    weight_var: str = NAPISTU_GRAPH_EDGES.WEIGHT,
-) -> tuple[pd.DataFrame, dict[Any, set]]:
-    """
-    Calculate Path Attributes
-
-    Return the vertices and path weights (sum of edge weights) for a list of paths.
-
-    Parameters
-    ----------
-    neighborhood_paths: list
-        List of lists of edge indices
-    edges: pd.DataFrame
-        Edges with rows correponding to entries in neighborhood_paths inner lists
-    vertices: list
-        List of vertices correponding to the ordering of neighborhood_paths
-    weights_var: str
-        variable in edges to use for scoring path weights
-
-    Returns
-    -------
-    path_attributes_df: pd.DataFrame
-        A table containing attributes summarizing the path to each neighbor
-    neighborhood_path_entities: dict
-        Dict mapping from each neighbor to the entities connecting it to the focal node
-
-    """
-
-    if not isinstance(neighborhood_paths, list):
-        raise TypeError("neighborhood_paths should be a list of lists of edge indices")
-    if not isinstance(vertices, list):
-        raise TypeError("vertices should be a list of list of vertices")
-    if len(vertices) <= 0:
-        raise ValueError("vertices must have length greater than zero")
-    if len(neighborhood_paths) != len(vertices):
-        raise ValueError("vertices and neighborhood_paths were not the same length")
-
-    if any([len(x) > 0 for x in neighborhood_paths]):
-        all_path_edges = (
-            # create a table of edges traversed to reach each neighbor
-            pd.concat(
-                [
-                    edges.iloc[neighborhood_paths[i]].assign(neighbor=vertices[i])
-                    for i in range(0, len(neighborhood_paths))
-                ]
-            ).groupby("neighbor")
-        )
-
-        # if all_path_edges.ngroups > 0:
-        path_attributes_df = pd.concat(
-            [
-                all_path_edges[weight_var].agg("sum").rename(DISTANCES.PATH_WEIGHT),
-                all_path_edges.agg("size").rename(DISTANCES.PATH_LENGTH),
-                all_path_edges[NET_POLARITY.LINK_POLARITY]
-                .agg(paths._terminal_net_polarity)
-                .rename(NET_POLARITY.NET_POLARITY),
-                # add the final edge since this can be used to add path attributes to edges
-                # i.e., apply net_polarity to an edge
-                all_path_edges["from"].agg("last").rename(DISTANCES.FINAL_FROM),
-                all_path_edges["to"].agg("last").rename(DISTANCES.FINAL_TO),
-            ],
-            axis=1,
-        ).reset_index()
-
-        # create a dict mapping from a neighbor to all mediating nodes
-        neighborhood_path_entities = {
-            group_name: set().union(*[dat["from"], dat["to"]])
-            for group_name, dat in all_path_edges
-        }
-
-    else:
-        # catch case where there are no paths
-        path_attributes_df = pd.DataFrame()
-        neighborhood_path_entities = dict()
-
-    # add entries with no edges
-    edgeless_nodes = [
-        vertices[i]
-        for i in range(0, len(neighborhood_paths))
-        if len(neighborhood_paths[i]) == 0
-    ]
-    edgeles_nodes_df = pd.DataFrame({"neighbor": edgeless_nodes}).assign(
-        **{
-            DISTANCES.PATH_LENGTH: 0,
-            DISTANCES.PATH_WEIGHT: 0,
-            NET_POLARITY.NET_POLARITY: None,
-        }
-    )
-
-    # add edgeless entries as entries in the two outputs
-    path_attributes_df = pd.concat([path_attributes_df, edgeles_nodes_df])
-    neighborhood_path_entities.update({x: {x} for x in edgeless_nodes})
-
-    if path_attributes_df.shape[0] != len(neighborhood_paths):
-        raise ValueError(
-            "path_attributes_df row count must match number of neighborhood_paths"
-        )
-    if len(neighborhood_path_entities) != len(neighborhood_paths):
-        raise ValueError(
-            "neighborhood_path_entities length must match number of neighborhood_paths"
-        )
-
-    return path_attributes_df, neighborhood_path_entities
-
-
-def _find_neighbors_paths(
-    neighborhood_graph: ig.Graph,
-    one_neighborhood_df: pd.DataFrame,
-    sc_id: str,
-    edges: pd.DataFrame,
-) -> tuple[pd.DataFrame, dict[Any, set], pd.DataFrame, dict[Any, set]]:
-    """
-    Find shortest paths between the focal node and its neighbors in both directions.
-
-    This function calculates shortest paths from the focal node to its descendants
-    (downstream) and ancestors (upstream) using igraph's shortest path algorithms.
-    It uses _calculate_path_attrs to compute path attributes including path weights,
-    lengths, and polarity information.
-
-    Parameters
-    ----------
-    neighborhood_graph: ig.Graph
-        The igraph Graph object representing the neighborhood network
-    one_neighborhood_df: pd.DataFrame
-        DataFrame containing neighborhood information with 'relationship' column
-        indicating 'descendants' or 'ancestors' for each node
-    sc_id: str
-        The compartmentalized species ID of the focal node
-    edges: pd.DataFrame
-        DataFrame containing edge information with columns for 'from', 'to',
-        weights, and link polarity
-
-    Returns
-    -------
-    downstream_path_attrs: pd.DataFrame
-        DataFrame containing path attributes for downstream paths from focal node
-        to descendants. Includes columns: neighbor, path_weight, path_length,
-        net_polarity, final_from, final_to, node_orientation
-    downstream_entity_dict: dict[Any, set]
-        Dictionary mapping each descendant neighbor to the set of entities
-        (nodes) connecting it to the focal node
-    upstream_path_attrs: pd.DataFrame
-        DataFrame containing path attributes for upstream paths from focal node
-        to ancestors. Includes columns: neighbor, path_weight, path_length,
-        net_polarity, final_from, final_to, node_orientation
-    upstream_entity_dict: dict[Any, set]
-        Dictionary mapping each ancestor neighbor to the set of entities
-        (nodes) connecting it to the focal node
-    """
-
-    one_descendants_df = one_neighborhood_df[
-        one_neighborhood_df["relationship"] == GRAPH_RELATIONSHIPS.DESCENDANTS
-    ]
-    descendants_list = list(
-        set(one_descendants_df[NAPISTU_GRAPH_VERTICES.NAME].tolist()).union({sc_id})
-    )
-
-    # hide warnings which are mostly just Dijkstra complaining about not finding neighbors
-    with warnings.catch_warnings():
-        # igraph throws warnings for each pair of unconnected species
-        warnings.simplefilter("ignore")
-
-        neighborhood_paths = neighborhood_graph.get_shortest_paths(
-            # focal node
-            v=sc_id,
-            to=descendants_list,
-            weights=NAPISTU_GRAPH_EDGES.WEIGHT,
-            mode="out",
-            output="epath",
-        )
-
-    downstream_path_attrs, downstream_entity_dict = _calculate_path_attrs(
-        neighborhood_paths,
-        edges,
-        vertices=descendants_list,
-        weight_var=NAPISTU_GRAPH_EDGES.WEIGHT,
-    )
-    downstream_path_attrs = downstream_path_attrs.assign(
-        node_orientation=NEIGHBORHOOD_NETWORK_TYPES.DOWNSTREAM
-    )
-
-    # ancestors -> focal_node
-
-    one_ancestors_df = one_neighborhood_df[
-        one_neighborhood_df["relationship"] == GRAPH_RELATIONSHIPS.ANCESTORS
-    ]
-    ancestors_list = list(
-        set(one_ancestors_df[NAPISTU_GRAPH_VERTICES.NAME].tolist()).union({sc_id})
-    )
-
-    with warnings.catch_warnings():
-        # igraph throws warnings for each pair of unconnected species
-        warnings.simplefilter("ignore")
-
-        neighborhood_paths = neighborhood_graph.get_shortest_paths(
-            v=sc_id,
-            to=ancestors_list,
-            weights=NAPISTU_GRAPH_EDGES.UPSTREAM_WEIGHT,
-            mode="in",
-            output="epath",
-        )
-
-    upstream_path_attrs, upstream_entity_dict = _calculate_path_attrs(
-        neighborhood_paths,
-        edges,
-        vertices=ancestors_list,
-        weight_var=NAPISTU_GRAPH_EDGES.UPSTREAM_WEIGHT,
-    )
-    upstream_path_attrs = upstream_path_attrs.assign(
-        node_orientation=NEIGHBORHOOD_NETWORK_TYPES.UPSTREAM
-    )
-
-    return (
-        downstream_path_attrs,
-        downstream_entity_dict,
-        upstream_path_attrs,
-        upstream_entity_dict,
-    )
-
-
 def _validate_neighborhood_consistency(neighborhood: dict, sc_id: str) -> None:
     """
     Validate that a single neighborhood has consistent vertices, edges, and reaction_sources.
@@ -1714,3 +1708,5 @@ def _validate_neighborhood_consistency(neighborhood: dict, sc_id: str) -> None:
             raise ValueError(
                 f"{sc_id} neighborhood: {len(extra_source_vertices)} vertices were present in reaction_sources but not vertices: {list(extra_source_vertices)[:10]}{'...' if len(extra_source_vertices) > 10 else ''}"
             )
+
+    return None

--- a/src/napistu/network/ng_core.py
+++ b/src/napistu/network/ng_core.py
@@ -935,10 +935,10 @@ class NapistuGraph(ig.Graph):
         edges_df = self.get_edge_dataframe()
 
         # Use the already-transformed edge data (transformations should have been applied in transform_edges)
-        edges_df = self._create_source_weights(edges_df, "source_wt")
+        edges_df = self._create_source_weights(edges_df, NAPISTU_GRAPH_EDGES.SOURCE_WT)
 
         score_vars = list(reaction_attrs.keys())
-        score_vars.append("source_wt")
+        score_vars.append(NAPISTU_GRAPH_EDGES.SOURCE_WT)
 
         logger.info(f"Creating mixed scores based on {', '.join(score_vars)}")
 
@@ -951,7 +951,7 @@ class NapistuGraph(ig.Graph):
             ]
 
         # add other attributes and update transformed attributes
-        self.es["source_wt"] = edges_df["source_wt"]
+        self.es[NAPISTU_GRAPH_EDGES.SOURCE_WT] = edges_df[NAPISTU_GRAPH_EDGES.SOURCE_WT]
         for k in reaction_attrs.keys():
             self.es[k] = edges_df[k]
 
@@ -960,9 +960,9 @@ class NapistuGraph(ig.Graph):
     def _create_source_weights(
         self,
         edges_df: pd.DataFrame,
-        source_wt_var: str = "source_wt",
+        source_wt_var: str = NAPISTU_GRAPH_EDGES.SOURCE_WT,
         source_vars_dict: dict = SOURCE_VARS_DICT,
-        source_wt_default: int = 1,
+        source_wt_default: float = 1,
     ) -> pd.DataFrame:
         """
         Create weights based on an edge's source.
@@ -975,8 +975,8 @@ class NapistuGraph(ig.Graph):
             The name of the column to store the source weights. Default is "source_wt".
         source_vars_dict : dict, optional
             Dictionary with keys indicating edge attributes and values indicating the weight to assign to that attribute. Default is SOURCE_VARS_DICT.
-        source_wt_default : int, optional
-            The default weight to assign to an edge if no other weight attribute is found. Default is 1.
+        source_wt_default : float, optional
+            The default weight to assign to an edge if no other weight attribute is found. Default is 0.5.
 
         Returns
         -------

--- a/src/napistu/network/ng_utils.py
+++ b/src/napistu/network/ng_utils.py
@@ -261,19 +261,6 @@ def get_minimal_sources_edges(
                     )
                 return None
 
-        # Debug: Log the input data
-        if verbose:
-            logger.info(f"get_minimal_sources_edges: Input nodes count: {len(nodes)}")
-            logger.info(
-                f"get_minimal_sources_edges: present_reactions count: {len(present_reactions)}"
-            )
-            logger.info(
-                f"get_minimal_sources_edges: source_df shape: {source_df.shape}"
-            )
-            logger.info(
-                f"get_minimal_sources_edges: source_df unique reactions: {len(source_df.index.get_level_values(0).unique())}"
-            )
-
         reaction_sources = source.source_set_coverage(
             source_df,
             source_total_counts,
@@ -281,41 +268,7 @@ def get_minimal_sources_edges(
             min_pw_size=min_pw_size,
             verbose=verbose,
         )
-
-        # Debug: Log the output before filtering
-        if verbose and reaction_sources is not None:
-            reaction_sources_reset = reaction_sources.reset_index()
-            logger.info(
-                f"get_minimal_sources_edges: reaction_sources before filtering shape: {reaction_sources_reset.shape}"
-            )
-            logger.info(
-                f"get_minimal_sources_edges: reaction_sources unique reactions before filtering: {len(reaction_sources_reset[SBML_DFS.R_ID].unique())}"
-            )
-
-            # Check for extra reactions
-            extra_reactions = set(reaction_sources_reset[SBML_DFS.R_ID]) - set(nodes)
-            if len(extra_reactions) > 0:
-                logger.warning(
-                    f"get_minimal_sources_edges: Found {len(extra_reactions)} extra reactions in source_set_coverage output: "
-                    f"{list(extra_reactions)[:10]}{'...' if len(extra_reactions) > 10 else ''}"
-                )
-
-        # Filter to only include reactions that were in the original input vertices
-        # source_set_coverage returns all reactions from selected pathways, but we only want
-        # reactions that were present in the neighborhood
-        reaction_sources = reaction_sources.reset_index()
-        reaction_sources = reaction_sources[reaction_sources[SBML_DFS.R_ID].isin(nodes)]
-
-        # Debug: Log the final output
-        if verbose:
-            logger.info(
-                f"get_minimal_sources_edges: Final reaction_sources shape: {reaction_sources.shape}"
-            )
-            logger.info(
-                f"get_minimal_sources_edges: Final unique reactions: {len(reaction_sources[SBML_DFS.R_ID].unique())}"
-            )
-
-        return reaction_sources[
+        return reaction_sources.reset_index()[
             [SBML_DFS.R_ID, SOURCE_SPEC.PATHWAY_ID, SOURCE_SPEC.NAME]
         ]
 

--- a/src/napistu/network/ng_utils.py
+++ b/src/napistu/network/ng_utils.py
@@ -261,6 +261,19 @@ def get_minimal_sources_edges(
                     )
                 return None
 
+        # Debug: Log the input data
+        if verbose:
+            logger.info(f"get_minimal_sources_edges: Input nodes count: {len(nodes)}")
+            logger.info(
+                f"get_minimal_sources_edges: present_reactions count: {len(present_reactions)}"
+            )
+            logger.info(
+                f"get_minimal_sources_edges: source_df shape: {source_df.shape}"
+            )
+            logger.info(
+                f"get_minimal_sources_edges: source_df unique reactions: {len(source_df.index.get_level_values(0).unique())}"
+            )
+
         reaction_sources = source.source_set_coverage(
             source_df,
             source_total_counts,
@@ -268,7 +281,41 @@ def get_minimal_sources_edges(
             min_pw_size=min_pw_size,
             verbose=verbose,
         )
-        return reaction_sources.reset_index()[
+
+        # Debug: Log the output before filtering
+        if verbose and reaction_sources is not None:
+            reaction_sources_reset = reaction_sources.reset_index()
+            logger.info(
+                f"get_minimal_sources_edges: reaction_sources before filtering shape: {reaction_sources_reset.shape}"
+            )
+            logger.info(
+                f"get_minimal_sources_edges: reaction_sources unique reactions before filtering: {len(reaction_sources_reset[SBML_DFS.R_ID].unique())}"
+            )
+
+            # Check for extra reactions
+            extra_reactions = set(reaction_sources_reset[SBML_DFS.R_ID]) - set(nodes)
+            if len(extra_reactions) > 0:
+                logger.warning(
+                    f"get_minimal_sources_edges: Found {len(extra_reactions)} extra reactions in source_set_coverage output: "
+                    f"{list(extra_reactions)[:10]}{'...' if len(extra_reactions) > 10 else ''}"
+                )
+
+        # Filter to only include reactions that were in the original input vertices
+        # source_set_coverage returns all reactions from selected pathways, but we only want
+        # reactions that were present in the neighborhood
+        reaction_sources = reaction_sources.reset_index()
+        reaction_sources = reaction_sources[reaction_sources[SBML_DFS.R_ID].isin(nodes)]
+
+        # Debug: Log the final output
+        if verbose:
+            logger.info(
+                f"get_minimal_sources_edges: Final reaction_sources shape: {reaction_sources.shape}"
+            )
+            logger.info(
+                f"get_minimal_sources_edges: Final unique reactions: {len(reaction_sources[SBML_DFS.R_ID].unique())}"
+            )
+
+        return reaction_sources[
             [SBML_DFS.R_ID, SOURCE_SPEC.PATHWAY_ID, SOURCE_SPEC.NAME]
         ]
 

--- a/src/napistu/sbml_dfs_core.py
+++ b/src/napistu/sbml_dfs_core.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 import copy
 import logging
 import re
-from typing import Any
-from typing import Iterable
-from typing import Mapping
-from typing import MutableMapping
-from typing import TYPE_CHECKING
-from typing import Optional
-from typing import Union
+import warnings
+from typing import Any, Iterable, Mapping, MutableMapping, TYPE_CHECKING, Optional, Union
 
-from fs import open_fs
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 import pandas as pd
 
 from napistu import identifiers

--- a/src/napistu/sbml_dfs_core.py
+++ b/src/napistu/sbml_dfs_core.py
@@ -4,7 +4,15 @@ import copy
 import logging
 import re
 import warnings
-from typing import Any, Iterable, Mapping, MutableMapping, TYPE_CHECKING, Optional, Union
+from typing import (
+    Any,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    TYPE_CHECKING,
+    Optional,
+    Union,
+)
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import copy
-
 import logging
 import re
 from typing import Any, Optional, Iterable
-from fs import open_fs
+import warnings
 
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
 import numpy as np
 import pandas as pd
+
 from napistu import utils
 from napistu import identifiers
 from napistu import indices

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -190,6 +190,18 @@ def construct_formula_string(
         )
     ]
 
+    if all(
+        reaction_species_df[SBML_DFS.SBO_TERM]
+        == MINI_SBO_FROM_NAME[SBOTERM_NAMES.INTERACTOR]
+    ):
+        labels = reaction_species_df["label"].tolist()
+        if len(labels) != 2:
+            logger.warning(
+                f"Reaction {reaction_species_df[SBML_DFS.R_ID].iloc[0]} has {len(labels)} species, expected 2"
+            )
+            return None
+        return f"{labels[0]} ---- {labels[1]}"
+
     rxn_reversible = bool(
         reactions_df.loc[
             reaction_species_df[SBML_DFS.R_ID].iloc[0], SBML_DFS.R_ISREVERSIBLE
@@ -210,9 +222,13 @@ def construct_formula_string(
             reaction_species_df[SBML_DFS.STOICHIOMETRY] < 0
         ].tolist()
     )
+    product_sbo_terms = [
+        MINI_SBO_FROM_NAME[SBOTERM_NAMES.PRODUCT],
+        MINI_SBO_FROM_NAME[SBOTERM_NAMES.MODIFIER],
+    ]
     products = " + ".join(
         reaction_species_df["label"][
-            reaction_species_df[SBML_DFS.STOICHIOMETRY] > 0
+            reaction_species_df[SBML_DFS.SBO_TERM].isin(product_sbo_terms)
         ].tolist()
     )
     modifiers = " + ".join(
@@ -220,6 +236,7 @@ def construct_formula_string(
             reaction_species_df[SBML_DFS.STOICHIOMETRY] == 0
         ].tolist()
     )
+
     if modifiers != "":
         modifiers = f" ---- modifiers: {modifiers}]"
 

--- a/src/napistu/source.py
+++ b/src/napistu/source.py
@@ -357,10 +357,7 @@ def source_set_coverage(
             )
 
     # rollup pathways with identical membership
-    if source_total_counts is None:
-        deduplicated_sources = _deduplicate_source_df(select_sources_df)
-    else:
-        deduplicated_sources = select_sources_df
+    deduplicated_sources = _deduplicate_source_df(select_sources_df)
 
     unaccounted_for_members = deduplicated_sources
     retained_pathway_ids = []
@@ -393,31 +390,6 @@ def source_set_coverage(
     minimial_sources = deduplicated_sources[
         deduplicated_sources[SOURCE_SPEC.PATHWAY_ID].isin(retained_pathway_ids)
     ].sort_index()
-
-    # Debug: Log what's being returned
-    if verbose:
-        logger.info(
-            f"source_set_coverage: Input select_sources_df shape: {select_sources_df.shape}"
-        )
-        logger.info(
-            f"source_set_coverage: Input unique reactions: {len(select_sources_df.index.get_level_values(0).unique())}"
-        )
-        logger.info(
-            f"source_set_coverage: Output minimial_sources shape: {minimial_sources.shape}"
-        )
-        logger.info(
-            f"source_set_coverage: Output unique reactions: {len(minimial_sources.index.get_level_values(0).unique())}"
-        )
-
-        # Check if we're adding extra reactions
-        input_reactions = set(select_sources_df.index.get_level_values(0).unique())
-        output_reactions = set(minimial_sources.index.get_level_values(0).unique())
-        extra_reactions = output_reactions - input_reactions
-        if len(extra_reactions) > 0:
-            logger.warning(
-                f"source_set_coverage: Found {len(extra_reactions)} extra reactions in output: "
-                f"{list(extra_reactions)[:10]}{'...' if len(extra_reactions) > 10 else ''}"
-            )
 
     return minimial_sources
 

--- a/src/napistu/source.py
+++ b/src/napistu/source.py
@@ -357,7 +357,10 @@ def source_set_coverage(
             )
 
     # rollup pathways with identical membership
-    deduplicated_sources = _deduplicate_source_df(select_sources_df)
+    if source_total_counts is None:
+        deduplicated_sources = _deduplicate_source_df(select_sources_df)
+    else:
+        deduplicated_sources = select_sources_df
 
     unaccounted_for_members = deduplicated_sources
     retained_pathway_ids = []
@@ -390,6 +393,31 @@ def source_set_coverage(
     minimial_sources = deduplicated_sources[
         deduplicated_sources[SOURCE_SPEC.PATHWAY_ID].isin(retained_pathway_ids)
     ].sort_index()
+
+    # Debug: Log what's being returned
+    if verbose:
+        logger.info(
+            f"source_set_coverage: Input select_sources_df shape: {select_sources_df.shape}"
+        )
+        logger.info(
+            f"source_set_coverage: Input unique reactions: {len(select_sources_df.index.get_level_values(0).unique())}"
+        )
+        logger.info(
+            f"source_set_coverage: Output minimial_sources shape: {minimial_sources.shape}"
+        )
+        logger.info(
+            f"source_set_coverage: Output unique reactions: {len(minimial_sources.index.get_level_values(0).unique())}"
+        )
+
+        # Check if we're adding extra reactions
+        input_reactions = set(select_sources_df.index.get_level_values(0).unique())
+        output_reactions = set(minimial_sources.index.get_level_values(0).unique())
+        extra_reactions = output_reactions - input_reactions
+        if len(extra_reactions) > 0:
+            logger.warning(
+                f"source_set_coverage: Found {len(extra_reactions)} extra reactions in output: "
+                f"{list(extra_reactions)[:10]}{'...' if len(extra_reactions) > 10 else ''}"
+            )
 
     return minimial_sources
 

--- a/src/napistu/utils.py
+++ b/src/napistu/utils.py
@@ -11,6 +11,7 @@ import requests
 import shutil
 import urllib.request as request
 import zipfile
+import warnings
 from contextlib import closing
 from itertools import starmap
 from textwrap import fill
@@ -25,15 +26,17 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-from fs import open_fs
-from fs.copy import copy_dir
-from fs.copy import copy_file
-from fs.copy import copy_fs
-from fs.errors import CreateFailed
-from fs.errors import ResourceNotFound
-from fs.tarfs import TarFS
-from fs.tempfs import TempFS
-from fs.zipfs import ZipFS
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+    from fs import open_fs
+    from fs.copy import copy_dir
+    from fs.copy import copy_file
+    from fs.copy import copy_fs
+    from fs.errors import CreateFailed
+    from fs.errors import ResourceNotFound
+    from fs.tarfs import TarFS
+    from fs.tempfs import TempFS
+    from fs.zipfs import ZipFS
 
 from napistu.constants import FILE_EXT_GZ
 from napistu.constants import FILE_EXT_ZIP

--- a/src/napistu/utils.py
+++ b/src/napistu/utils.py
@@ -26,6 +26,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
     from fs import open_fs


### PR DESCRIPTION
- Suppress warning when importing `fs`. Closes #175 
- neighborhoods
    - refactored `find_neighborhoods` to pull out utility function
    - added util for validating that vertices are consistent across vertices, edges, and reaction_sources
    - reaction_sources were not being appropriately filtered if no reactions were in a pruned neighborhood. This happened when there were just species-species edges from high confidence STRING interactions. Closes #174
- only deduplicated pathways if `reaction_sources_total_counts`  is not provided. Closes #161
- added an argument to `filter_singleton_nodes` so by default this only filters reactions. Closes #157