### PR TITLE
Issue 188: summarizing entity provenance and ontologies + using these to update pre- and post-consensus checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.6.1.dev2
+version = 0.6.2
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -17,7 +17,17 @@ with warnings.catch_warnings():
 
 from napistu import consensus as napistu_consensus
 from napistu import utils
-from napistu._cli import overwrite_option, setup_logging, verbosity_option
+from napistu._cli import (
+    genodexito_options,
+    nondogmatic_option,
+    organismal_species_argument,
+    overwrite_option,
+    sbml_dfs_input,
+    sbml_dfs_io,
+    sbml_dfs_output,
+    setup_logging,
+    verbosity_option,
+)
 from napistu.constants import ONTOLOGIES, RESOLVE_MATCHES_AGGREGATORS
 from napistu.context import filtering
 from napistu.ingestion import (
@@ -71,9 +81,7 @@ def ingestion():
 
 @ingestion.command(name="reactome")
 @click.argument("base_folder", type=str)
-@click.option(
-    "--overwrite", "-o", is_flag=True, default=False, help="Overwrite existing files?"
-)
+@overwrite_option
 @verbosity_option
 def ingest_reactome(base_folder: str, overwrite=True):
     logger.info("Start downloading Reactome to %s", base_folder)
@@ -82,9 +90,7 @@ def ingest_reactome(base_folder: str, overwrite=True):
 
 @ingestion.command(name="bigg")
 @click.argument("base_folder", type=str)
-@click.option(
-    "--overwrite", "-o", is_flag=True, default=False, help="Overwrite existing files?"
-)
+@overwrite_option
 @verbosity_option
 def ingest_bigg(base_folder: str, overwrite: bool):
     logger.info("Start downloading Bigg to %s", base_folder)
@@ -127,7 +133,7 @@ def ingest_gtex_rnaseq(target_uri: str, url: str):
 
 @ingestion.command(name="string_db")
 @click.argument("target_uri", type=str)
-@click.argument("organismal_species", type=str)
+@organismal_species_argument
 @verbosity_option
 def ingest_string_db(organismal_species: str, target_uri: str):
     string.download_string(target_uri, organismal_species)
@@ -135,7 +141,7 @@ def ingest_string_db(organismal_species: str, target_uri: str):
 
 @ingestion.command(name="string_aliases")
 @click.argument("target_uri", type=str)
-@click.argument("organismal_species", type=str)
+@organismal_species_argument
 @verbosity_option
 def ingest_string_aliases(organismal_species: str, target_uri: str):
     string.download_string_aliases(target_uri, organismal_species)
@@ -162,7 +168,7 @@ def ingest_reactome_fi(target_uri: str, url: str, overwrite: bool):
 
 @ingestion.command(name="intact")
 @click.argument("output_dir_path", type=str)
-@click.argument("organismal_species", type=str)
+@organismal_species_argument
 @overwrite_option
 @verbosity_option
 def ingest_intact(output_dir_path: str, organismal_species: str, overwrite: bool):
@@ -192,8 +198,8 @@ def integrate():
 
 @integrate.command(name="reactome")
 @click.argument("pw_index_uri", type=str)
-@click.argument("organismal_species", type=str)
-@click.argument("output_model_uri", type=str)
+@organismal_species_argument
+@sbml_dfs_output
 @overwrite_option
 @click.option(
     "--permissive",
@@ -236,8 +242,8 @@ def integrate_reactome(
 
 @integrate.command(name="bigg")
 @click.argument("pw_index_uri", type=str)
-@click.argument("organismal_species", type=str)
-@click.argument("output_model_uri", type=str)
+@organismal_species_argument
+@sbml_dfs_output
 @overwrite_option
 @verbosity_option
 def integrate_bigg(
@@ -256,7 +262,7 @@ def integrate_bigg(
 
 @integrate.command(name="trrust")
 @click.argument("trrust_csv_uri", type=str)
-@click.argument("output_model_uri", type=str)
+@sbml_dfs_output
 @overwrite_option
 @verbosity_option
 def integrate_trrust(
@@ -275,19 +281,8 @@ def integrate_trrust(
 
 @integrate.command(name="reactome_fi")
 @click.argument("reactome_fi_uri", type=str)
-@click.argument("output_model_uri", type=str)
-@click.option(
-    "--preferred-method",
-    type=str,
-    default="bioconductor",
-    help="Preferred Genodexito method for identifier mapping (default: bioconductor).",
-)
-@click.option(
-    "--allow-fallback",
-    is_flag=True,
-    default=False,
-    help="Allow fallback to other Genodexito methods if preferred method fails.",
-)
+@sbml_dfs_output
+@genodexito_options
 @overwrite_option
 @verbosity_option
 def integrate_reactome_fi(
@@ -315,8 +310,8 @@ def integrate_reactome_fi(
 @integrate.command(name="string_db")
 @click.argument("string_db_uri", type=str)
 @click.argument("string_aliases_uri", type=str)
-@click.argument("organismal_species", type=str)
-@click.argument("output_model_uri", type=str)
+@organismal_species_argument
+@sbml_dfs_output
 @overwrite_option
 @verbosity_option
 def integrate_string_db(
@@ -339,8 +334,8 @@ def integrate_string_db(
 
 @integrate.command(name="intact")
 @click.argument("intact_xml_dir", type=str)
-@click.argument("organismal_species", type=str)
-@click.argument("output_model_uri", type=str)
+@organismal_species_argument
+@sbml_dfs_output
 @overwrite_option
 @verbosity_option
 def integrate_intact(
@@ -382,20 +377,9 @@ def integrate_intact(
 
 
 @integrate.command(name="omnipath")
-@click.argument("organismal_species", type=str)
-@click.argument("output_model_uri", type=str)
-@click.option(
-    "--preferred-method",
-    type=str,
-    default="bioconductor",
-    help="Preferred Genodexito method for identifier mapping (default: bioconductor).",
-)
-@click.option(
-    "--allow-fallback",
-    is_flag=True,
-    default=True,
-    help="Allow fallback to other Genodexito methods if preferred method fails (default: True).",
-)
+@organismal_species_argument
+@sbml_dfs_output
+@genodexito_options
 @overwrite_option
 @verbosity_option
 def integrate_omnipath(
@@ -443,22 +427,26 @@ def consensus():
 
 @consensus.command(name="create")
 @click.argument("sbml_dfs_uris", type=str, nargs=-1)
-@click.argument("output_model_uri", type=str, nargs=1)
+@sbml_dfs_output
+@nondogmatic_option
 @click.option(
-    "--nondogmatic",
-    "-n",
+    "--ignore-mergeability",
     is_flag=True,
     default=False,
-    help="Run in non-dogmatic mode (trying to merge genes and proteins)?",
+    help="Ignore issues which will prevent merging across models",
 )
 @verbosity_option
 def create_consensus(
-    sbml_dfs_uris: Sequence[str], output_model_uri: str, nondogmatic: bool
+    sbml_dfs_uris: Sequence[str],
+    output_model_uri: str,
+    nondogmatic: bool,
+    ignore_mergeability: bool,
 ):
     """Create a consensus model from a list of SBML_dfs"""
 
     dogmatic = not nondogmatic
-    logger.debug(f"nondogmatic = {nondogmatic}; dogmatic = {dogmatic}")
+    check_mergeability = not ignore_mergeability
+    logger.debug(f"dogmatic = {dogmatic}; check_mergeability = {check_mergeability}")
     logger.info(
         f"Creating a consensus from {len(sbml_dfs_uris)} sbml_dfs where dogmatic = {dogmatic}"
     )
@@ -470,9 +458,29 @@ def create_consensus(
     sbml_dfs_dict, pw_index = napistu_consensus.prepare_consensus_model(sbml_dfs_list)
 
     consensus_model = napistu_consensus.construct_consensus_model(
-        sbml_dfs_dict, pw_index, dogmatic=dogmatic
+        sbml_dfs_dict,
+        pw_index,
+        dogmatic=dogmatic,
+        check_mergeability=check_mergeability,
     )
     consensus_model.to_pickle(output_model_uri)
+
+
+@consensus.command(name="check")
+@sbml_dfs_input
+@verbosity_option
+def check_consensus(sbml_dfs_uri: str):
+    """Check a consensus model for potential issues"""
+
+    logger.info(f"Checking consensus model: {sbml_dfs_uri}")
+
+    # Load the consensus model
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
+
+    # Run post-consensus checks
+    sbml_dfs.post_consensus_checks()
+
+    logger.info("Consensus model check completed")
 
 
 @click.group()
@@ -482,91 +490,86 @@ def refine():
 
 
 @refine.command(name="add_reactome_entity_sets")
-@click.argument("model_uri", type=str)
+@sbml_dfs_io
 @click.argument("entity_set_csv", type=str)
-@click.argument("output_model_uri", type=str)
 def add_reactome_entity_sets(
-    model_uri: str, entity_set_csv: str, output_model_uri: str
+    sbml_dfs_uri: str, entity_set_csv: str, output_model_uri: str
 ):
     """Add reactome entity sets to a consensus model
 
     The entity set csv is classically exported from the neo4j reactome
     database.
     """
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     annotated_sbml_dfs = pathwayannot.add_entity_sets(sbml_dfs, entity_set_csv)
     annotated_sbml_dfs.to_pickle(output_model_uri)
 
 
 @refine.command(name="add_reactome_identifiers")
-@click.argument("model_uri", type=str)
+@sbml_dfs_io
 @click.argument("crossref_csv", type=str)
-@click.argument("output_model_uri", type=str)
-def add_reactome_identifiers(model_uri: str, crossref_csv: str, output_model_uri: str):
+def add_reactome_identifiers(
+    sbml_dfs_uri: str, crossref_csv: str, output_model_uri: str
+):
     """Add reactome identifiers to a consensus model
 
     The crossref csv is classically exported from the neo4j reactome
     database.
     """
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     annotated_sbml_dfs = pathwayannot.add_reactome_identifiers(sbml_dfs, crossref_csv)
     annotated_sbml_dfs.to_pickle(output_model_uri)
 
 
 @refine.command(name="infer_uncompartmentalized_species_location")
-@click.argument("model_uri", type=str)
-@click.argument("output_model_uri", type=str)
-def infer_uncompartmentalized_species_location(model_uri: str, output_model_uri: str):
+@sbml_dfs_io
+def infer_uncompartmentalized_species_location(
+    sbml_dfs_uri: str, output_model_uri: str
+):
     """
     Infer Uncompartmentalized Species Location
 
     If the compartment of a subset of compartmentalized species was
     not specified, infer an appropriate compartment from other members of reactions they particpate in
     """
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
-    # modify in-place
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     sbml_dfs.infer_uncompartmentalized_species_location()
     sbml_dfs.to_pickle(output_model_uri)
 
 
 @refine.command(name="name_compartmentalized_species")
-@click.argument("model_uri", type=str)
-@click.argument("output_model_uri", type=str)
-def name_compartmentalized_species(model_uri: str, output_model_uri: str):
+@sbml_dfs_io
+def name_compartmentalized_species(sbml_dfs_uri: str, output_model_uri: str):
     """
     Name Compartmentalized Species
 
     Rename compartmentalized species if they have the same name as their species
     """
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
-    # modify in-place
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     sbml_dfs.name_compartmentalized_species()
     sbml_dfs.to_pickle(output_model_uri)
 
 
 @refine.command(name="merge_model_compartments")
-@click.argument("model_uri", type=str)
-@click.argument("output_model_uri", type=str)
-def merge_model_compartments(model_uri: str, output_model_uri: str):
+@sbml_dfs_io
+def merge_model_compartments(sbml_dfs_uri: str, output_model_uri: str):
     """Take a compartmentalized mechanistic model and merge all of the compartments."""
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     uncompartmentalized_sbml_dfs = uncompartmentalize_sbml_dfs(sbml_dfs)
     uncompartmentalized_sbml_dfs.to_pickle(output_model_uri)
 
 
 @refine.command(name="drop_cofactors")
-@click.argument("model_uri", type=str)
-@click.argument("output_model_uri", type=str)
-def drop_cofactors(model_uri: str, output_model_uri: str):
+@sbml_dfs_io
+def drop_cofactors(sbml_dfs_uri: str, output_model_uri: str):
     """Remove reaction species acting as cofactors"""
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     cofactor_filtered_sbml_dfs = pathwayannot.drop_cofactors(sbml_dfs)
     cofactor_filtered_sbml_dfs.to_pickle(output_model_uri)
 
 
 @refine.command(name="add_transportation_reactions")
-@click.argument("model_uri", type=str)
-@click.argument("output_model_uri", type=str)
+@sbml_dfs_io
 @click.option(
     "--exchange-compartment",
     "-e",
@@ -575,11 +578,11 @@ def drop_cofactors(model_uri: str, output_model_uri: str):
 )
 @verbosity_option
 def add_transportation_reaction(
-    model_uri, output_model_uri, exchange_compartment="cytosol"
+    sbml_dfs_uri, output_model_uri, exchange_compartment="cytosol"
 ):
     """Add transportation reactions to a consensus model"""
 
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     annotated_sbml_dfs = add_transportation_reactions(
         sbml_dfs, exchange_compartment=exchange_compartment
     )
@@ -587,41 +590,26 @@ def add_transportation_reaction(
 
 
 @refine.command(name="apply_manual_curations")
-@click.argument("model_uri", type=str)
+@sbml_dfs_io
 @click.argument("curation_dir", type=str)
-@click.argument("output_model_uri", type=str)
-def apply_manual_curations(model_uri: str, curation_dir: str, output_model_uri: str):
+def apply_manual_curations(sbml_dfs_uri: str, curation_dir: str, output_model_uri: str):
     """Apply manual curations to a consensus model
 
     The curation dir is a directory containing the manual curations
     Check napistu.modify.curation.curate_sbml_dfs for more information.
     """
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     annotated_sbml_dfs = curate_sbml_dfs(curation_dir=curation_dir, sbml_dfs=sbml_dfs)
     annotated_sbml_dfs.to_pickle(output_model_uri)
 
 
 @refine.command(name="expand_identifiers")
-@click.argument("sbml_dfs_uri", type=str)
-@click.argument("organismal_species", type=str)
-@click.argument("output_model_uri", type=str)
+@sbml_dfs_io
+@organismal_species_argument
 @click.option(
     "--ontologies", "-o", multiple=True, type=str, help="Ontologies to add or complete"
 )
-@click.option(
-    "--preferred_method",
-    "-p",
-    default="bioconductor",
-    type=str,
-    help="Preferred method to use for identifier expansion",
-)
-@click.option(
-    "--allow_fallback",
-    "-a",
-    default=True,
-    type=bool,
-    help="Allow fallback to other methods if preferred method fails",
-)
+@genodexito_options
 def expand_identifiers(
     sbml_dfs_uri: str,
     organismal_species: str,
@@ -660,22 +648,9 @@ def expand_identifiers(
 
 
 @integrate.command(name="dogmatic_scaffold")
-@click.argument("organismal_species", type=str)
-@click.argument("output_model_uri", type=str)
-@click.option(
-    "--preferred_method",
-    "-p",
-    default="bioconductor",
-    type=str,
-    help="Preferred method to use for identifier expansion",
-)
-@click.option(
-    "--allow_fallback",
-    "-a",
-    default=True,
-    type=bool,
-    help="Allow fallback to other methods if preferred method fails",
-)
+@organismal_species_argument
+@sbml_dfs_output
+@genodexito_options
 @verbosity_option
 def dogmatic_scaffold(
     organismal_species: str,
@@ -710,9 +685,8 @@ def dogmatic_scaffold(
 
 
 @refine.command(name="filter_gtex_tissue")
-@click.argument("sbml_dfs_uri", type=str)
+@sbml_dfs_io
 @click.argument("gtex_file_uri", type=str)
-@click.argument("output_model_uri", type=str)
 @click.argument("tissue", type=str)
 @verbosity_option
 def filter_gtex_tissue(
@@ -752,9 +726,8 @@ def filter_gtex_tissue(
 
 
 @refine.command(name="filter_hpa_compartments")
-@click.argument("sbml_dfs_uri", type=str)
+@sbml_dfs_io
 @click.argument("hpa_file_uri", type=str)
-@click.argument("output_model_uri", type=str)
 @verbosity_option
 def filter_hpa_gene_compartments(
     sbml_dfs_uri: str, hpa_file_uri: str, output_model_uri: str
@@ -800,7 +773,7 @@ def exporter():
 
 
 @exporter.command(name="export_igraph")
-@click.argument("sbml_dfs_uri", type=str)
+@sbml_dfs_input
 @click.argument("output_uri", type=str)
 @click.option(
     "--graph_attrs_spec_uri",
@@ -954,24 +927,16 @@ def export_precomputed_distances(
 
 
 @exporter.command(name="export_smbl_dfs_tables")
-@click.argument("model_uri", type=str)
+@sbml_dfs_input
 @click.argument("output_uri", type=str)
-@click.option(
-    "--overwrite", "-o", is_flag=True, default=False, help="Overwrite existing files?"
-)
 @click.option(
     "--model-prefix", "-m", type=str, default="", help="Model prefix for files?"
 )
-@click.option(
-    "--nondogmatic",
-    "-n",
-    is_flag=True,
-    default=False,
-    help="Run in non-dogmatic mode (trying to merge genes and proteins)?",
-)
+@nondogmatic_option
 @verbosity_option
+@overwrite_option
 def export_sbml_dfs_tables(
-    model_uri: str,
+    sbml_dfs_uri: str,
     output_uri: str,
     overwrite=False,
     model_prefix="",
@@ -983,7 +948,7 @@ def export_sbml_dfs_tables(
     logger.debug(f"nondogmatic = {nondogmatic}; dogmatic = {dogmatic}")
     logger.info(f"Exporting tables with dogmatic = {dogmatic}")
 
-    sbml_dfs = SBML_dfs.from_pickle(model_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     sbml_dfs.export_sbml_dfs(
         model_prefix, output_uri, overwrite=overwrite, dogmatic=dogmatic
     )
@@ -997,22 +962,21 @@ def importer():
 
 @importer.command(name="sbml_dfs")
 @click.argument("input_uri", type=str)
-@click.argument("output_uri", type=str)
+@sbml_dfs_io
 @verbosity_option
-def import_sbml_dfs_from_sbml_dfs_uri(input_uri, output_uri):
+def import_sbml_dfs_from_sbml_dfs_uri(sbml_dfs_uri, output_model_uri):
     """Import sbml_dfs from an uri, eg another GCS bucket"""
-    logger.info("Load sbml_dfs from %s", input_uri)
-    # Load using the class method for better type safety
-    sbml_dfs = SBML_dfs.from_pickle(input_uri)
-    logger.info("Save file to %s", output_uri)
-    sbml_dfs.to_pickle(output_uri)
+    logger.info("Load sbml_dfs from %s", sbml_dfs_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
+    logger.info("Save file to %s", output_model_uri)
+    sbml_dfs.to_pickle(output_model_uri)
 
 
 @importer.command(name="sbml")
 @click.argument("input_uri", type=str)
-@click.argument("output_uri", type=str)
+@sbml_dfs_output
 @verbosity_option
-def import_sbml_dfs_from_sbml(input_uri, output_uri):
+def import_sbml_dfs_from_sbml(input_uri, output_model_uri):
     """Import sbml_dfs from a sbml file"""
     logger.info("Load sbml from %s", input_uri)
     # We could also just copy the file, but I think validating
@@ -1020,8 +984,8 @@ def import_sbml_dfs_from_sbml(input_uri, output_uri):
     sbml_file = SBML(input_uri)
     logger.info("Convert file to sbml_dfs")
     sbml_dfs = SBML_dfs(sbml_file)
-    logger.info("Save file to %s", output_uri)
-    sbml_dfs.to_pickle(output_uri)
+    logger.info("Save file to %s", output_model_uri)
+    sbml_dfs.to_pickle(output_model_uri)
 
 
 @click.group()
@@ -1048,18 +1012,18 @@ def copy_uri(input_uri, output_uri, is_file=True):
 
 
 @helpers.command(name="validate_sbml_dfs")
-@click.argument("input_uri", type=str)
+@sbml_dfs_input
 @verbosity_option
-def validate_sbml_dfs(input_uri):
+def validate_sbml_dfs(sbml_dfs_uri):
     """Validate a sbml_dfs object"""
-    sbml_dfs = SBML_dfs.from_pickle(input_uri)
+    sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     sbml_dfs.validate()
 
-    logger.info(f"Successfully validated: {input_uri}")
+    logger.info(f"Successfully validated: {sbml_dfs_uri}")
 
 
 @helpers.command(name="validate_assets")
-@click.argument("sbml_dfs_uri", type=str)
+@sbml_dfs_input
 @click.option(
     "--napistu-graph-uri", "-g", type=str, help="URI to NapistuGraph pickle file"
 )
@@ -1131,11 +1095,11 @@ def stats():
 
 
 @stats.command(name="sbml_dfs_network")
-@click.argument("input_uri", type=str)
+@sbml_dfs_input
 @click.argument("output_uri", type=str)
-def calculate_sbml_dfs_stats(input_uri, output_uri):
+def calculate_sbml_dfs_stats(sbml_dfs_uri, output_uri):
     """Calculate statistics for a sbml_dfs object"""
-    model = SBML_dfs.from_pickle(input_uri)
+    model = SBML_dfs.from_pickle(sbml_dfs_uri)
     stats = model.get_network_summary()
     utils.save_json(output_uri, stats)
 

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -62,6 +62,7 @@ from napistu.network.precompute import precompute_distances
 from napistu.ontologies import dogma
 from napistu.ontologies.genodexito import Genodexito
 from napistu.sbml_dfs_core import SBML_dfs
+from napistu.sbml_dfs_utils import display_post_consensus_checks
 
 # Set up logging using shared configuration
 logger, console = setup_logging()
@@ -478,7 +479,8 @@ def check_consensus(sbml_dfs_uri: str):
     sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
 
     # Run post-consensus checks
-    sbml_dfs.post_consensus_checks()
+    results = sbml_dfs.post_consensus_checks()
+    display_post_consensus_checks(results)
 
     logger.info("Consensus model check completed")
 

--- a/src/napistu/_cli.py
+++ b/src/napistu/_cli.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 import napistu
+from napistu.constants import NAPISTU_CLI
 
 
 def setup_logging() -> tuple[logging.Logger, Console]:
@@ -109,3 +110,79 @@ def overwrite_option(f: Callable) -> Callable:
         default=False,
         help="Overwrite existing files.",
     )(f)
+
+
+def sbml_dfs_input(f: Callable) -> Callable:
+    """
+    Decorator that adds a standardized model_uri argument.
+
+    Common pattern for CLI commands that take a model file as input.
+    """
+    return click.argument(NAPISTU_CLI.SBML_DFS_URI, type=str)(f)
+
+
+def sbml_dfs_output(f: Callable) -> Callable:
+    """
+    Decorator that adds a standardized output_model_uri argument.
+
+    Common pattern for CLI commands that create a new model file as output.
+    """
+    return click.argument(NAPISTU_CLI.OUTPUT_MODEL_URI, type=str)(f)
+
+
+def sbml_dfs_io(f: Callable) -> Callable:
+    """
+    Decorator that adds both model_uri and output_model_uri arguments.
+
+    Common pattern for CLI commands that read a model and write a new one.
+    """
+    return click.argument(NAPISTU_CLI.SBML_DFS_URI, type=str)(
+        click.argument(NAPISTU_CLI.OUTPUT_MODEL_URI, type=str)(f)
+    )
+
+
+def organismal_species_argument(f: Callable) -> Callable:
+    """
+    Decorator that adds a standardized organismal_species argument.
+
+    Common pattern for CLI commands that work with specific species.
+    """
+    return click.argument("organismal_species", type=str)(f)
+
+
+def nondogmatic_option(f: Callable) -> Callable:
+    """
+    Decorator that adds a standardized --nondogmatic option.
+
+    Common pattern for CLI commands that can run in non-dogmatic mode.
+    """
+    return click.option(
+        "--nondogmatic",
+        "-n",
+        is_flag=True,
+        default=False,
+        help="Run in non-dogmatic mode (trying to merge genes and proteins)?",
+    )(f)
+
+
+def genodexito_options(f: Callable) -> Callable:
+    """
+    Decorator that adds standardized Genodexito method options.
+
+    Common pattern for CLI commands that use Genodexito for identifier mapping.
+    """
+    return click.option(
+        "--preferred-method",
+        "-p",
+        default="bioconductor",
+        type=str,
+        help="Preferred method to use for identifier expansion",
+    )(
+        click.option(
+            "--allow-fallback",
+            "-a",
+            default=True,
+            type=bool,
+            help="Allow fallback to other methods if preferred method fails",
+        )(f)
+    )

--- a/src/napistu/constants.py
+++ b/src/napistu/constants.py
@@ -22,7 +22,6 @@ PACKAGE_DEFS = SimpleNamespace(
 
 FILE_EXT_ZIP = "zip"
 FILE_EXT_GZ = "gz"
-
 # SBML_dfs
 
 SBML_DFS = SimpleNamespace(
@@ -168,6 +167,13 @@ NAPISTU_STANDARD_OUTPUTS = SimpleNamespace(
     COMPARTMENTS="compartments.json",
     COMPARTMENTALIZED_SPECIES="compartmentalized_species.json",
 )
+
+CONSENSUS_CHECKS = SimpleNamespace(
+    SOURCE_COOCCURRENCE="source_cooccurrence",
+    ONTOLOGY_X_SOURCE_COOCCURRENCE="ontology_x_source_cooccurrence",
+)
+
+CONSENSUS_CHECKS_LIST = list(CONSENSUS_CHECKS.__dict__.values())
 
 # SBML
 # Biological qualifiers

--- a/src/napistu/constants.py
+++ b/src/napistu/constants.py
@@ -406,6 +406,7 @@ EXPECTED_PW_INDEX_COLUMNS = {
 ONTOLOGIES = SimpleNamespace(
     CHEBI="chebi",
     CORUM="corum",
+    EC_CODE="ec-code",
     ENSEMBL_GENE="ensembl_gene",
     ENSEMBL_GENE_VERSION="ensembl_gene_version",
     ENSEMBL_TRANSCRIPT="ensembl_transcript",

--- a/src/napistu/constants.py
+++ b/src/napistu/constants.py
@@ -20,6 +20,12 @@ PACKAGE_DEFS = SimpleNamespace(
     CACHE_DIR="napistu_data",
 )
 
+NAPISTU_CLI = SimpleNamespace(
+    SBML_DFS_URI="sbml_dfs_uri",
+    OUTPUT_MODEL_URI="output_model_uri",
+    OVERWRITE="overwrite",
+)
+
 FILE_EXT_ZIP = "zip"
 FILE_EXT_GZ = "gz"
 # SBML_dfs

--- a/src/napistu/ingestion/constants.py
+++ b/src/napistu/ingestion/constants.py
@@ -26,6 +26,8 @@ DATA_SOURCES = SimpleNamespace(
     TRRUST="TRRUST",
 )
 
+DATA_SOURCES_LIST = list(DATA_SOURCES.__dict__.values())
+
 DATA_SOURCE_DESCRIPTIONS = {
     DATA_SOURCES.BIGG: "UCSD genome-scale metabolic models",
     DATA_SOURCES.DOGMA: "Napistu gene, transcript, and protein annotations",

--- a/src/napistu/ingestion/reactome.py
+++ b/src/napistu/ingestion/reactome.py
@@ -132,7 +132,7 @@ def construct_reactome_consensus(
     )
 
     consensus_model = construct_consensus_model_fkt(
-        sbml_dfs_dict, pw_index, model_source
+        sbml_dfs_dict, pw_index, model_source, check_mergeability=False
     )
 
     return consensus_model

--- a/src/napistu/network/net_create.py
+++ b/src/napistu/network/net_create.py
@@ -318,8 +318,8 @@ def process_napistu_graph(
     napistu_graph.add_edge_data(sbml_dfs)
     napistu_graph.transform_edges(custom_transformations=custom_transformations)
 
-    if "reactions" in reaction_graph_attrs.keys():
-        reaction_attrs = reaction_graph_attrs["reactions"]
+    if SBML_DFS.REACTIONS in reaction_graph_attrs.keys():
+        reaction_attrs = reaction_graph_attrs[SBML_DFS.REACTIONS]
     else:
         reaction_attrs = dict()
 

--- a/src/napistu/sbml_dfs_core.py
+++ b/src/napistu/sbml_dfs_core.py
@@ -900,6 +900,7 @@ class SBML_dfs:
         allow_col_multindex: bool = False,
         characteristic_only: bool = False,
         dogmatic: bool = True,
+        include_missing: bool = False,
     ) -> pd.DataFrame:
         """
         Get ontology occurrence summary for a specific entity type.
@@ -921,6 +922,8 @@ class SBML_dfs:
                 false - returns all identifiers
         dogmatic: bool, optional
             Whether to use a strict or loose definition of characteristic identifiers. Only applicable if `characteristic_only` is True and `entity_type` is SBML_DFS.SPECIES.
+        include_missing: bool, optional
+            Whether to include missing entities in the result using add_missing_ids_column, by default False
 
         Returns
         -------
@@ -937,9 +940,16 @@ class SBML_dfs:
             entity_type, characteristic_only, dogmatic
         )
 
-        return sbml_dfs_utils._summarize_ontology_occurrence(
+        result = sbml_dfs_utils._summarize_ontology_occurrence(
             identifiers_table, stratify_by_bqb, allow_col_multindex
         )
+
+        if include_missing:
+            # Get the reference table (all entities of this type)
+            reference_table = self.get_table(entity_type)
+            result = sbml_dfs_utils.add_missing_ids_column(result, reference_table)
+
+        return result
 
     def get_source_cooccurrence(
         self, entity_type: str, priority_pathways: list[str] = DATA_SOURCES_LIST
@@ -981,7 +991,10 @@ class SBML_dfs:
         return sbml_dfs_utils._summarize_source_cooccurrence(filtered_sources)
 
     def get_source_occurrence(
-        self, entity_type: str, priority_pathways: list[str] = DATA_SOURCES_LIST
+        self,
+        entity_type: str,
+        priority_pathways: list[str] = DATA_SOURCES_LIST,
+        include_missing: bool = False,
     ) -> pd.DataFrame:
         """
         Get pathway occurrence summary for a specific entity type.
@@ -995,6 +1008,8 @@ class SBML_dfs:
             The type of entity to analyze (e.g., 'species', 'reactions', 'compartments')
         priority_pathways : list[str], optional
             List of pathway IDs to prioritize in the analysis. Defaults to DATA_SOURCES_LIST.
+        include_missing: bool, optional
+            Whether to include missing entities in the result using add_missing_ids_column, by default False
 
         Returns
         -------
@@ -1017,7 +1032,14 @@ class SBML_dfs:
             source_table, priority_pathways
         )
 
-        return sbml_dfs_utils._summarize_source_occurrence(filtered_sources)
+        result = sbml_dfs_utils._summarize_source_occurrence(filtered_sources)
+
+        if include_missing:
+            # Get the reference table (all entities of this type)
+            reference_table = self.get_table(entity_type)
+            result = sbml_dfs_utils.add_missing_ids_column(result, reference_table)
+
+        return result
 
     def get_sources(self, entity_type: str) -> pd.DataFrame | None:
         """

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -49,7 +49,9 @@ logger = logging.getLogger(__name__)
 
 
 def add_missing_ids_column(
-    contingency_table: pd.DataFrame, reference_table: pd.DataFrame
+    contingency_table: pd.DataFrame,
+    reference_table: pd.DataFrame,
+    other_column_name: str = "other",
 ) -> pd.DataFrame:
     """
     Add an 'other' column to a contingency table for IDs that exist in a reference table
@@ -110,9 +112,9 @@ def add_missing_ids_column(
 
     # Create 'other' column name based on column structure
     if isinstance(result_table.columns, pd.MultiIndex):
-        other_column = tuple(["other"] * result_table.columns.nlevels)
+        other_column = tuple([other_column_name] * result_table.columns.nlevels)
     else:
-        other_column = "other"
+        other_column = other_column_name
 
     # Add the 'other' column
     result_table[other_column] = 0

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -250,7 +250,7 @@ def construct_formula_string(
 
     """
 
-    reaction_species_df["label"] = [
+    reaction_species_df[SCHEMA_DEFS.LABEL] = [
         _add_stoi_to_species_name(x, y)
         for x, y in zip(
             reaction_species_df[SBML_DFS.STOICHIOMETRY], reaction_species_df[name_var]
@@ -261,7 +261,7 @@ def construct_formula_string(
         reaction_species_df[SBML_DFS.SBO_TERM]
         == MINI_SBO_FROM_NAME[SBOTERM_NAMES.INTERACTOR]
     ):
-        labels = reaction_species_df["label"].tolist()
+        labels = reaction_species_df[SCHEMA_DEFS.LABEL].tolist()
         if len(labels) != 2:
             logger.warning(
                 f"Reaction {reaction_species_df[SBML_DFS.R_ID].iloc[0]} has {len(labels)} species, expected 2"
@@ -332,7 +332,6 @@ def display_post_consensus_checks(checks_results: dict) -> None:
         for check_type, cooccurrences in entity_results.items():
             display(f"Entity type: {entity_type}, Check type: {check_type}")
             display(utils.style_df(cooccurrences))
-            display("\n")
 
 
 def find_underspecified_reactions(

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -7,6 +7,14 @@ from typing import Any, Iterable, Optional
 import numpy as np
 import pandas as pd
 
+try:
+    from IPython.display import display
+except ImportError:
+    # Fallback for non-Jupyter environments
+    def display(obj):
+        print(obj)
+
+
 from napistu import identifiers, utils
 from napistu.constants import (
     BQB,
@@ -300,6 +308,31 @@ def construct_formula_string(
         modifiers = f" ---- modifiers: {modifiers}]"
 
     return f"{substrates}{arrow_type}{products}{modifiers}"
+
+
+def display_post_consensus_checks(checks_results: dict) -> None:
+    """
+    Display the results of post_consensus_checks in a formatted way.
+
+    This function takes the results from the post_consensus_checks method and displays
+    them using the same formatting as shown in the sandbox notebook.
+
+    Parameters
+    ----------
+    checks_results : dict
+        Dictionary returned by the post_consensus_checks method, containing nested
+        dictionaries with entity types and check types as keys, and DataFrames as values.
+
+    Returns
+    -------
+    None
+        This function displays results but doesn't return anything.
+    """
+    for entity_type, entity_results in checks_results.items():
+        for check_type, cooccurrences in entity_results.items():
+            display(f"Entity type: {entity_type}, Check type: {check_type}")
+            display(utils.style_df(cooccurrences))
+            display("\n")
 
 
 def find_underspecified_reactions(

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -63,11 +63,15 @@ def add_missing_ids_column(
         The contingency table with binary values (subset of IDs)
     reference_table : pd.DataFrame
         The reference table containing all possible IDs
+    other_column_name : str, optional
+        Name for the 'other' column, by default "other"
 
     Returns:
     --------
     pd.DataFrame
-        Updated contingency table with 'other' column(s) added
+        Updated contingency table with 'other' column(s) added if there are missing IDs.
+        If no IDs are missing, returns a copy of the original contingency table without
+        adding an 'other' column.
 
     Raises:
     -------
@@ -109,6 +113,10 @@ def add_missing_ids_column(
 
     # Create a copy of the contingency table to avoid modifying the original
     result_table = contingency_table.copy()
+
+    # If no missing IDs, return the original table without adding 'other' column
+    if len(missing_ids) == 0:
+        return result_table
 
     # Create 'other' column name based on column structure
     if isinstance(result_table.columns, pd.MultiIndex):
@@ -1641,11 +1649,11 @@ def _summarize_ontology_cooccurrence(
     )
 
     # Convert to binary (1 if compound is in pathway, 0 otherwise)
-    entity_ontology__matrix = (entity_ontology_occurrences > 0).astype(int)
+    entity_ontology_matrix = (entity_ontology_occurrences > 0).astype(int)
 
     # Calculate co-occurrence matrix: pathways × pathways
     # This gives us the number of compounds shared between each pair of pathways
-    cooccurrences = entity_ontology__matrix.T @ entity_ontology__matrix
+    cooccurrences = entity_ontology_matrix.T @ entity_ontology_matrix
 
     return cooccurrences
 

--- a/src/tests/test_sbml_dfs_core.py
+++ b/src/tests/test_sbml_dfs_core.py
@@ -1040,3 +1040,54 @@ def test_get_ontology_occurrence_characteristic_only(sbml_dfs_characteristic_tes
     assert isinstance(occurrence_df_all, pd.DataFrame)
     assert occurrence_df_all.shape[0] == 1
     assert occurrence_df_all.shape[1] == 5
+
+
+def test_get_ontology_x_source_cooccurrence(sbml_dfs_metabolism):
+    """
+    Test get_ontology_x_source_cooccurrence method with metabolism data.
+
+    This test verifies that the method correctly creates a co-occurrence matrix
+    between ontologies and sources using the metabolism fixture.
+    """
+    # Test basic functionality
+    cooccurrence_matrix = sbml_dfs_metabolism.get_ontology_x_source_cooccurrence(
+        SBML_DFS.SPECIES
+    )
+
+    # Verify the result is a DataFrame with correct data types
+    assert isinstance(cooccurrence_matrix, pd.DataFrame)
+    assert (cooccurrence_matrix >= 0).all().all(), "All values should be non-negative"
+    assert cooccurrence_matrix.dtypes.apply(
+        lambda x: pd.api.types.is_integer_dtype(x)
+    ).all(), "All values should be integers"
+
+    # Test with characteristic_only=True
+    char_cooccurrence = sbml_dfs_metabolism.get_ontology_x_source_cooccurrence(
+        SBML_DFS.SPECIES, characteristic_only=True
+    )
+    assert isinstance(char_cooccurrence, pd.DataFrame)
+
+    # Test with custom priority pathways (use actual pathway names from the data)
+    custom_pathways = cooccurrence_matrix.columns[
+        :2
+    ].tolist()  # Use first 2 pathways from the data
+    custom_cooccurrence = sbml_dfs_metabolism.get_ontology_x_source_cooccurrence(
+        SBML_DFS.SPECIES, priority_pathways=custom_pathways
+    )
+    assert isinstance(custom_cooccurrence, pd.DataFrame)
+
+    # Test with reactions
+    reaction_cooccurrence = sbml_dfs_metabolism.get_ontology_x_source_cooccurrence(
+        SBML_DFS.REACTIONS
+    )
+    assert isinstance(reaction_cooccurrence, pd.DataFrame)
+
+    # Test exact dimensions
+    assert cooccurrence_matrix.shape == (
+        7,
+        4,
+    ), f"Expected species co-occurrence shape (7, 4), got {cooccurrence_matrix.shape}"
+    assert reaction_cooccurrence.shape == (
+        4,
+        4,
+    ), f"Expected reaction co-occurrence shape (4, 4), got {reaction_cooccurrence.shape}"


### PR DESCRIPTION
- Pulling out source and identifier information as a contingency table. Closes #188 . 
    - `get_ontology_occurrence` creates a table with 1 row per entity and 1 column for each ontology (optionally stratifying by BQB codes.
    - `get_ontology_cooccurrence` creates a cooccurrence matrix from `get_ontology_occurrence`:  t(x) %*% x 
    - `get_ontology_x_source_cooccurrence` multiple the ontology and source matrices to indicate the number of entities arising from each source that get tagged with an ontology.
    - `get_source_occurrence` creates a table with 1 row per entity and 1 column for each source (optionally filtering to priority pathways)
    - `get_source_cooccurrence` creates a source x source contingency table capturing the number of times pairs of pathway models contain the same entity.
    - `post_consensus_checks` uses the above functions to generate some informative summaries. These can be visualized with 

- `sbml_dfs_utils`
    - `add_missing_ids_column` ensures that results from occurrence tables above contain all entities (e.g., a table of species sources will have the same index as the species table itself). This is needed for `get_ontology_x_source_cooccurrence` but will also be helpful for easily joining source or ontology summaries onto an sbml_dfs table.

- updated pre- and post-consensus checks for diagnosing pathological consensuses.
    - rather than individual pre-consensus check functions which needed to be individually called. I rewrote the functions and rolled them into a `_check_sbml_dfs_mergeability` function which is called by default as part of the `check_sbml_dfs` function run at the beginning of `consensus.create_consensus`  
    - post-consensus checks became an SBML_dfs method which leans heavily on the new source and identifier tabulation approach.


- CLI updates:
    - pulled out lots of arguments as click functions in _cli.py. this helps to reduce visual clutter.  Added `ignore_mergeability` arg to consensus CLI and a `consensus_check` function to perform pre- and post-consensus checks.

- `reaction_formulas` method updated to address future warning. Closes #196 