### PR TITLE
Issue 180 - added semantic search to the MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 
 napistu_data
 docs/source/generated/
+chroma_db

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.5.3
+version = 0.5.4
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -65,12 +65,14 @@ dev =
     ruff
     testcontainers
 mcp = 
+    chromadb>=0.4.15,<1.0.0
     fastmcp>=2.0.0,<2.9.0
-    mcp>=1.0.0,<2.0.0  
     httpx>=0.24.0
-    markdown>=3.4.0
     jupyter-client>=7.0.0
+    markdown>=3.4.0
+    mcp>=1.0.0,<2.0.0  
     nbformat>=5.0.0
+    sentence-transformers>=2.2.0,<3.0.0
 rpy2 =
     rpy2>=3.5.0,<4.0.0
     rpy2-arrow>=0.1.0,<1.0.0

--- a/src/napistu/mcp/codebase.py
+++ b/src/napistu/mcp/codebase.py
@@ -12,12 +12,37 @@ from napistu.mcp.component_base import ComponentState, MCPComponent
 from napistu.mcp.constants import NAPISTU_PY_READTHEDOCS_API
 from napistu.mcp import codebase_utils
 from napistu.mcp import utils as mcp_utils
+from napistu.mcp.semantic_search import SemanticSearch
 
 logger = logging.getLogger(__name__)
 
 
 class CodebaseState(ComponentState):
-    """State management for codebase component."""
+    """
+    State management for codebase component with semantic search capabilities.
+
+    Manages cached codebase information and tracks semantic search availability.
+    Extends ComponentState to provide standardized health monitoring and status reporting.
+
+    Attributes
+    ----------
+    codebase_cache : Dict[str, Dict[str, Any]]
+        Dictionary containing cached codebase information organized by type:
+        - modules: Module documentation and metadata
+        - classes: Class documentation and metadata
+        - functions: Function documentation, signatures, and metadata
+    semantic_search : SemanticSearch or None
+        Reference to shared semantic search instance for AI-powered codebase search,
+        None if not initialized
+
+    Examples
+    --------
+    >>> state = CodebaseState()
+    >>> state.codebase_cache["functions"]["create_network"] = {...}
+    >>> print(state.is_healthy())  # True if any codebase info loaded
+    >>> health = state.get_health_details()
+    >>> print(health["total_items"])
+    """
 
     def __init__(self):
         super().__init__()
@@ -26,13 +51,48 @@ class CodebaseState(ComponentState):
             "classes": {},
             "functions": {},
         }
+        self.semantic_search = None
 
     def is_healthy(self) -> bool:
-        """Component is healthy if it has loaded any codebase information."""
+        """
+        Check if component has successfully loaded codebase information.
+
+        Returns
+        -------
+        bool
+            True if any codebase information is loaded, False otherwise
+
+        Notes
+        -----
+        This method checks for the presence of any codebase content.
+        Semantic search availability is not required for health.
+        """
         return any(bool(section) for section in self.codebase_cache.values())
 
     def get_health_details(self) -> Dict[str, Any]:
-        """Provide codebase-specific health details."""
+        """
+        Get detailed health information including codebase element counts.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary containing:
+            - modules_count : int
+                Number of modules loaded
+            - classes_count : int
+                Number of classes loaded
+            - functions_count : int
+                Number of functions loaded
+            - total_items : int
+                Total number of codebase elements loaded
+
+        Examples
+        --------
+        >>> state = CodebaseState()
+        >>> # ... load content ...
+        >>> details = state.get_health_details()
+        >>> print(f"Total codebase items: {details['total_items']}")
+        """
         return {
             "modules_count": len(self.codebase_cache["modules"]),
             "classes_count": len(self.codebase_cache["classes"]),
@@ -44,20 +104,77 @@ class CodebaseState(ComponentState):
 
 
 class CodebaseComponent(MCPComponent):
-    """MCP component for codebase exploration and search."""
+    """
+    MCP component for codebase exploration and search with semantic capabilities.
+
+    Provides access to Napistu codebase documentation including modules, classes, and
+    functions with both exact text matching and AI-powered semantic search for natural
+    language queries. Loads comprehensive API documentation from ReadTheDocs.
+
+    The component fetches codebase information from the Napistu ReadTheDocs API and
+    uses a shared semantic search instance for intelligent code discovery and exploration.
+
+    Examples
+    --------
+    Basic component usage:
+
+    >>> component = CodebaseComponent()
+    >>> semantic_search = SemanticSearch()  # Shared instance
+    >>> success = await component.safe_initialize(semantic_search)
+    >>> if success:
+    ...     state = component.get_state()
+    ...     print(f"Loaded {state.get_health_details()['total_items']} codebase items")
+
+    Notes
+    -----
+    The component gracefully handles failures in codebase loading and semantic search
+    initialization. If semantic search is not provided, the component continues to
+    function with exact text search only.
+
+    **CONTENT SCOPE:**
+    Codebase documentation covers Napistu API reference, function signatures, and
+    implementation details. Use this component for technical API guidance, not conceptual
+    tutorials or general usage patterns.
+    """
 
     def _create_state(self) -> CodebaseState:
-        """Create codebase-specific state."""
+        """
+        Create codebase-specific state instance.
+
+        Returns
+        -------
+        CodebaseState
+            New state instance for managing codebase content and semantic search
+        """
         return CodebaseState()
 
-    async def initialize(self) -> bool:
+    async def initialize(self, semantic_search: SemanticSearch = None) -> bool:
         """
-        Initialize codebase component by loading documentation from ReadTheDocs.
+        Initialize codebase component with content loading and semantic indexing.
+
+        Performs the following operations:
+        1. Loads codebase documentation from ReadTheDocs API
+        2. Extracts and organizes modules, classes, and functions
+        3. Stores reference to shared semantic search instance
+        4. Indexes loaded codebase content if semantic search is available
+
+        Parameters
+        ----------
+        semantic_search : SemanticSearch, optional
+            Shared semantic search instance for AI-powered search capabilities.
+            If None, component will operate with exact text search only.
 
         Returns
         -------
         bool
-            True if codebase information was loaded successfully
+            True if codebase information was loaded successfully, False if
+            loading failed
+
+        Notes
+        -----
+        ReadTheDocs API failures are logged as errors and cause initialization failure.
+        Semantic search indexing failure is logged but doesn't affect the return value -
+        the component can function without semantic search.
         """
         try:
             logger.info("Loading codebase documentation from ReadTheDocs...")
@@ -82,27 +199,113 @@ class CodebaseComponent(MCPComponent):
                 f"{len(functions)} functions"
             )
 
-            # Consider successful if we loaded any modules
-            return len(modules) > 0
+            # Store reference to shared semantic search instance
+            content_loaded = len(modules) > 0
+            if semantic_search and content_loaded:
+                self.state.semantic_search = semantic_search
+                semantic_success = await self._initialize_semantic_search()
+                logger.info(
+                    f"Semantic search initialization: {'✅ Success' if semantic_success else '⚠️ Failed'}"
+                )
+
+            return content_loaded
 
         except Exception as e:
             logger.error(f"Failed to load codebase documentation: {e}")
+            return False
+
+    async def _initialize_semantic_search(self) -> bool:
+        """
+        Index codebase content into the shared semantic search instance.
+
+        Uses the shared semantic search instance (stored in self.state.semantic_search)
+        to index this component's codebase content into the "codebase" collection.
+
+        Returns
+        -------
+        bool
+            True if content was successfully indexed, False if indexing failed
+
+        Notes
+        -----
+        Assumes self.state.semantic_search has already been set to a valid
+        SemanticSearch instance during initialize().
+
+        Failure to index content is not considered a critical error.
+        The component continues to function with exact text search if semantic
+        search indexing fails.
+        """
+        try:
+            if not self.state.semantic_search:
+                logger.warning("No semantic search instance available")
+                return False
+
+            logger.info("Indexing codebase content for semantic search...")
+
+            # Index codebase content using the shared semantic search instance
+            self.state.semantic_search.index_content(
+                "codebase", self.state.codebase_cache
+            )
+
+            logger.info("✅ Codebase content indexed successfully")
+            return True
+
+        except Exception as e:
+            logger.error(f"❌ Failed to index codebase content: {e}")
             return False
 
     def register(self, mcp: FastMCP) -> None:
         """
         Register codebase resources and tools with the MCP server.
 
+        Registers the following MCP endpoints:
+        - Resources for accessing codebase summaries and specific API documentation
+        - Tools for searching codebase with semantic and exact modes
+
         Parameters
         ----------
         mcp : FastMCP
-            FastMCP server instance
+            FastMCP server instance to register endpoints with
+
+        Notes
+        -----
+        The search tool automatically selects semantic search when available,
+        falling back to exact search if semantic search is not initialized.
         """
 
         # Register resources
         @mcp.resource("napistu://codebase/summary")
         async def get_codebase_summary():
-            """Get a summary of all available codebase information."""
+            """
+            Get a summary of all available Napistu codebase information.
+
+            **USE THIS WHEN:**
+            - Getting an overview of available Napistu API documentation
+            - Understanding what modules, classes, and functions are documented
+            - Checking codebase documentation availability and counts
+
+            **DO NOT USE FOR:**
+            - General programming concepts not specific to Napistu
+            - Documentation for other libraries or frameworks
+            - Conceptual tutorials (use tutorials component instead)
+            - Implementation examples (use documentation component for wikis/READMEs)
+
+            Returns
+            -------
+            Dict[str, Any]
+                Dictionary containing:
+                - modules : List[str]
+                    Names of documented Napistu modules
+                - classes : List[str]
+                    Names of documented Napistu classes
+                - functions : List[str]
+                    Names of documented Napistu functions
+
+            Examples
+            --------
+            Use this to understand what Napistu API documentation is available before
+            searching for specific function signatures or class definitions.
+            """
             return {
                 "modules": list(self.state.codebase_cache["modules"].keys()),
                 "classes": list(self.state.codebase_cache["classes"].keys()),
@@ -111,7 +314,35 @@ class CodebaseComponent(MCPComponent):
 
         @mcp.resource("napistu://codebase/modules/{module_name}")
         async def get_module_details(module_name: str) -> Dict[str, Any]:
-            """Get detailed information about a specific module."""
+            """
+            Get detailed API documentation for a specific Napistu module.
+
+            **USE THIS WHEN:**
+            - Reading complete documentation for a specific Napistu module
+            - Understanding module structure, classes, and functions
+            - Getting detailed API reference information
+
+            **DO NOT USE FOR:**
+            - Modules from other libraries (only covers Napistu modules)
+            - General programming concepts or tutorials
+            - Implementation examples (use tutorials/documentation components)
+
+            Parameters
+            ----------
+            module_name : str
+                Name of the Napistu module (from codebase summary)
+
+            Returns
+            -------
+            Dict[str, Any]
+                Complete module documentation including classes, functions,
+                and detailed API information
+
+            Raises
+            ------
+            Exception
+                If the module is not found in the codebase documentation
+            """
             if module_name not in self.state.codebase_cache["modules"]:
                 return {"error": f"Module {module_name} not found"}
 
@@ -119,78 +350,205 @@ class CodebaseComponent(MCPComponent):
 
         # Register tools
         @mcp.tool()
-        async def search_codebase(query: str) -> Dict[str, Any]:
+        async def search_codebase(
+            query: str, search_type: str = "semantic"
+        ) -> Dict[str, Any]:
             """
-            Search the codebase for a specific query.
+            Search Napistu codebase documentation with intelligent search strategy.
 
-            Args:
-                query: Search term
+            Provides flexible search capabilities for finding relevant Napistu API documentation
+            using either AI-powered semantic search for natural language queries or exact text
+            matching for precise keyword searches. Covers modules, classes, and functions from
+            the Napistu codebase.
 
-            Returns:
-                Dictionary with search results organized by code element type, including snippets for context.
+            **USE THIS WHEN:**
+            - Looking for specific Napistu functions, classes, or modules
+            - Finding API documentation for Napistu features
+            - Searching for function signatures, parameters, or return types
+            - Understanding Napistu class hierarchies and method documentation
+            - Finding implementation details for Napistu functionality
+
+            **DO NOT USE FOR:**
+            - General programming concepts not specific to Napistu
+            - Documentation for other libraries or frameworks
+            - Conceptual tutorials or usage examples (use tutorials component)
+            - Installation or setup instructions (use documentation component)
+            - Academic research not involving Napistu implementation
+
+            **EXAMPLE APPROPRIATE QUERIES:**
+            - "consensus network creation functions"
+            - "SBML parsing classes"
+            - "pathway analysis methods"
+            - "graph algorithms in Napistu"
+            - "data ingestion API"
+
+            **EXAMPLE INAPPROPRIATE QUERIES:**
+            - "how to install Python" (not Napistu-specific)
+            - "general graph theory" (too broad, not API-focused)
+            - "pandas DataFrame methods" (wrong library)
+
+            Parameters
+            ----------
+            query : str
+                Search term or natural language question about Napistu API.
+                Should be specific to Napistu functions, classes, or modules.
+            search_type : str, optional
+                Search strategy to use:
+                - "semantic" (default): AI-powered search using embeddings
+                - "exact": Traditional text matching search
+                Default is "semantic".
+
+            Returns
+            -------
+            Dict[str, Any]
+                Search results dictionary containing:
+                - query : str
+                    Original search query
+                - search_type : str
+                    Actual search type used ("semantic" or "exact")
+                - results : List[Dict] or Dict[str, List]
+                    Search results. Format depends on search type:
+                    - Semantic: List of result dictionaries with content, metadata, source, similarity_score
+                    - Exact: Dictionary organized by code element type (modules, classes, functions)
+                - tip : str
+                    Helpful guidance for improving search results
+
+            Examples
+            --------
+            Natural language semantic search for Napistu API:
+
+            >>> results = await search_codebase("functions for creating networks")
+            >>> print(results["search_type"])  # "semantic"
+            >>> for result in results["results"]:
+            ...     score = result['similarity_score']
+            ...     print(f"Score: {score:.3f} - {result['source']}")
+
+            Exact keyword search for specific API elements:
+
+            >>> results = await search_codebase("create_consensus", search_type="exact")
+            >>> print(len(results["results"]["functions"]))  # Number of matching functions
+
+            Notes
+            -----
+            **CONTENT SCOPE:**
+            This tool searches only Napistu API documentation including:
+            - Function signatures, parameters, and return types
+            - Class definitions, methods, and attributes
+            - Module organization and structure
+            - Technical API reference information
+
+            **SEARCH TYPE GUIDANCE:**
+            - Use semantic (default) for conceptual API queries and natural language
+            - Use exact for precise function names, class names, or known API terms
+
+            **RESULT INTERPRETATION:**
+            - Semantic results include similarity scores (0.8-1.0 = very relevant)
+            - Results may include chunked sections from long documentation for precision
+            - Follow up with get_function_documentation() or get_class_documentation() for complete details
+
+            The function automatically handles semantic search failures by falling back
+            to exact search, ensuring reliable results even if AI components are unavailable.
             """
-            results = {
-                "modules": [],
-                "classes": [],
-                "functions": [],
-            }
+            if search_type == "semantic" and self.state.semantic_search:
+                # Use shared semantic search instance
+                results = self.state.semantic_search.search(
+                    query, "codebase", n_results=5
+                )
+                return {
+                    "query": query,
+                    "search_type": "semantic",
+                    "results": results,
+                    "tip": "For Napistu API documentation only. Try different phrasings if results aren't relevant, or use search_type='exact' for precise keyword matching",
+                }
+            else:
+                # Fall back to exact search
+                results = {
+                    "modules": [],
+                    "classes": [],
+                    "functions": [],
+                }
 
-            # Search modules
-            for module_name, info in self.state.codebase_cache["modules"].items():
-                # Use docstring or description for snippet
-                doc = info.get("doc") or info.get("description") or ""
-                module_text = json.dumps(info)
-                if query.lower() in module_text.lower():
-                    snippet = mcp_utils.get_snippet(doc, query)
-                    results["modules"].append(
-                        {
-                            "name": module_name,
-                            "description": doc,
-                            "snippet": snippet,
-                        }
-                    )
+                # Search modules
+                for module_name, info in self.state.codebase_cache["modules"].items():
+                    # Use docstring or description for snippet
+                    doc = info.get("doc") or info.get("description") or ""
+                    module_text = json.dumps(info)
+                    if query.lower() in module_text.lower():
+                        snippet = mcp_utils.get_snippet(doc, query)
+                        results["modules"].append(
+                            {
+                                "name": module_name,
+                                "description": doc,
+                                "snippet": snippet,
+                            }
+                        )
 
-            # Search classes
-            for class_name, info in self.state.codebase_cache["classes"].items():
-                doc = info.get("doc") or info.get("description") or ""
-                class_text = json.dumps(info)
-                if query.lower() in class_text.lower():
-                    snippet = mcp_utils.get_snippet(doc, query)
-                    results["classes"].append(
-                        {
-                            "name": class_name,
-                            "description": doc,
-                            "snippet": snippet,
-                        }
-                    )
+                # Search classes
+                for class_name, info in self.state.codebase_cache["classes"].items():
+                    doc = info.get("doc") or info.get("description") or ""
+                    class_text = json.dumps(info)
+                    if query.lower() in class_text.lower():
+                        snippet = mcp_utils.get_snippet(doc, query)
+                        results["classes"].append(
+                            {
+                                "name": class_name,
+                                "description": doc,
+                                "snippet": snippet,
+                            }
+                        )
 
-            # Search functions
-            for func_name, info in self.state.codebase_cache["functions"].items():
-                doc = info.get("doc") or info.get("description") or ""
-                func_text = json.dumps(info)
-                if query.lower() in func_text.lower():
-                    snippet = mcp_utils.get_snippet(doc, query)
-                    results["functions"].append(
-                        {
-                            "name": func_name,
-                            "description": doc,
-                            "signature": info.get("signature", ""),
-                            "snippet": snippet,
-                        }
-                    )
+                # Search functions
+                for func_name, info in self.state.codebase_cache["functions"].items():
+                    doc = info.get("doc") or info.get("description") or ""
+                    func_text = json.dumps(info)
+                    if query.lower() in func_text.lower():
+                        snippet = mcp_utils.get_snippet(doc, query)
+                        results["functions"].append(
+                            {
+                                "name": func_name,
+                                "description": doc,
+                                "signature": info.get("signature", ""),
+                                "snippet": snippet,
+                            }
+                        )
 
-            return results
+                return {
+                    "query": query,
+                    "search_type": "exact",
+                    "results": results,
+                    "tip": "Use search_type='semantic' for natural language queries about Napistu API",
+                }
 
         @mcp.tool()
         async def get_function_documentation(function_name: str) -> Dict[str, Any]:
             """
-            Get detailed documentation for a specific function.
+            Get detailed API documentation for a specific Napistu function.
 
-            Args:
-                function_name: Name of the function
+            **USE THIS WHEN:**
+            - Reading complete documentation for a specific Napistu function
+            - Understanding function signatures, parameters, and return types
+            - Getting detailed API reference for function implementation
 
-            Returns:
-                Dictionary with function documentation
+            **DO NOT USE FOR:**
+            - Functions from other libraries (only covers Napistu functions)
+            - General programming concepts or tutorials
+            - Usage examples (use tutorials component for implementation guidance)
+
+            Parameters
+            ----------
+            function_name : str
+                Name of the Napistu function (from codebase search or summary)
+
+            Returns
+            -------
+            Dict[str, Any]
+                Complete function documentation including signature, parameters,
+                return type, and detailed description
+
+            Examples
+            --------
+            After finding a function via search, use this to get complete API details
+            for implementation guidance and parameter understanding.
             """
             if function_name not in self.state.codebase_cache["functions"]:
                 return {"error": f"Function {function_name} not found"}
@@ -200,13 +558,33 @@ class CodebaseComponent(MCPComponent):
         @mcp.tool()
         async def get_class_documentation(class_name: str) -> Dict[str, Any]:
             """
-            Get detailed documentation for a specific class.
+            Get detailed API documentation for a specific Napistu class.
 
-            Args:
-                class_name: Name of the class
+            **USE THIS WHEN:**
+            - Reading complete documentation for a specific Napistu class
+            - Understanding class methods, attributes, and inheritance
+            - Getting detailed API reference for class usage
 
-            Returns:
-                Dictionary with class documentation
+            **DO NOT USE FOR:**
+            - Classes from other libraries (only covers Napistu classes)
+            - General object-oriented programming concepts
+            - Usage examples (use tutorials component for implementation guidance)
+
+            Parameters
+            ----------
+            class_name : str
+                Name of the Napistu class (from codebase search or summary)
+
+            Returns
+            -------
+            Dict[str, Any]
+                Complete class documentation including methods, attributes,
+                inheritance, and detailed description
+
+            Examples
+            --------
+            After finding a class via search, use this to get complete API details
+            for understanding class structure and method signatures.
             """
             if class_name not in self.state.codebase_cache["classes"]:
                 return {"error": f"Class {class_name} not found"}
@@ -225,6 +603,12 @@ def get_component() -> CodebaseComponent:
     Returns
     -------
     CodebaseComponent
-        The codebase component instance
+        Singleton codebase component instance for use across the MCP server.
+        The same instance is returned on every call to ensure consistent state.
+
+    Notes
+    -----
+    This function provides the standard interface for accessing the codebase
+    component. The component must be initialized via safe_initialize() before use.
     """
     return _component

--- a/src/napistu/mcp/component_base.py
+++ b/src/napistu/mcp/component_base.py
@@ -8,6 +8,8 @@ import logging
 
 from fastmcp import FastMCP
 
+from napistu.mcp.semantic_search import SemanticSearch
+
 logger = logging.getLogger(__name__)
 
 
@@ -139,9 +141,15 @@ class MCPComponent(ABC):
         """
         return self.state
 
-    async def safe_initialize(self) -> bool:
+    async def safe_initialize(self, semantic_search: SemanticSearch = None) -> bool:
         """
         Initialize with error handling and state tracking.
+
+        Parameters
+        ----------
+        semantic_search : SemanticSearch, optional
+            Shared semantic search instance for AI-powered search capabilities.
+            If None, component will operate with exact text search only.
 
         Returns
         -------
@@ -151,7 +159,8 @@ class MCPComponent(ABC):
         try:
             logger.info(f"Initializing {self.__class__.__name__}...")
 
-            result = await self.initialize()
+            # Pass semantic_search to the component-specific initialize method
+            result = await self.initialize(semantic_search)
 
             self.state.initialized = True
             self.state.initialization_error = None

--- a/src/napistu/mcp/config.py
+++ b/src/napistu/mcp/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, computed_field, validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 from typing import Optional
 import click
 from napistu.mcp.constants import MCP_DEFAULTS, MCP_PRODUCTION_URL
@@ -11,7 +11,8 @@ class MCPServerConfig(BaseModel):
     port: int = Field(ge=1, le=65535, description="Port to bind server to")
     server_name: str = Field(description="Server name")
 
-    @validator("host")
+    @field_validator("host")
+    @classmethod
     def validate_host(cls, v):
         """Basic host validation."""
         if not v or v.isspace():

--- a/src/napistu/mcp/documentation.py
+++ b/src/napistu/mcp/documentation.py
@@ -7,18 +7,48 @@ import logging
 
 from fastmcp import FastMCP
 
-from napistu.mcp.component_base import ComponentState, MCPComponent
 from napistu.mcp import documentation_utils
 from napistu.mcp import utils as mcp_utils
+from napistu.mcp.component_base import ComponentState, MCPComponent
+from napistu.mcp.semantic_search import SemanticSearch
 from napistu.mcp.constants import DOCUMENTATION, READMES, REPOS_WITH_ISSUES, WIKI_PAGES
 
 logger = logging.getLogger(__name__)
 
 
 class DocumentationState(ComponentState):
-    """State management for documentation component."""
+    """
+    State management for documentation component with semantic search capabilities.
+
+    Manages cached documentation content from multiple sources and tracks semantic
+    search initialization status. Extends ComponentState to provide standardized
+    health monitoring and status reporting.
+
+    Attributes
+    ----------
+    docs_cache : Dict[str, Dict[str, Any]]
+        Nested dictionary containing cached documentation content organized by type:
+        - readme: README files from repositories
+        - wiki: Wiki pages from project documentation
+        - issues: GitHub issues from project repositories
+        - prs: Pull requests from project repositories
+        - packagedown: Package documentation sections (if any)
+    semantic_search : SemanticSearch or None
+        Semantic search instance for AI-powered content search, None if not initialized
+    semantic_indexed : bool
+        Whether documentation content has been indexed for semantic search
+
+    Examples
+    --------
+    >>> state = DocumentationState()
+    >>> state.docs_cache["readme"]["install"] = "Installation guide..."
+    >>> print(state.is_healthy())  # True if any content loaded
+    >>> health = state.get_health_details()
+    >>> print(health["semantic_search_available"])  # False initially
+    """
 
     def __init__(self):
+        """Initialize documentation state with empty cache and no semantic search."""
         super().__init__()
         self.docs_cache: Dict[str, Dict[str, Any]] = {
             DOCUMENTATION.README: {},
@@ -27,14 +57,57 @@ class DocumentationState(ComponentState):
             DOCUMENTATION.PRS: {},
             DOCUMENTATION.PACKAGEDOWN: {},
         }
+        self.semantic_search = None
+        self.semantic_indexed = False
 
     def is_healthy(self) -> bool:
-        """Component is healthy if it has loaded any documentation."""
+        """
+        Check if component has successfully loaded documentation content.
+
+        Returns
+        -------
+        bool
+            True if any documentation section contains content, False otherwise
+
+        Notes
+        -----
+        This method checks for the presence of any content in any documentation
+        category. Semantic search availability is not required for health.
+        """
         return any(bool(section) for section in self.docs_cache.values())
 
     def get_health_details(self) -> Dict[str, Any]:
-        """Provide documentation-specific health details."""
-        return {
+        """
+        Get detailed health information including content counts and semantic search status.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary containing:
+            - readme_count : int
+                Number of README files loaded
+            - wiki_pages : int
+                Number of wiki pages loaded
+            - issues_repos : int
+                Number of repositories with issues loaded
+            - prs_repos : int
+                Number of repositories with pull requests loaded
+            - total_sections : int
+                Total number of content items across all categories
+            - semantic_search_available : bool
+                Whether semantic search has been initialized
+            - semantic_indexed : bool
+                Whether content has been indexed for semantic search
+
+        Examples
+        --------
+        >>> state = DocumentationState()
+        >>> # ... load content ...
+        >>> details = state.get_health_details()
+        >>> print(f"Total content items: {details['total_sections']}")
+        >>> print(f"Semantic search ready: {details['semantic_indexed']}")
+        """
+        base_details = {
             "readme_count": len(self.docs_cache[DOCUMENTATION.README]),
             "wiki_pages": len(self.docs_cache[DOCUMENTATION.WIKI]),
             "issues_repos": len(self.docs_cache[DOCUMENTATION.ISSUES]),
@@ -42,22 +115,86 @@ class DocumentationState(ComponentState):
             "total_sections": sum(len(section) for section in self.docs_cache.values()),
         }
 
+        # Add semantic search status
+        base_details.update(
+            {
+                "semantic_search_available": self.semantic_search is not None,
+                "semantic_indexed": self.semantic_indexed,
+            }
+        )
+
+        return base_details
+
 
 class DocumentationComponent(MCPComponent):
-    """MCP component for documentation management and search."""
+    """
+    MCP component for documentation management and search with semantic capabilities.
+
+    Provides access to Napistu project documentation including README files, wiki pages,
+    GitHub issues, and pull requests. Supports both exact text matching and AI-powered
+    semantic search for flexible content discovery.
+
+    The component loads documentation from multiple sources:
+    - README files from GitHub repositories (raw URLs)
+    - Wiki pages from project wikis
+    - GitHub issues and pull requests via GitHub API
+    - Optional package documentation sections
+
+    After loading content, the component initializes semantic search capabilities
+    using ChromaDB and sentence transformers for natural language queries.
+
+    Examples
+    --------
+    Basic component usage:
+
+    >>> component = DocumentationComponent()
+    >>> success = await component.safe_initialize()
+    >>> if success:
+    ...     state = component.get_state()
+    ...     print(f"Loaded {state.get_health_details()['total_sections']} items")
+
+    Notes
+    -----
+    The component gracefully handles failures in individual documentation sources
+    and semantic search initialization. If semantic search fails, the component
+    continues to function with exact text search only.
+    """
 
     def _create_state(self) -> DocumentationState:
-        """Create documentation-specific state."""
+        """
+        Create documentation-specific state instance.
+
+        Returns
+        -------
+        DocumentationState
+            New state instance for managing documentation content and semantic search
+        """
         return DocumentationState()
 
     async def initialize(self) -> bool:
         """
-        Initialize documentation component by loading all documentation sources.
+        Initialize documentation component with content loading and semantic indexing.
+
+        Performs the following operations:
+        1. Loads README files from configured repository URLs
+        2. Fetches wiki pages from project wikis
+        3. Retrieves GitHub issues and pull requests via API
+        4. Initializes semantic search and indexes loaded content
 
         Returns
         -------
         bool
-            True if at least some documentation was loaded successfully
+            True if at least some documentation was loaded successfully, False if
+            all loading operations failed
+
+        Notes
+        -----
+        Individual source failures are logged as warnings but don't fail the entire
+        initialization. Semantic search initialization failure is logged but doesn't
+        affect the return value - the component can function without semantic search.
+
+        The method tracks success/failure rates and provides detailed logging for
+        debugging content loading issues.
         """
         success_count = 0
         total_operations = 0
@@ -110,24 +247,115 @@ class DocumentationComponent(MCPComponent):
             f"Documentation loading complete: {success_count}/{total_operations} operations successful"
         )
 
-        # Consider successful if at least some documentation loaded
-        return success_count > 0
+        # Initialize semantic search if content was loaded
+        content_loaded = success_count > 0
+        if content_loaded:
+            semantic_success = await self._initialize_semantic_search()
+            logger.info(
+                f"Semantic search initialization: {'✅ Success' if semantic_success else '⚠️ Failed'}"
+            )
+
+        return content_loaded
+
+    async def _initialize_semantic_search(self) -> bool:
+        """
+        Initialize semantic search engine and index documentation content.
+
+        Creates a SemanticSearch instance, sets up ChromaDB collections, and indexes
+        all loaded documentation content for AI-powered search capabilities.
+
+        Returns
+        -------
+        bool
+            True if semantic search was successfully initialized and content indexed,
+            False if initialization failed
+
+        Notes
+        -----
+        Failure to initialize semantic search is not considered a critical error.
+        The component continues to function with exact text search if semantic
+        search initialization fails.
+
+        The method updates state.semantic_search and state.semantic_indexed to
+        track semantic search availability for health monitoring.
+
+        Raises
+        ------
+        Exception
+            Any exception during semantic search setup is caught and logged,
+            ensuring component initialization continues
+        """
+        try:
+            logger.info("Initializing semantic search...")
+
+            # Create semantic search instance
+            self.state.semantic_search = SemanticSearch()
+
+            # Index the documentation content
+            logger.info("Indexing documentation content for semantic search...")
+            self.state.semantic_search.index_content(
+                "documentation", self.state.docs_cache
+            )
+
+            self.state.semantic_indexed = True
+            logger.info("✅ Semantic search initialized and content indexed")
+            return True
+
+        except Exception as e:
+            logger.error(f"❌ Semantic search initialization failed: {e}")
+            # Don't fail the entire component if semantic search fails
+            self.state.semantic_search = None
+            self.state.semantic_indexed = False
+            return False
 
     def register(self, mcp: FastMCP) -> None:
         """
         Register documentation resources and tools with the MCP server.
 
+        Registers the following MCP endpoints:
+        - Resources for accessing documentation summaries and specific content
+        - Tools for searching documentation with semantic and exact modes
+
         Parameters
         ----------
         mcp : FastMCP
-            FastMCP server instance
+            FastMCP server instance to register endpoints with
+
+        Notes
+        -----
+        The search tool automatically selects semantic search when available,
+        falling back to exact search if semantic search is not initialized.
         """
 
-        # Register resources
+        # Register existing resources (unchanged)
         @mcp.resource("napistu://documentation/summary")
         async def get_documentation_summary():
-            """Get a summary of all available documentation."""
-            return {
+            """
+            Get a comprehensive summary of all available documentation.
+
+            Returns
+            -------
+            Dict[str, Any]
+                Dictionary containing:
+                - readme_files : List[str]
+                    Names of loaded README files
+                - issues : List[str]
+                    Repository names with loaded issues
+                - prs : List[str]
+                    Repository names with loaded pull requests
+                - wiki_pages : List[str]
+                    Names of loaded wiki pages
+                - packagedown_sections : List[str]
+                    Names of package documentation sections
+                - semantic_search : Dict[str, bool]
+                    Status of semantic search availability and indexing
+
+            Examples
+            --------
+            Resource provides overview of all documentation content and capabilities
+            for clients to understand what information is available.
+            """
+            summary = {
                 "readme_files": list(
                     self.state.docs_cache[DOCUMENTATION.README].keys()
                 ),
@@ -138,6 +366,14 @@ class DocumentationComponent(MCPComponent):
                     self.state.docs_cache[DOCUMENTATION.PACKAGEDOWN].keys()
                 ),
             }
+
+            # Add semantic search status
+            summary["semantic_search"] = {
+                "available": self.state.semantic_search is not None,
+                "indexed": self.state.semantic_indexed,
+            }
+
+            return summary
 
         @mcp.resource("napistu://documentation/readme/{file_name}")
         async def get_readme_content(file_name: str):
@@ -196,75 +432,151 @@ class DocumentationComponent(MCPComponent):
 
         # Register tools
         @mcp.tool()
-        async def search_documentation(query: str):
+        async def search_documentation(query: str, search_type: str = "semantic"):
             """
-            Search all documentation for a specific query.
+            Search all documentation with intelligent search strategy.
 
-            Args:
-                query: Search term
+            Provides flexible search capabilities using either AI-powered semantic search
+            for natural language queries or exact text matching for precise keyword searches.
+            Automatically falls back to exact search if semantic search is unavailable.
 
-            Returns:
-                Dictionary with search results organized by documentation type
+            Parameters
+            ----------
+            query : str
+                Search term or natural language question. For semantic search, can be
+                full questions like "how to install napistu". For exact search, use
+                specific keywords like "installation" or "consensus".
+            search_type : str, optional
+                Search strategy to use:
+                - "semantic" (default): AI-powered search using embeddings
+                - "exact": Traditional text matching search
+                Default is "semantic".
+
+            Returns
+            -------
+            Dict[str, Any]
+                Search results dictionary containing:
+                - query : str
+                    Original search query
+                - search_type : str
+                    Actual search type used ("semantic" or "exact")
+                - results : List[Dict] or Dict[str, List]
+                    Search results. Format depends on search type:
+                    - Semantic: List of result dictionaries with content, metadata, source
+                    - Exact: Dictionary organized by content type (readme, wiki, issues, prs)
+                - tip : str
+                    Helpful guidance for improving search results
+
+            Examples
+            --------
+            Natural language semantic search:
+
+            >>> results = await search_documentation("how to install napistu")
+            >>> print(results["search_type"])  # "semantic"
+            >>> for result in results["results"]:
+            ...     print(f"Found in: {result['source']}")
+
+            Exact keyword search:
+
+            >>> results = await search_documentation("installation", search_type="exact")
+            >>> print(len(results["results"]["readme"]))  # Number of matching READMEs
+
+            Notes
+            -----
+            **WHEN TO USE:**
+            - Finding information about Napistu project features, setup, or usage
+            - Looking for README content, wiki pages, GitHub issues, or pull requests
+            - Researching Napistu-specific concepts, workflows, or troubleshooting
+
+            **SEARCH TYPE GUIDANCE:**
+            - Use semantic (default) for conceptual queries and natural language
+            - Use exact for precise terms, function names, or known keywords
+
+            **EXAMPLE QUERIES:**
+            - Semantic: "consensus network creation", "SBML file processing", "pathway integration"
+            - Exact: "installation", "consensus", "SBML", "create_graph"
+
+            The function automatically handles semantic search failures by falling back
+            to exact search, ensuring reliable results even if AI components are unavailable.
             """
-            results = {
-                DOCUMENTATION.README: [],
-                DOCUMENTATION.WIKI: [],
-                DOCUMENTATION.ISSUES: [],
-                DOCUMENTATION.PRS: [],
-                DOCUMENTATION.PACKAGEDOWN: [],
-            }
+            if search_type == "semantic" and self.state.semantic_search:
+                # Use semantic search
+                results = self.state.semantic_search.search(
+                    query, "documentation", n_results=5
+                )
+                return {
+                    "query": query,
+                    "search_type": "semantic",
+                    "results": results,
+                    "tip": "Try different phrasings if results aren't relevant, or use search_type='exact' for precise keyword matching",
+                }
+            else:
+                # Fall back to exact search (existing logic)
+                results = {
+                    DOCUMENTATION.README: [],
+                    DOCUMENTATION.WIKI: [],
+                    DOCUMENTATION.ISSUES: [],
+                    DOCUMENTATION.PRS: [],
+                }
 
-            # Search README files
-            for readme_name, content in self.state.docs_cache[
-                DOCUMENTATION.README
-            ].items():
-                if query.lower() in content.lower():
-                    results[DOCUMENTATION.README].append(
-                        {
-                            "name": readme_name,
-                            "snippet": mcp_utils.get_snippet(content, query),
-                        }
-                    )
-
-            # Search wiki pages
-            for page_name, content in self.state.docs_cache[DOCUMENTATION.WIKI].items():
-                if query.lower() in content.lower():
-                    results[DOCUMENTATION.WIKI].append(
-                        {
-                            "name": page_name,
-                            "snippet": mcp_utils.get_snippet(content, query),
-                        }
-                    )
-
-            # Search issues
-            for repo, issues in self.state.docs_cache[DOCUMENTATION.ISSUES].items():
-                for issue in issues:
-                    issue_text = f"{issue.get('title', '')} {issue.get('body', '')}"
-                    if query.lower() in issue_text.lower():
-                        results[DOCUMENTATION.ISSUES].append(
+                # Search README files
+                for readme_name, content in self.state.docs_cache[
+                    DOCUMENTATION.README
+                ].items():
+                    if query.lower() in content.lower():
+                        results[DOCUMENTATION.README].append(
                             {
-                                "name": f"{repo}#{issue.get('number')}",
-                                "title": issue.get("title"),
-                                "url": issue.get("url"),
-                                "snippet": mcp_utils.get_snippet(issue_text, query),
+                                "name": readme_name,
+                                "snippet": mcp_utils.get_snippet(content, query),
                             }
                         )
 
-            # Search PRs
-            for repo, prs in self.state.docs_cache[DOCUMENTATION.PRS].items():
-                for pr in prs:
-                    pr_text = f"{pr.get('title', '')} {pr.get('body', '')}"
-                    if query.lower() in pr_text.lower():
-                        results[DOCUMENTATION.PRS].append(
+                # Search wiki pages
+                for page_name, content in self.state.docs_cache[
+                    DOCUMENTATION.WIKI
+                ].items():
+                    if query.lower() in content.lower():
+                        results[DOCUMENTATION.WIKI].append(
                             {
-                                "name": f"{repo}#{pr.get('number')}",
-                                "title": pr.get("title"),
-                                "url": pr.get("url"),
-                                "snippet": mcp_utils.get_snippet(pr_text, query),
+                                "name": page_name,
+                                "snippet": mcp_utils.get_snippet(content, query),
                             }
                         )
 
-            return results
+                # Search issues
+                for repo, issues in self.state.docs_cache[DOCUMENTATION.ISSUES].items():
+                    for issue in issues:
+                        issue_text = f"{issue.get('title', '')} {issue.get('body', '')}"
+                        if query.lower() in issue_text.lower():
+                            results[DOCUMENTATION.ISSUES].append(
+                                {
+                                    "name": f"{repo}#{issue.get('number')}",
+                                    "title": issue.get("title"),
+                                    "url": issue.get("url"),
+                                    "snippet": mcp_utils.get_snippet(issue_text, query),
+                                }
+                            )
+
+                # Search PRs
+                for repo, prs in self.state.docs_cache[DOCUMENTATION.PRS].items():
+                    for pr in prs:
+                        pr_text = f"{pr.get('title', '')} {pr.get('body', '')}"
+                        if query.lower() in pr_text.lower():
+                            results[DOCUMENTATION.PRS].append(
+                                {
+                                    "name": f"{repo}#{pr.get('number')}",
+                                    "title": pr.get("title"),
+                                    "url": pr.get("url"),
+                                    "snippet": mcp_utils.get_snippet(pr_text, query),
+                                }
+                            )
+
+                return {
+                    "query": query,
+                    "search_type": "exact",
+                    "results": results,
+                    "tip": "Use search_type='semantic' for natural language queries",
+                }
 
 
 # Module-level component instance
@@ -278,6 +590,12 @@ def get_component() -> DocumentationComponent:
     Returns
     -------
     DocumentationComponent
-        The documentation component instance
+        Singleton documentation component instance for use across the MCP server.
+        The same instance is returned on every call to ensure consistent state.
+
+    Notes
+    -----
+    This function provides the standard interface for accessing the documentation
+    component. The component must be initialized via safe_initialize() before use.
     """
     return _component

--- a/src/napistu/mcp/semantic_search.py
+++ b/src/napistu/mcp/semantic_search.py
@@ -1,0 +1,320 @@
+"""
+Semantic search implementation using ChromaDB for Napistu MCP server.
+"""
+
+import chromadb
+from chromadb.utils import embedding_functions
+from typing import Dict, List, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SemanticSearch:
+    """
+    Semantic search engine using ChromaDB and sentence transformers.
+
+    Provides AI-powered search capabilities for text content using vector embeddings.
+    Manages multiple collections for different content types and handles persistent
+    storage of embeddings.
+
+    Parameters
+    ----------
+    persist_directory : str, optional
+        Directory path for persistent storage of ChromaDB data.
+        Default is "./chroma_db". The directory will be created if it doesn't exist.
+
+    Attributes
+    ----------
+    client : chromadb.PersistentClient
+        ChromaDB client instance for managing collections and persistence.
+    embedding_function : chromadb.utils.embedding_functions.SentenceTransformerEmbeddingFunction
+        Embedding function using the 'all-MiniLM-L6-v2' model for text vectorization.
+    collections : Dict[str, chromadb.Collection]
+        Dictionary mapping collection names to ChromaDB collection objects.
+
+    Examples
+    --------
+    Basic usage for semantic search:
+
+    >>> search = SemanticSearch()
+    >>> collection = search.get_or_create_collection("documents")
+    >>> content = {"readme": {"install": "pip install package"}}
+    >>> search.index_content("documents", content)
+    >>> results = search.search("how to install", "documents")
+    >>> print(f"Found {len(results)} results")
+
+    Notes
+    -----
+    The class uses the 'all-MiniLM-L6-v2' sentence transformer model which:
+    - Produces 384-dimensional embeddings
+    - Is optimized for semantic similarity tasks
+    - Has a good balance of speed and quality
+    - Downloads automatically on first use (~90MB)
+
+    ChromaDB stores embeddings persistently, so collections survive across
+    sessions. The first indexing operation may be slower due to model download
+    and embedding computation.
+    """
+
+    def __init__(self, persist_directory: str = "./chroma_db"):
+        """
+        Initialize SemanticSearch with persistent ChromaDB storage.
+
+        Parameters
+        ----------
+        persist_directory : str, optional
+            Path to directory for storing ChromaDB data. Created if doesn't exist.
+            Default is "./chroma_db".
+
+        Examples
+        --------
+        >>> search = SemanticSearch()  # Uses default ./chroma_db
+        >>> search = SemanticSearch("/custom/path/db")  # Custom path
+        """
+        self.client = chromadb.PersistentClient(path=persist_directory)
+        self.embedding_function = (
+            embedding_functions.SentenceTransformerEmbeddingFunction(
+                model_name="all-MiniLM-L6-v2"
+            )
+        )
+        self.collections = {}
+
+    def get_or_create_collection(self, name: str):
+        """
+        Get existing collection or create a new one with consistent configuration.
+
+        Parameters
+        ----------
+        name : str
+            Name of the collection. Will be prefixed with "napistu_" for namespacing.
+
+        Returns
+        -------
+        chromadb.Collection
+            ChromaDB collection object for storing and querying embeddings.
+
+        Examples
+        --------
+        >>> search = SemanticSearch()
+        >>> collection = search.get_or_create_collection("documentation")
+        >>> print(collection.name)  # "napistu_documentation"
+
+        Notes
+        -----
+        Collections are cached in self.collections for efficient reuse.
+        If a collection already exists, it will be loaded with the same
+        embedding function to ensure consistency.
+        """
+        collection_name = f"napistu_{name}"
+
+        try:
+            collection = self.client.get_collection(
+                name=collection_name, embedding_function=self.embedding_function
+            )
+        except (chromadb.errors.CollectionNotFoundError, ValueError):
+            # Collection doesn't exist, create it
+            collection = self.client.create_collection(
+                name=collection_name,
+                embedding_function=self.embedding_function,
+                metadata={"hnsw:space": "cosine"},
+            )
+
+        self.collections[name] = collection
+        return collection
+
+    def index_content(self, collection_name: str, content_dict: Dict[str, Any]):
+        """
+        Index content into a collection for semantic search.
+
+        Processes nested content dictionaries and creates searchable embeddings.
+        Handles different content types appropriately (issues/PRs vs regular content).
+        Existing content in the collection is cleared before adding new content.
+
+        Parameters
+        ----------
+        collection_name : str
+            Name of the collection to index content into.
+        content_dict : Dict[str, Any]
+            Nested dictionary containing content to index. Structure should be:
+            {content_type: {name: content_text, ...}, ...}
+
+            Special handling for content types:
+            - 'issues', 'prs': Expected to contain lists of dictionaries with 'title', 'body', 'number'
+            - Other types: Expected to contain direct text content
+
+        Examples
+        --------
+        Index documentation content with mixed types:
+
+        >>> content = {
+        ...     "readme": {
+        ...         "install": "Installation instructions...",
+        ...         "usage": "Usage examples..."
+        ...     },
+        ...     "issues": {
+        ...         "repo1": [
+        ...             {"title": "Bug report", "body": "Description...", "number": 123}
+        ...         ]
+        ...     }
+        ... }
+        >>> search.index_content("documentation", content)
+
+        Notes
+        -----
+        - Content shorter than 50 characters is filtered out for regular content
+        - Content shorter than 20 characters is filtered out for issues/PRs
+        - Issues and PRs combine title and body for better searchability
+        - Each piece of content gets metadata including type, name, and source
+        - IDs are generated for uniqueness and later retrieval
+        - The collection is cleared before indexing to ensure consistency
+
+        Raises
+        ------
+        Exception
+            If ChromaDB indexing fails (e.g., invalid content format)
+        """
+        collection = self.get_or_create_collection(collection_name)
+
+        documents = []
+        metadatas = []
+        ids = []
+
+        for content_type, items in content_dict.items():
+            if content_type in ["issues", "prs"]:
+                # Handle issues and PRs specially - they're lists of dictionaries
+                for repo_name, item_list in items.items():
+                    if isinstance(item_list, list):
+                        for item in item_list:
+                            if isinstance(item, dict) and item.get("title"):
+                                # Combine title and body for better search
+                                title = item.get("title", "")
+                                body = item.get("body", "")
+                                content = f"{title}\n\n{body}" if body else title
+
+                                if len(content.strip()) > 20:  # Skip very short content
+                                    documents.append(content)
+                                    metadatas.append(
+                                        {
+                                            "type": content_type,
+                                            "name": f"{repo_name}#{item.get('number', '')}",
+                                            "source": f"{content_type}: {repo_name}#{item.get('number', '')}",
+                                        }
+                                    )
+                                    ids.append(
+                                        f"{content_type}_{repo_name}_{item.get('number', '')}"
+                                    )
+
+            elif isinstance(items, dict):
+                # Handle regular content (readme, wiki, etc.)
+                for name, content in items.items():
+                    if content and len(str(content).strip()) > 50:
+                        documents.append(str(content))
+                        metadatas.append(
+                            {
+                                "type": content_type,
+                                "name": name,
+                                "source": f"{content_type}: {name}",
+                            }
+                        )
+                        ids.append(f"{content_type}_{name}")
+
+        if documents:
+            # Clear existing content and reindex
+            try:
+                collection.delete(where={})
+            except (chromadb.errors.NoIndexException, ValueError, RuntimeError):
+                # Collection might be empty or not properly initialized
+                pass
+
+            collection.add(documents=documents, metadatas=metadatas, ids=ids)
+            logger.info(f"Indexed {len(documents)} items in {collection_name}")
+
+            # Log breakdown by content type for debugging
+            type_counts = {}
+            for metadata in metadatas:
+                content_type = metadata["type"]
+                type_counts[content_type] = type_counts.get(content_type, 0) + 1
+
+            logger.debug(f"Content type breakdown: {type_counts}")
+        else:
+            logger.warning(f"No content to index in {collection_name}")
+
+    def search(
+        self, query: str, collection_name: str, n_results: int = 5
+    ) -> List[Dict[str, Any]]:
+        """
+        Perform semantic search on a collection with similarity scores.
+
+        Uses AI embeddings to find content semantically similar to the query,
+        even if exact keywords don't match. Returns results with similarity scores.
+
+        Parameters
+        ----------
+        query : str
+            Natural language search query. Can be keywords, phrases, or questions.
+        collection_name : str
+            Name of the collection to search in.
+        n_results : int, optional
+            Maximum number of results to return. Default is 5.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            List of search results ordered by similarity (highest first), each containing:
+            - 'content': The matched text content
+            - 'metadata': Dictionary with type, name, source information
+            - 'source': Human-readable source description
+            - 'similarity_score': Float between 0 and 1 (1 = perfect match, 0 = no similarity)
+
+        Examples
+        --------
+        Basic semantic search with scores:
+
+        >>> results = search.search("how to install", "documentation")
+        >>> for result in results:
+        ...     score = result['similarity_score']
+        ...     print(f"Score: {score:.3f} - {result['source']}")
+
+        Notes
+        -----
+        Similarity scores help you understand result quality:
+        - 0.8-1.0: Very relevant matches
+        - 0.6-0.8: Good matches
+        - 0.4-0.6: Moderate relevance
+        - 0.0-0.4: Low relevance (may not be useful)
+
+        ChromaDB uses cosine similarity between embeddings, where:
+        - 1.0 = identical semantic meaning
+        - 0.0 = completely unrelated content
+        """
+        if collection_name not in self.collections:
+            return []
+
+        collection = self.collections[collection_name]
+
+        results = collection.query(
+            query_texts=[query],
+            n_results=n_results,
+            include=["documents", "metadatas", "distances"],  # Include distances
+        )
+
+        formatted_results = []
+        for i in range(len(results["documents"][0])):
+            # Convert distance to similarity score
+            # ChromaDB returns distances, but we want similarity (higher = better)
+            distance = results["distances"][0][i] if "distances" in results else 0.0
+
+            # For cosine distance, similarity = 1 - distance
+            similarity_score = 1.0 - distance
+
+            formatted_results.append(
+                {
+                    "content": results["documents"][0][i],
+                    "metadata": results["metadatas"][0][i],
+                    "source": results["metadatas"][0][i].get("source", "Unknown"),
+                    "similarity_score": similarity_score,
+                }
+            )
+
+        return formatted_results

--- a/src/napistu/mcp/semantic_search.py
+++ b/src/napistu/mcp/semantic_search.py
@@ -7,6 +7,8 @@ from chromadb.utils import embedding_functions
 from typing import Dict, List, Any
 import logging
 
+from napistu.mcp import semantic_search_utils
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,13 +18,17 @@ class SemanticSearch:
 
     Provides AI-powered search capabilities for text content using vector embeddings.
     Manages multiple collections for different content types and handles persistent
-    storage of embeddings.
+    storage of embeddings with smart chunking for optimal search performance.
 
     Parameters
     ----------
     persist_directory : str, optional
         Directory path for persistent storage of ChromaDB data.
         Default is "./chroma_db". The directory will be created if it doesn't exist.
+    chunk_threshold : int, optional
+        Content length threshold for chunking (default 1200 chars)
+    max_chunk_size : int, optional
+        Maximum size per chunk (default 1000 chars)
 
     Attributes
     ----------
@@ -32,6 +38,10 @@ class SemanticSearch:
         Embedding function using the 'all-MiniLM-L6-v2' model for text vectorization.
     collections : Dict[str, chromadb.Collection]
         Dictionary mapping collection names to ChromaDB collection objects.
+    chunk_threshold : int
+        Content length threshold for chunking
+    max_chunk_size : int
+        Maximum size per chunk
 
     Examples
     --------
@@ -55,9 +65,19 @@ class SemanticSearch:
     ChromaDB stores embeddings persistently, so collections survive across
     sessions. The first indexing operation may be slower due to model download
     and embedding computation.
+
+    Content is automatically chunked for optimal search performance:
+    - Long documents (>1200 chars) are split into smaller, searchable chunks
+    - Markdown headers are preserved to maintain document structure
+    - Issues and PRs are kept as single units since they're typically shorter
     """
 
-    def __init__(self, persist_directory: str = "./chroma_db"):
+    def __init__(
+        self,
+        persist_directory: str = "./chroma_db",
+        chunk_threshold: int = 1200,
+        max_chunk_size: int = 1000,
+    ):
         """
         Initialize SemanticSearch with persistent ChromaDB storage.
 
@@ -66,11 +86,15 @@ class SemanticSearch:
         persist_directory : str, optional
             Path to directory for storing ChromaDB data. Created if doesn't exist.
             Default is "./chroma_db".
+        chunk_threshold : int, optional
+            Content length threshold for chunking (default 1200 chars)
+        max_chunk_size : int, optional
+            Maximum size per chunk (default 1000 chars)
 
         Examples
         --------
         >>> search = SemanticSearch()  # Uses default ./chroma_db
-        >>> search = SemanticSearch("/custom/path/db")  # Custom path
+        >>> search = SemanticSearch("/custom/path/db", chunk_threshold=800)  # Custom settings
         """
         self.client = chromadb.PersistentClient(path=persist_directory)
         self.embedding_function = (
@@ -79,6 +103,8 @@ class SemanticSearch:
             )
         )
         self.collections = {}
+        self.chunk_threshold = chunk_threshold
+        self.max_chunk_size = max_chunk_size
 
     def get_or_create_collection(self, name: str):
         """
@@ -112,7 +138,7 @@ class SemanticSearch:
             collection = self.client.get_collection(
                 name=collection_name, embedding_function=self.embedding_function
             )
-        except (chromadb.errors.CollectionNotFoundError, ValueError):
+        except Exception:
             # Collection doesn't exist, create it
             collection = self.client.create_collection(
                 name=collection_name,
@@ -125,11 +151,11 @@ class SemanticSearch:
 
     def index_content(self, collection_name: str, content_dict: Dict[str, Any]):
         """
-        Index content into a collection for semantic search.
+        Index content into a collection for semantic search with smart chunking.
 
-        Processes nested content dictionaries and creates searchable embeddings.
-        Handles different content types appropriately (issues/PRs vs regular content).
-        Existing content in the collection is cleared before adding new content.
+        Processes nested content dictionaries and creates searchable embeddings using
+        specialized handling for different content types. Long content is automatically
+        chunked for optimal search performance while preserving document structure.
 
         Parameters
         ----------
@@ -141,7 +167,8 @@ class SemanticSearch:
 
             Special handling for content types:
             - 'issues', 'prs': Expected to contain lists of dictionaries with 'title', 'body', 'number'
-            - Other types: Expected to contain direct text content
+            - 'wiki', 'readme': Automatically chunked if content exceeds chunk_threshold
+            - Other types: Indexed as-is if content meets minimum length requirements
 
         Examples
         --------
@@ -149,8 +176,11 @@ class SemanticSearch:
 
         >>> content = {
         ...     "readme": {
-        ...         "install": "Installation instructions...",
-        ...         "usage": "Usage examples..."
+        ...         "install": "Very long installation guide..." * 100,  # Will be chunked
+        ...         "quickstart": "Short guide"  # Will not be chunked
+        ...     },
+        ...     "wiki": {
+        ...         "api-reference": "## Overview\nDetailed API docs..." * 50  # Chunked by headers
         ...     },
         ...     "issues": {
         ...         "repo1": [
@@ -162,12 +192,25 @@ class SemanticSearch:
 
         Notes
         -----
-        - Content shorter than 50 characters is filtered out for regular content
-        - Content shorter than 20 characters is filtered out for issues/PRs
-        - Issues and PRs combine title and body for better searchability
-        - Each piece of content gets metadata including type, name, and source
-        - IDs are generated for uniqueness and later retrieval
-        - The collection is cleared before indexing to ensure consistency
+        Content processing rules:
+        - Issues/PRs: Combine title and body, filter content < 20 chars
+        - Wiki/README: Smart chunking for content > chunk_threshold chars
+        - Other content: Index as-is if > 50 chars
+
+        Chunking preserves:
+        - Markdown header structure
+        - Paragraph boundaries
+        - Sentence boundaries for very long paragraphs
+
+        Each chunk gets metadata including:
+        - type: Content type (wiki, readme, issues, etc.)
+        - name: Original content name
+        - source: Human-readable source description
+        - chunk: Chunk number (0 for non-chunked content)
+        - is_chunked: Boolean indicating if content was split
+        - total_chunks: Total number of chunks (for chunked content)
+
+        The collection is cleared before indexing to ensure consistency.
 
         Raises
         ------
@@ -176,67 +219,72 @@ class SemanticSearch:
         """
         collection = self.get_or_create_collection(collection_name)
 
-        documents = []
-        metadatas = []
-        ids = []
+        all_documents = []
+        all_metadatas = []
+        all_ids = []
 
         for content_type, items in content_dict.items():
             if content_type in ["issues", "prs"]:
-                # Handle issues and PRs specially - they're lists of dictionaries
-                for repo_name, item_list in items.items():
-                    if isinstance(item_list, list):
-                        for item in item_list:
-                            if isinstance(item, dict) and item.get("title"):
-                                # Combine title and body for better search
-                                title = item.get("title", "")
-                                body = item.get("body", "")
-                                content = f"{title}\n\n{body}" if body else title
+                # Handle issues and PRs - no chunking needed as they're typically short
+                documents, metadatas, ids = (
+                    semantic_search_utils.process_issues_and_prs(content_type, items)
+                )
 
-                                if len(content.strip()) > 20:  # Skip very short content
-                                    documents.append(content)
-                                    metadatas.append(
-                                        {
-                                            "type": content_type,
-                                            "name": f"{repo_name}#{item.get('number', '')}",
-                                            "source": f"{content_type}: {repo_name}#{item.get('number', '')}",
-                                        }
-                                    )
-                                    ids.append(
-                                        f"{content_type}_{repo_name}_{item.get('number', '')}"
-                                    )
+            elif content_type in ["wiki", "readme", "tutorials"]:
+                # Handle content that may need chunking
+                documents, metadatas, ids = (
+                    semantic_search_utils.process_chunkable_content(
+                        content_type, items, self.chunk_threshold, self.max_chunk_size
+                    )
+                )
 
-            elif isinstance(items, dict):
-                # Handle regular content (readme, wiki, etc.)
-                for name, content in items.items():
-                    if content and len(str(content).strip()) > 50:
-                        documents.append(str(content))
-                        metadatas.append(
-                            {
-                                "type": content_type,
-                                "name": name,
-                                "source": f"{content_type}: {name}",
-                            }
-                        )
-                        ids.append(f"{content_type}_{name}")
+            elif content_type in ["classes", "functions", "methods"]:
+                # Handle codebase content with specialized processing
+                documents, metadatas, ids = (
+                    semantic_search_utils.process_codebase_content(content_type, items)
+                )
 
-        if documents:
+            else:
+                logger.warning(
+                    f"Unknown content type: {content_type} - this will be indexed but it may be pathological as whatever the content is will be turned into a string as-is"
+                )
+                # Handle regular content without chunking
+                documents, metadatas, ids = (
+                    semantic_search_utils.process_regular_content(content_type, items)
+                )
+
+            # Accumulate results
+            all_documents.extend(documents)
+            all_metadatas.extend(metadatas)
+            all_ids.extend(ids)
+
+        if all_documents:
             # Clear existing content and reindex
             try:
                 collection.delete(where={})
-            except (chromadb.errors.NoIndexException, ValueError, RuntimeError):
+            except Exception:
                 # Collection might be empty or not properly initialized
                 pass
 
-            collection.add(documents=documents, metadatas=metadatas, ids=ids)
-            logger.info(f"Indexed {len(documents)} items in {collection_name}")
+            collection.add(
+                documents=all_documents, metadatas=all_metadatas, ids=all_ids
+            )
 
-            # Log breakdown by content type for debugging
+            logger.info(f"Indexed {len(all_documents)} items in {collection_name}")
+
+            # Log breakdown by content type and chunking for debugging
             type_counts = {}
-            for metadata in metadatas:
+            chunk_counts = {}
+            for metadata in all_metadatas:
                 content_type = metadata["type"]
                 type_counts[content_type] = type_counts.get(content_type, 0) + 1
 
+                if metadata.get("is_chunked", False):
+                    chunk_counts[content_type] = chunk_counts.get(content_type, 0) + 1
+
             logger.debug(f"Content type breakdown: {type_counts}")
+            if chunk_counts:
+                logger.debug(f"Chunked content counts: {chunk_counts}")
         else:
             logger.warning(f"No content to index in {collection_name}")
 
@@ -247,7 +295,8 @@ class SemanticSearch:
         Perform semantic search on a collection with similarity scores.
 
         Uses AI embeddings to find content semantically similar to the query,
-        even if exact keywords don't match. Returns results with similarity scores.
+        even if exact keywords don't match. Returns results with similarity scores
+        and handles chunked content appropriately.
 
         Parameters
         ----------
@@ -262,19 +311,20 @@ class SemanticSearch:
         -------
         List[Dict[str, Any]]
             List of search results ordered by similarity (highest first), each containing:
-            - 'content': The matched text content
-            - 'metadata': Dictionary with type, name, source information
-            - 'source': Human-readable source description
+            - 'content': The matched text content (may be a chunk of larger document)
+            - 'metadata': Dictionary with type, name, source, chunking information
+            - 'source': Human-readable source description (includes chunk info if applicable)
             - 'similarity_score': Float between 0 and 1 (1 = perfect match, 0 = no similarity)
 
         Examples
         --------
-        Basic semantic search with scores:
+        Basic semantic search with chunked content:
 
         >>> results = search.search("how to install", "documentation")
         >>> for result in results:
         ...     score = result['similarity_score']
-        ...     print(f"Score: {score:.3f} - {result['source']}")
+        ...     source = result['source']  # May include "(part 2)" for chunks
+        ...     print(f"Score: {score:.3f} - {source}")
 
         Notes
         -----
@@ -283,6 +333,12 @@ class SemanticSearch:
         - 0.6-0.8: Good matches
         - 0.4-0.6: Moderate relevance
         - 0.0-0.4: Low relevance (may not be useful)
+
+        Chunked content handling:
+        - Each chunk is searched independently for best precision
+        - Source descriptions indicate chunk numbers (e.g., "wiki: API Guide (part 2)")
+        - Multiple chunks from the same document may appear in results
+        - This allows finding the most relevant section within long documents
 
         ChromaDB uses cosine similarity between embeddings, where:
         - 1.0 = identical semantic meaning
@@ -296,7 +352,7 @@ class SemanticSearch:
         results = collection.query(
             query_texts=[query],
             n_results=n_results,
-            include=["documents", "metadatas", "distances"],  # Include distances
+            include=["documents", "metadatas", "distances"],
         )
 
         formatted_results = []

--- a/src/napistu/mcp/semantic_search_utils.py
+++ b/src/napistu/mcp/semantic_search_utils.py
@@ -1,0 +1,443 @@
+"""
+Utility functions for semantic search content processing and chunking.
+
+These functions are designed to be pure, testable utilities that don't depend
+on any specific class state. They can be easily tested, reused, and maintained
+independently of the SemanticSearch class.
+"""
+
+import re
+import logging
+from typing import List, Dict, Any, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def process_issues_and_prs(
+    content_type: str, items: Dict[str, Any]
+) -> Tuple[List[str], List[Dict], List[str]]:
+    """
+    Process issues and pull requests for indexing.
+
+    Combines title and body for each issue/PR without chunking since they're
+    typically reasonably sized.
+
+    Parameters
+    ----------
+    content_type : str
+        Type of content ('issues' or 'prs')
+    items : Dict[str, Any]
+        Dictionary mapping repo names to lists of issues/PRs
+
+    Returns
+    -------
+    Tuple[List[str], List[Dict], List[str]]
+        Tuple of (documents, metadatas, ids) ready for ChromaDB indexing
+    """
+    documents = []
+    metadatas = []
+    ids = []
+
+    for repo_name, item_list in items.items():
+        if isinstance(item_list, list):
+            for item in item_list:
+                if isinstance(item, dict) and item.get("title"):
+                    title = item.get("title", "")
+                    body = item.get("body", "")
+                    content = f"{title}\n\n{body}" if body else title
+
+                    if len(content.strip()) > 20:
+                        documents.append(content)
+                        metadatas.append(
+                            {
+                                "type": content_type,
+                                "name": f"{repo_name}#{item.get('number', '')}",
+                                "source": f"{content_type}: {repo_name}#{item.get('number', '')}",
+                                "chunk": 0,
+                                "is_chunked": False,
+                                "chunking_method": "none",
+                            }
+                        )
+                        ids.append(
+                            f"{content_type}_{repo_name}_{item.get('number', '')}"
+                        )
+
+    return documents, metadatas, ids
+
+
+def process_chunkable_content(
+    content_type: str,
+    items: Dict[str, Any],
+    chunk_threshold: int = 1200,
+    max_chunk_size: int = 1000,
+) -> Tuple[List[str], List[Dict], List[str]]:
+    """
+    Process content that may need chunking (wiki, README, etc.).
+
+    Uses smart chunking that preserves document structure and semantic boundaries.
+    Automatically detects markdown headers and splits appropriately.
+
+    Parameters
+    ----------
+    content_type : str
+        Type of content ('wiki', 'readme', etc.)
+    items : Dict[str, Any]
+        Dictionary mapping content names to content text
+    chunk_threshold : int, optional
+        Content length threshold for chunking (default 1200 chars)
+    max_chunk_size : int, optional
+        Maximum size per chunk (default 1000 chars)
+
+    Returns
+    -------
+    Tuple[List[str], List[Dict], List[str]]
+        Tuple of (documents, metadatas, ids) ready for ChromaDB indexing
+    """
+    documents = []
+    metadatas = []
+    ids = []
+
+    for name, content in items.items():
+        if content and len(str(content).strip()) > 50:
+            content_str = str(content)
+
+            if len(content_str) > chunk_threshold:
+                # Use smart chunking for long content
+                chunks = _chunk_content_smart(content_str, name, max_chunk_size)
+
+                for chunk_idx, chunk in enumerate(chunks):
+                    documents.append(chunk)
+                    metadatas.append(
+                        {
+                            "type": content_type,
+                            "name": name,
+                            "source": f"{content_type}: {name} (part {chunk_idx + 1})",
+                            "chunk": chunk_idx,
+                            "total_chunks": len(chunks),
+                            "is_chunked": True,
+                        }
+                    )
+                    ids.append(f"{content_type}_{name}_chunk_{chunk_idx}")
+            else:
+                # Short content, index as-is
+                documents.append(content_str)
+                metadatas.append(
+                    {
+                        "type": content_type,
+                        "name": name,
+                        "source": f"{content_type}: {name}",
+                        "chunk": 0,
+                        "is_chunked": False,
+                    }
+                )
+                ids.append(f"{content_type}_{name}")
+
+    return documents, metadatas, ids
+
+
+def process_regular_content(
+    content_type: str, items: Dict[str, Any]
+) -> Tuple[List[str], List[Dict], List[str]]:
+    """
+    Process regular content types without special handling.
+
+    For content types that don't need chunking or special processing,
+    indexes content directly if it meets minimum length requirements.
+
+    Parameters
+    ----------
+    content_type : str
+        Type of content
+    items : Dict[str, Any]
+        Dictionary mapping content names to content text
+
+    Returns
+    -------
+    Tuple[List[str], List[Dict], List[str]]
+        Tuple of (documents, metadatas, ids) ready for ChromaDB indexing
+    """
+    documents = []
+    metadatas = []
+    ids = []
+
+    for name, content in items.items():
+        if content and len(str(content).strip()) > 50:
+            documents.append(str(content))
+            metadatas.append(
+                {
+                    "type": content_type,
+                    "name": name,
+                    "source": f"{content_type}: {name}",
+                    "chunk": 0,
+                    "is_chunked": False,
+                    "chunking_method": "none",
+                }
+            )
+            ids.append(f"{content_type}_{name}")
+
+    return documents, metadatas, ids
+
+
+# utility functions
+
+
+def _chunk_content_smart(
+    text: str, content_name: str, max_chunk_size: int = 1000
+) -> List[str]:
+    """
+    Smart chunking that works well for any structured content (wiki, README, etc.).
+
+    Automatically detects document structure and chunks appropriately:
+    1. Tries to split by markdown headers first
+    2. Falls back to paragraph-based grouping if no headers or content is too long
+    3. Ensures chunks don't exceed max_chunk_size
+
+    Parameters
+    ----------
+    text : str
+        Content to chunk
+    content_name : str
+        Name of the content for logging
+    max_chunk_size : int, optional
+        Maximum characters per chunk (default 1000)
+
+    Returns
+    -------
+    List[str]
+        List of well-structured chunks
+    """
+    if len(text) <= max_chunk_size:
+        return [text]
+
+    chunks = []
+
+    # Step 1: Try to split by headers first (works for wiki, README, etc.)
+    header_sections = _split_by_headers(text)
+
+    logger.debug(
+        f"Chunking '{content_name}': found {len(header_sections)} header sections"
+    )
+
+    # Check if we actually found meaningful header sections
+    if len(header_sections) == 1 and header_sections[0] == text:
+        # No headers found, use paragraph-based chunking for the entire text
+        logger.info(
+            f"No headers found in '{content_name}', using paragraph-based chunking"
+        )
+        paragraphs = text.split("\n\n")
+        chunks = _group_paragraphs_semantically(paragraphs, max_chunk_size)
+    else:
+        # Process each header section
+        for section in header_sections:
+            if (
+                len(section) <= max_chunk_size * 1.2
+            ):  # Allow slightly larger for coherence
+                chunks.append(section)
+            else:
+                # Step 2: Split long sections by paragraphs
+                paragraphs = section.split("\n\n")
+                logger.debug(
+                    f"Splitting long section ({len(section)} chars) into {len(paragraphs)} paragraphs"
+                )
+                grouped_chunks = _group_paragraphs_semantically(
+                    paragraphs, max_chunk_size
+                )
+                chunks.extend(grouped_chunks)
+
+    logger.debug(
+        f"Smart chunking '{content_name}': {len(text)} chars → {len(chunks)} chunks"
+    )
+    return chunks
+
+
+def _find_best_break_point(text: str, start: int, end: int) -> int:
+    """
+    Find the best break point for chunking text at natural boundaries.
+
+    Tries to break at paragraphs, then sentences, then words.
+
+    Parameters
+    ----------
+    text : str
+        Text to find break point in
+    start : int
+        Start position for the chunk
+    end : int
+        Desired end position for the chunk
+
+    Returns
+    -------
+    int
+        Best break point position
+    """
+    # Look for paragraph break (double newline)
+    para_break = text.rfind("\n\n", start, end)
+    if para_break > start + (end - start) // 2:
+        return para_break + 2
+
+    # Look for line break
+    line_break = text.rfind("\n", start, end)
+    if line_break > start + (end - start) // 2:
+        return line_break + 1
+
+    # Look for sentence end
+    sent_break = text.rfind(". ", start, end)
+    if sent_break > start + (end - start) // 2:
+        return sent_break + 2
+
+    # Fall back to word boundary
+    word_break = text.rfind(" ", start, end)
+    if word_break > start + (end - start) // 2:
+        return word_break + 1
+
+    # Last resort: break at end
+    return end
+
+
+def _group_paragraphs_semantically(
+    paragraphs: List[str], max_chunk_size: int = 1000
+) -> List[str]:
+    """
+    Group related paragraphs into semantically coherent chunks.
+
+    Uses a simple heuristic: consecutive paragraphs that together don't exceed
+    max_chunk_size are kept together. More sophisticated semantic similarity
+    could be added here using embeddings.
+
+    Parameters
+    ----------
+    paragraphs : List[str]
+        List of paragraph strings
+    max_chunk_size : int, optional
+        Maximum characters per chunk (default 1000)
+
+    Returns
+    -------
+    List[str]
+        List of grouped paragraph chunks
+    """
+    if not paragraphs:
+        return []
+
+    # Special case: if there's only one paragraph and it's too long, split it
+    if len(paragraphs) == 1 and len(paragraphs[0].strip()) > max_chunk_size:
+        logger.debug(
+            f"Single long paragraph ({len(paragraphs[0].strip())} chars), splitting at sentences"
+        )
+        return _split_long_paragraph(paragraphs[0].strip(), max_chunk_size)
+
+    chunks = []
+    current_chunk = []
+    current_length = 0
+
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+
+        # If this single paragraph is too long, split it
+        if len(para) > max_chunk_size:
+            # First, finalize any current chunk
+            if current_chunk:
+                chunks.append("\n\n".join(current_chunk))
+                current_chunk = []
+                current_length = 0
+
+            # Split the long paragraph and add all chunks
+            para_chunks = _split_long_paragraph(para, max_chunk_size)
+            chunks.extend(para_chunks)
+            continue
+
+        para_length = len(para)
+
+        # If adding this paragraph would exceed limit, finalize current chunk
+        if current_length + para_length + 2 > max_chunk_size and current_chunk:
+            chunks.append("\n\n".join(current_chunk))
+            current_chunk = [para]
+            current_length = para_length
+        else:
+            current_chunk.append(para)
+            current_length += para_length + 2  # +2 for \n\n
+
+    # Add final chunk
+    if current_chunk:
+        chunks.append("\n\n".join(current_chunk))
+
+    return chunks
+
+
+def _split_by_headers(text: str) -> List[str]:
+    """Split text by markdown headers while preserving structure."""
+    # Find all headers (##, ###, ####)
+    header_pattern = r"^(#{2,4})\s+(.+)$"
+    lines = text.split("\n")
+
+    sections = []
+    current_section = []
+
+    for line in lines:
+        header_match = re.match(header_pattern, line, re.MULTILINE)
+
+        if header_match:
+            # Save previous section
+            if current_section:
+                section_text = "\n".join(current_section)
+                if section_text.strip():
+                    sections.append(section_text)
+
+            # Start new section with header
+            current_section = [line]
+        else:
+            current_section.append(line)
+
+    # Add final section
+    if current_section:
+        section_text = "\n".join(current_section)
+        if section_text.strip():
+            sections.append(section_text)
+
+    # If no headers found, return original text
+    return sections if sections else [text]
+
+
+def _split_long_paragraph(text: str, max_chunk_size: int) -> List[str]:
+    """
+    Split a single long paragraph into smaller chunks at sentence boundaries.
+
+    This handles the case where content has no paragraph breaks but is too long
+    to be a single chunk.
+    """
+    if len(text) <= max_chunk_size:
+        return [text]
+
+    chunks = []
+    sentences = text.split(". ")
+
+    current_chunk = []
+    current_length = 0
+
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+
+        # Add period back if it was split off (except for last sentence)
+        if not sentence.endswith(".") and sentence != sentences[-1]:
+            sentence += "."
+
+        sentence_length = len(sentence)
+
+        # If adding this sentence would exceed limit, finalize current chunk
+        if current_length + sentence_length + 1 > max_chunk_size and current_chunk:
+            chunks.append(" ".join(current_chunk))
+            current_chunk = [sentence]
+            current_length = sentence_length
+        else:
+            current_chunk.append(sentence)
+            current_length += sentence_length + 1  # +1 for space
+
+    # Add final chunk
+    if current_chunk:
+        chunks.append(" ".join(current_chunk))
+
+    return chunks

--- a/src/napistu/mcp/tutorials.py
+++ b/src/napistu/mcp/tutorials.py
@@ -11,23 +11,76 @@ from napistu.mcp.component_base import ComponentState, MCPComponent
 from napistu.mcp import tutorials_utils
 from napistu.mcp import utils as mcp_utils
 from napistu.mcp.constants import TUTORIAL_URLS
+from napistu.mcp.semantic_search import SemanticSearch
 
 logger = logging.getLogger(__name__)
 
 
 class TutorialsState(ComponentState):
-    """State management for tutorials component."""
+    """
+    State management for tutorials component with semantic search capabilities.
+
+    Manages cached tutorial content and tracks semantic search availability.
+    Extends ComponentState to provide standardized health monitoring and status reporting.
+
+    Attributes
+    ----------
+    tutorials : Dict[str, str]
+        Dictionary mapping tutorial IDs to their markdown content
+    semantic_search : SemanticSearch or None
+        Reference to shared semantic search instance for AI-powered tutorial search,
+        None if not initialized
+
+    Examples
+    --------
+    >>> state = TutorialsState()
+    >>> state.tutorials["consensus-networks"] = "# Creating Networks..."
+    >>> print(state.is_healthy())  # True if any tutorials loaded
+    >>> health = state.get_health_details()
+    >>> print(health["tutorial_count"])
+    """
 
     def __init__(self):
         super().__init__()
         self.tutorials: Dict[str, str] = {}
+        self.semantic_search = None
 
     def is_healthy(self) -> bool:
-        """Component is healthy if it has loaded tutorials."""
+        """
+        Check if component has successfully loaded tutorial content.
+
+        Returns
+        -------
+        bool
+            True if any tutorials are loaded, False otherwise
+
+        Notes
+        -----
+        This method checks for the presence of any tutorial content.
+        Semantic search availability is not required for health.
+        """
         return bool(self.tutorials)
 
     def get_health_details(self) -> Dict[str, Any]:
-        """Provide tutorials-specific health details."""
+        """
+        Get detailed health information including tutorial counts.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary containing:
+            - tutorial_count : int
+                Number of tutorials loaded
+            - tutorial_ids : List[str]
+                List of loaded tutorial IDs
+
+        Examples
+        --------
+        >>> state = TutorialsState()
+        >>> # ... load content ...
+        >>> details = state.get_health_details()
+        >>> print(f"Total tutorials: {details['tutorial_count']}")
+        """
         return {
             "tutorial_count": len(self.tutorials),
             "tutorial_ids": list(self.tutorials.keys()),
@@ -35,23 +88,79 @@ class TutorialsState(ComponentState):
 
 
 class TutorialsComponent(MCPComponent):
-    """MCP component for tutorial management and search."""
+    """
+    MCP component for tutorial management and search with semantic capabilities.
+
+    Provides access to Napistu project tutorials with both exact text matching and
+    AI-powered semantic search for natural language queries. Tutorials cover practical
+    workflows, code examples, and step-by-step guides for using Napistu functionality.
+
+    The component loads tutorial content from configured URLs and uses a shared
+    semantic search instance for natural language tutorial discovery.
+
+    Examples
+    --------
+    Basic component usage:
+
+    >>> component = TutorialsComponent()
+    >>> semantic_search = SemanticSearch()  # Shared instance
+    >>> success = await component.safe_initialize(semantic_search)
+    >>> if success:
+    ...     state = component.get_state()
+    ...     print(f"Loaded {state.get_health_details()['tutorial_count']} tutorials")
+
+    Notes
+    -----
+    The component gracefully handles failures in individual tutorial loading and
+    semantic search initialization. If semantic search is not provided, the component
+    continues to function with exact text search only.
+
+    **CONTENT SCOPE:**
+    Tutorials specifically cover Napistu workflows, not general bioinformatics concepts.
+    Use this component for Napistu-specific implementation guidance, not broad domain knowledge.
+    """
 
     def _create_state(self) -> TutorialsState:
-        """Create tutorials-specific state."""
+        """
+        Create tutorials-specific state instance.
+
+        Returns
+        -------
+        TutorialsState
+            New state instance for managing tutorial content and semantic search
+        """
         return TutorialsState()
 
-    async def initialize(self) -> bool:
+    async def initialize(self, semantic_search: SemanticSearch = None) -> bool:
         """
-        Initialize tutorials component by loading all tutorials.
+        Initialize tutorials component with content loading and semantic indexing.
+
+        Performs the following operations:
+        1. Loads tutorial content from configured URLs
+        2. Stores reference to shared semantic search instance
+        3. Indexes loaded tutorials if semantic search is available
+
+        Parameters
+        ----------
+        semantic_search : SemanticSearch, optional
+            Shared semantic search instance for AI-powered search capabilities.
+            If None, component will operate with exact text search only.
 
         Returns
         -------
         bool
-            True if at least one tutorial was loaded successfully
+            True if at least one tutorial was loaded successfully, False if
+            all loading operations failed
+
+        Notes
+        -----
+        Individual tutorial failures are logged as warnings but don't fail the entire
+        initialization. Semantic search indexing failure is logged but doesn't
+        affect the return value - the component can function without semantic search.
         """
         tutorials_loaded = 0
 
+        logger.info("Loading tutorials...")
         for tutorial_id, url in TUTORIAL_URLS.items():
             try:
                 content = await tutorials_utils.get_tutorial_markdown(tutorial_id)
@@ -64,54 +173,157 @@ class TutorialsComponent(MCPComponent):
 
         logger.info(f"Loaded {tutorials_loaded}/{len(TUTORIAL_URLS)} tutorials")
 
-        # Consider successful if at least one tutorial loaded
-        return tutorials_loaded > 0
+        # Store reference to shared semantic search instance
+        content_loaded = tutorials_loaded > 0
+        if semantic_search and content_loaded:
+            self.state.semantic_search = semantic_search
+            semantic_success = await self._initialize_semantic_search()
+            logger.info(
+                f"Semantic search initialization: {'✅ Success' if semantic_success else '⚠️ Failed'}"
+            )
+
+        return content_loaded
+
+    async def _initialize_semantic_search(self) -> bool:
+        """
+        Index tutorial content into the shared semantic search instance.
+
+        Uses the shared semantic search instance (stored in self.state.semantic_search)
+        to index this component's tutorial content into the "tutorials" collection.
+
+        Returns
+        -------
+        bool
+            True if content was successfully indexed, False if indexing failed
+
+        Notes
+        -----
+        Assumes self.state.semantic_search has already been set to a valid
+        SemanticSearch instance during initialize().
+
+        Failure to index content is not considered a critical error.
+        The component continues to function with exact text search if semantic
+        search indexing fails.
+        """
+        try:
+            if not self.state.semantic_search:
+                logger.warning("No semantic search instance available")
+                return False
+
+            logger.info("Indexing tutorial content for semantic search...")
+
+            # Prepare content for indexing in the format expected by SemanticSearch
+            content_dict = {"tutorials": self.state.tutorials}
+
+            # Index content into the shared semantic search instance
+            self.state.semantic_search.index_content("tutorials", content_dict)
+
+            logger.info("✅ Tutorial content indexed successfully")
+            return True
+
+        except Exception as e:
+            logger.error(f"❌ Failed to index tutorial content: {e}")
+            return False
 
     def register(self, mcp: FastMCP) -> None:
         """
         Register tutorial resources and tools with the MCP server.
 
+        Registers the following MCP endpoints:
+        - Resources for accessing tutorial summaries and specific content
+        - Tools for searching tutorials with semantic and exact modes
+
         Parameters
         ----------
         mcp : FastMCP
-            FastMCP server instance
+            FastMCP server instance to register endpoints with
+
+        Notes
+        -----
+        The search tool automatically selects semantic search when available,
+        falling back to exact search if semantic search is not initialized.
         """
 
         # Register resources
         @mcp.resource("napistu://tutorials/index")
-        async def get_tutorials_index() -> List[Dict[str, Any]]:
+        async def get_tutorials_index() -> Dict[str, Any]:
             """
             Get the index of all available tutorials.
 
+            **USE THIS WHEN:**
+            - Getting an overview of available Napistu tutorials
+            - Understanding what tutorial content is available before searching
+            - Checking tutorial availability and counts
+
+            **DO NOT USE FOR:**
+            - General bioinformatics tutorials (only covers Napistu-specific content)
+            - Questions not related to Napistu workflows or implementation
+            - Academic research that doesn't involve Napistu usage
+
             Returns
             -------
-            List[dict]
-                List of dictionaries with tutorial IDs and URLs.
+            Dict[str, Any]
+                Dictionary containing:
+                - tutorials : List[Dict[str, str]]
+                    List of tutorial metadata with IDs and URLs
+                - total_count : int
+                    Total number of available tutorials
+
+            Examples
+            --------
+            Use this to understand what Napistu tutorials are available before
+            searching for specific implementation guidance.
             """
-            return [
+            tutorial_list = [
                 {"id": tutorial_id, "url": url}
                 for tutorial_id, url in TUTORIAL_URLS.items()
             ]
 
+            return {
+                "tutorials": tutorial_list,
+                "total_count": len(tutorial_list),
+            }
+
         @mcp.resource("napistu://tutorials/content/{tutorial_id}")
         async def get_tutorial_content_resource(tutorial_id: str) -> Dict[str, Any]:
             """
-            Get the content of a specific tutorial as markdown.
+            Get the full content of a specific Napistu tutorial as markdown.
+
+            **USE THIS WHEN:**
+            - Reading a specific Napistu tutorial you've identified via search
+            - Getting detailed implementation steps for Napistu workflows
+            - Following along with Napistu code examples and exercises
+
+            **DO NOT USE FOR:**
+            - General bioinformatics concepts (only covers Napistu implementation)
+            - Non-Napistu tools or frameworks
+            - Academic theory not related to practical Napistu usage
 
             Parameters
             ----------
             tutorial_id : str
-                ID of the tutorial.
+                ID of the tutorial (from tutorials index)
 
             Returns
             -------
-            dict
-                Dictionary with markdown content and format.
+            Dict[str, Any]
+                Dictionary containing:
+                - content : str
+                    Full markdown content of the tutorial
+                - format : str
+                    Content format ("markdown")
+                - tutorial_id : str
+                    ID of the loaded tutorial
 
             Raises
             ------
             Exception
-                If the tutorial cannot be loaded.
+                If the tutorial cannot be loaded or doesn't exist
+
+            Examples
+            --------
+            After finding a relevant tutorial via search, use this to get the
+            complete tutorial content for step-by-step implementation guidance.
             """
             # Check local state first
             content = self.state.tutorials.get(tutorial_id)
@@ -129,35 +341,129 @@ class TutorialsComponent(MCPComponent):
             return {
                 "content": content,
                 "format": "markdown",
+                "tutorial_id": tutorial_id,
             }
 
         @mcp.tool()
-        async def search_tutorials(query: str) -> List[Dict[str, Any]]:
+        async def search_tutorials(
+            query: str, search_type: str = "semantic"
+        ) -> Dict[str, Any]:
             """
-            Search tutorials for a specific query.
+            Search Napistu tutorials with intelligent search strategy.
+
+            Provides flexible search capabilities for finding relevant Napistu tutorial content
+            using either AI-powered semantic search for natural language queries or exact text
+            matching for precise keyword searches. Uses shared semantic search instance when available.
+
+            **USE THIS WHEN:**
+            - Looking for Napistu implementation tutorials and workflows
+            - Finding step-by-step guides for specific Napistu features
+            - Searching for code examples and practical usage patterns
+            - Learning how to use Napistu for consensus networks, SBML processing, etc.
+
+            **DO NOT USE FOR:**
+            - General bioinformatics concepts not related to Napistu
+            - Questions about other tools, libraries, or frameworks
+            - Academic research that doesn't involve Napistu implementation
+            - Basic programming concepts unrelated to Napistu workflows
+
+            **EXAMPLE APPROPRIATE QUERIES:**
+            - "how to create consensus networks"
+            - "SBML file processing tutorial"
+            - "pathway integration with Napistu"
+            - "data source ingestion examples"
+
+            **EXAMPLE INAPPROPRIATE QUERIES:**
+            - "what is systems biology" (too general)
+            - "how to use pandas" (not Napistu-specific)
+            - "gene ontology enrichment" (unless specifically about Napistu implementation)
 
             Parameters
             ----------
             query : str
-                Search term.
+                Search term or natural language question about Napistu usage.
+                Should be specific to Napistu workflows, features, or implementation.
+            search_type : str, optional
+                Search strategy to use:
+                - "semantic" (default): AI-powered search using embeddings
+                - "exact": Traditional text matching search
+                Default is "semantic".
 
             Returns
             -------
-            List[dict]
-                List of matching tutorials with metadata and snippet.
+            Dict[str, Any]
+                Search results dictionary containing:
+                - query : str
+                    Original search query
+                - search_type : str
+                    Actual search type used ("semantic" or "exact")
+                - results : List[Dict] or List[Dict[str, Any]]
+                    Search results. Format depends on search type:
+                    - Semantic: List of result dictionaries with content, metadata, source, similarity_score
+                    - Exact: List of tutorial matches with id and snippet
+                - tip : str
+                    Helpful guidance for improving search results
+
+            Examples
+            --------
+            Natural language semantic search for Napistu workflows:
+
+            >>> results = await search_tutorials("how to create consensus networks")
+            >>> print(results["search_type"])  # "semantic"
+            >>> for result in results["results"]:
+            ...     score = result['similarity_score']
+            ...     print(f"Score: {score:.3f} - {result['source']}")
+
+            Exact keyword search for specific Napistu terms:
+
+            >>> results = await search_tutorials("SBML", search_type="exact")
+            >>> for result in results["results"]:
+            ...     print(f"Tutorial: {result['id']}")
+
+            Notes
+            -----
+            **SEARCH TYPE GUIDANCE:**
+            - Use semantic (default) for conceptual queries and natural language questions
+            - Use exact for precise Napistu function names, API calls, or known keywords
+
+            **RESULT INTERPRETATION:**
+            - Semantic results include similarity scores (0.8-1.0 = very relevant)
+            - Multiple tutorial sections may appear for comprehensive coverage
+            - Follow up with get_tutorial_content_resource() for full tutorial text
+
+            The function automatically handles semantic search failures by falling back
+            to exact search, ensuring reliable results even if AI components are unavailable.
             """
-            results: List[Dict[str, Any]] = []
+            if search_type == "semantic" and self.state.semantic_search:
+                # Use shared semantic search instance
+                results = self.state.semantic_search.search(
+                    query, "tutorials", n_results=5
+                )
+                return {
+                    "query": query,
+                    "search_type": "semantic",
+                    "results": results,
+                    "tip": "For Napistu-specific tutorials only. Try different phrasings if results aren't relevant, or use search_type='exact' for precise keyword matching",
+                }
+            else:
+                # Fall back to exact search
+                results: List[Dict[str, Any]] = []
 
-            for tutorial_id, content in self.state.tutorials.items():
-                if query.lower() in content.lower():
-                    results.append(
-                        {
-                            "id": tutorial_id,
-                            "snippet": mcp_utils.get_snippet(content, query),
-                        }
-                    )
+                for tutorial_id, content in self.state.tutorials.items():
+                    if query.lower() in content.lower():
+                        results.append(
+                            {
+                                "id": tutorial_id,
+                                "snippet": mcp_utils.get_snippet(content, query),
+                            }
+                        )
 
-            return results
+                return {
+                    "query": query,
+                    "search_type": "exact",
+                    "results": results,
+                    "tip": "Use search_type='semantic' for natural language queries about Napistu workflows",
+                }
 
 
 # Module-level component instance
@@ -171,6 +477,12 @@ def get_component() -> TutorialsComponent:
     Returns
     -------
     TutorialsComponent
-        The tutorials component instance
+        Singleton tutorials component instance for use across the MCP server.
+        The same instance is returned on every call to ensure consistent state.
+
+    Notes
+    -----
+    This function provides the standard interface for accessing the tutorials
+    component. The component must be initialized via safe_initialize() before use.
     """
     return _component

--- a/src/tests/test_mcp_semantic_search_utils.py
+++ b/src/tests/test_mcp_semantic_search_utils.py
@@ -1,0 +1,328 @@
+"""
+Tests for semantic search utility functions.
+"""
+
+from napistu.mcp import semantic_search_utils
+
+
+def test_chunk_content_smart_header_splitting():
+    """Test that smart chunking properly splits by headers."""
+    wiki_text = """## Overview
+This is an overview section about SBML.
+
+SBML stands for Systems Biology Markup Language.
+
+## Details
+Here are the technical details.
+
+### Subsection
+More specific information here.
+
+## Conclusion
+Final thoughts on SBML usage."""
+
+    chunks = semantic_search_utils._chunk_content_smart(
+        wiki_text, "test-wiki", max_chunk_size=200
+    )
+
+    # Should create 4 chunks (one per header section)
+    assert len(chunks) == 4
+    assert chunks[0].startswith("## Overview")
+    assert chunks[1].startswith("## Details")
+    assert chunks[2].startswith("### Subsection")
+    assert chunks[3].startswith("## Conclusion")
+
+    # All chunks should be reasonable size
+    for chunk in chunks:
+        assert 20 < len(chunk) < 250
+
+
+def test_chunk_content_smart_no_chunking_needed():
+    """Test that short content is not chunked."""
+    short_text = "This is a short piece of content."
+    chunks = semantic_search_utils._chunk_content_smart(
+        short_text, "test", max_chunk_size=1000
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0] == short_text
+
+
+def test_split_by_headers():
+    """Test header-based text splitting."""
+    text_with_headers = """## First Section
+Content for first section.
+
+## Second Section  
+Content for second section.
+
+### Subsection
+Subsection content."""
+
+    sections = semantic_search_utils._split_by_headers(text_with_headers)
+
+    assert len(sections) == 3
+    assert sections[0].startswith("## First Section")
+    assert "Content for first section." in sections[0]
+    assert sections[1].startswith("## Second Section")
+    assert sections[2].startswith("### Subsection")
+
+
+def test_split_by_headers_no_headers():
+    """Test that text without headers returns unchanged."""
+    text_no_headers = "Just some regular text without any headers."
+    sections = semantic_search_utils._split_by_headers(text_no_headers)
+
+    assert len(sections) == 1
+    assert sections[0] == text_no_headers
+
+
+def test_group_paragraphs_semantically():
+    """Test paragraph grouping by size."""
+    # Small paragraphs should be grouped together
+    small_paragraphs = ["Short one.", "Short two.", "Short three."]
+    chunks = semantic_search_utils._group_paragraphs_semantically(
+        small_paragraphs, max_chunk_size=1000
+    )
+
+    assert len(chunks) == 1
+    assert all(p in chunks[0] for p in small_paragraphs)
+
+    # Large paragraph should be split when it exceeds max_chunk_size
+    large_paragraph = "This is a very long paragraph. " * 20  # ~640 chars
+    mixed_paragraphs = [large_paragraph, "Short paragraph."]
+    chunks = semantic_search_utils._group_paragraphs_semantically(
+        mixed_paragraphs, max_chunk_size=100
+    )
+
+    # Should have multiple chunks: several from the split large paragraph + 1 for short paragraph
+    assert len(chunks) > 2, f"Expected more than 2 chunks, got {len(chunks)}"
+
+    # The last chunk should be the short paragraph
+    assert "Short paragraph." in chunks[-1]
+
+    # All chunks should be reasonable size
+    for chunk in chunks:
+        assert len(chunk) <= 150, f"Chunk too large: {len(chunk)} chars"
+
+
+def test_group_paragraphs_filters_empty():
+    """Test that empty paragraphs are filtered out."""
+    paragraphs = ["Real content.", "", "  ", "More content."]
+    chunks = semantic_search_utils._group_paragraphs_semantically(
+        paragraphs, max_chunk_size=1000
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0] == "Real content.\n\nMore content."
+
+
+def test_process_issues_and_prs():
+    """Test processing of issues and PR data."""
+    issues_data = {
+        "test-repo": [
+            {"title": "Bug report", "body": "This is a bug", "number": 123},
+            {
+                "title": "Feature request with longer title",
+                "body": "",
+                "number": 124,
+            },  # >20 chars
+            {
+                "title": "x",
+                "body": "y",
+                "number": 125,
+            },  # Should be filtered (too short)
+        ]
+    }
+
+    docs, metas, ids = semantic_search_utils.process_issues_and_prs(
+        "issues", issues_data
+    )
+
+    # Should process 2 items: "Bug report\n\nThis is a bug" and "Feature request with longer title"
+    assert len(docs) == 2
+    assert len(metas) == 2
+    assert len(ids) == 2
+
+    # Check content combination
+    assert "Bug report\n\nThis is a bug" in docs[0]
+    assert "Feature request with longer title" in docs[1]  # No body, just title
+
+    # Check metadata
+    assert metas[0]["type"] == "issues"
+    assert metas[0]["name"] == "test-repo#123"
+    assert metas[0]["is_chunked"] is False
+
+
+def test_process_chunkable_content():
+    """Test processing of content that may need chunking."""
+    content_data = {
+        "short-page": "This is short content that meets the minimum length requirement.",
+        "long-page": "This is a very long page. " * 100,  # ~2600 chars
+    }
+
+    docs, metas, ids = semantic_search_utils.process_chunkable_content(
+        "wiki", content_data, chunk_threshold=1200, max_chunk_size=1000
+    )
+
+    # Debug: print what we actually get
+    print(f"Got {len(docs)} documents")
+    for i, meta in enumerate(metas):
+        print(f"  {i}: {meta['name']} - chunked: {meta['is_chunked']}")
+
+    # Find items by checking the source field instead of name
+    short_items = [i for i, meta in enumerate(metas) if "short-page" in meta["source"]]
+    long_items = [i for i, meta in enumerate(metas) if "long-page" in meta["source"]]
+
+    assert len(short_items) == 1  # Should not be chunked
+    assert len(long_items) >= 1  # Should be chunked (may be multiple chunks)
+
+    # Check metadata
+    short_meta = metas[short_items[0]]
+    assert short_meta["is_chunked"] is False
+    assert short_meta["type"] == "wiki"
+
+    # At least one long item should be chunked
+    long_meta = metas[long_items[0]]
+    assert long_meta["type"] == "wiki"
+
+
+def test_processing_content_filters_short():
+    """Test that very short content is filtered out."""
+    content_data = {
+        "good-content": "This is substantial content that should be indexed.",
+        "bad-content": "x",  # Too short
+    }
+
+    docs, metas, ids = semantic_search_utils.process_chunkable_content(
+        "test", content_data
+    )
+
+    assert len(docs) == 1
+    assert metas[0]["name"] == "good-content"
+
+
+def test_content_filtering():
+    """Test that very short content gets filtered appropriately."""
+    issues_data = {
+        "test-repo": [
+            {
+                "title": "Long enough title and body",
+                "body": "Substantial content here",
+                "number": 1,
+            },
+            {"title": "Short", "body": "x", "number": 2},  # Should be filtered
+        ]
+    }
+
+    docs, metas, ids = semantic_search_utils.process_issues_and_prs(
+        "issues", issues_data
+    )
+    assert len(docs) == 1  # Only the long one should survive
+
+
+def test_split_long_paragraph():
+    """Test that a single long paragraph gets split properly."""
+    # Create a long paragraph with clear sentence boundaries
+    long_paragraph = (
+        "This is sentence one. This is sentence two. This is sentence three. " * 50
+    )  # ~3300 chars
+
+    from napistu.mcp.semantic_search_utils import _split_long_paragraph
+
+    chunks = _split_long_paragraph(long_paragraph, max_chunk_size=500)
+
+    print(f"Long paragraph test: {len(long_paragraph)} chars → {len(chunks)} chunks")
+    for i, chunk in enumerate(chunks):
+        print(f"  Chunk {i}: {len(chunk)} chars - {chunk[:50]}...")
+
+    # Should create multiple chunks
+    assert (
+        len(chunks) > 1
+    ), f"Expected multiple chunks for {len(long_paragraph)} char paragraph, got {len(chunks)}"
+
+    # Each chunk should be under the limit
+    for i, chunk in enumerate(chunks):
+        assert (
+            len(chunk) <= 600
+        ), f"Chunk {i} is {len(chunk)} chars, exceeds max_chunk_size"
+        assert len(chunk) > 50, f"Chunk {i} is only {len(chunk)} chars, too small"
+
+
+def test_group_paragraphs_with_long_paragraph():
+    """Test that group_paragraphs_semantically handles a single long paragraph."""
+    # Create content that will be one "paragraph" (no \n\n breaks)
+    long_single_para = "This is a very long sentence. " * 100  # ~3100 chars
+
+    chunks = semantic_search_utils._group_paragraphs_semantically(
+        [long_single_para], max_chunk_size=800
+    )
+
+    print(
+        f"Group paragraphs test: {len(long_single_para)} chars → {len(chunks)} chunks"
+    )
+    for i, chunk in enumerate(chunks):
+        print(f"  Chunk {i}: {len(chunk)} chars")
+
+    # Should create multiple chunks since it's > 800 chars
+    assert (
+        len(chunks) > 1
+    ), f"Expected multiple chunks for {len(long_single_para)} char content, got {len(chunks)}"
+
+
+def test_chunking_works_without_headers():
+    """Test that long content without headers still gets chunked properly."""
+    # Create long content without any markdown headers
+    long_content_no_headers = (
+        "This is a paragraph with substantial content. " * 100
+    )  # ~4500 chars
+
+    content_data = {"no-headers-page": long_content_no_headers}
+
+    docs, metas, ids = semantic_search_utils.process_chunkable_content(
+        "wiki", content_data, chunk_threshold=1000, max_chunk_size=800
+    )
+
+    # Should be chunked into multiple pieces since it's > 1000 chars
+    chunks_for_page = [
+        i for i, meta in enumerate(metas) if "no-headers-page" in meta["source"]
+    ]
+
+    # This test will fail if chunking doesn't work - we expect multiple chunks
+    assert (
+        len(chunks_for_page) > 1
+    ), f"Expected multiple chunks for {len(long_content_no_headers)} char content, got {len(chunks_for_page)}"
+
+    # Each chunk should be reasonable size
+    for i in chunks_for_page:
+        chunk_length = len(docs[i])
+        assert (
+            chunk_length <= 1000
+        ), f"Chunk {i} is {chunk_length} chars, exceeds max_chunk_size of 800"
+        assert chunk_length > 100, f"Chunk {i} is only {chunk_length} chars, too small"
+
+
+def test_split_long_paragraph_direct():
+    """Test split_long_paragraph function directly."""
+
+    # Test the exact pattern from the failing test
+    repeated_sentence = "This is a very long sentence. " * 50  # ~1500 chars
+    chunks = semantic_search_utils._split_long_paragraph(
+        repeated_sentence, max_chunk_size=400
+    )
+
+    print(f"Input: {len(repeated_sentence)} chars → {len(chunks)} chunks")
+    for i, chunk in enumerate(chunks):
+        print(f"  Chunk {i}: {len(chunk)} chars")
+
+    # Should create multiple chunks since 1500 chars > 400 char limit
+    assert (
+        len(chunks) > 1
+    ), f"Expected multiple chunks for {len(repeated_sentence)} chars, got {len(chunks)}"
+
+    # Each chunk should be under the limit
+    for i, chunk in enumerate(chunks):
+        assert (
+            len(chunk) <= 500
+        ), f"Chunk {i} is {len(chunk)} chars, exceeds reasonable limit"
+        assert len(chunk) > 20, f"Chunk {i} is {len(chunk)} chars, too small"


### PR DESCRIPTION
- added thorough docstrings for MCP tools and resources to hopefully guide clients towards using them more appropriately. Closes #181 
- added semantic search support. A shared `SemanticSearch` object is used to manage collections which are part of a sqlite chromadb database.  Closes #180 
    - Individual resources (documentaiton, codebase, tutorials) are organized and for longer documents chunked and then vectorized using a sentence transformer. Queries are compared to reference vectors returning the entries with the highest cosine similarity.
     - Lots of utility functions and tests for breaking up long markdown docs into logical chunks but this ending up working quite well.
     - added semantic_search to health endpoints
     - added general tool use and a server search function to client.py. Exposed the search function through the CLI to easily try out semantic search of a local or remote server. 