### PR TITLE
Issue 209 - improved visualization of tables on the CLI

### DIFF
--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -18,6 +18,7 @@ with warnings.catch_warnings():
 from napistu import consensus as napistu_consensus
 from napistu import utils
 from napistu._cli import (
+    click_str_to_list,
     genodexito_options,
     nondogmatic_option,
     organismal_species_argument,
@@ -915,7 +916,7 @@ def export_precomputed_distances(
                 raise ValueError("Unknown format: %s" % format)
 
     # convert weight vars from a str to list
-    weight_vars_list = utils.click_str_to_list(weight_vars)
+    weight_vars_list = click_str_to_list(weight_vars)
 
     precomputed_distances = precompute_distances(
         napistu_graph,

--- a/src/napistu/_cli.py
+++ b/src/napistu/_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Callable
 
 import click
@@ -50,6 +51,23 @@ def setup_logging() -> tuple[logging.Logger, Console]:
     logger.addHandler(handler)
 
     return logger, console
+
+
+def click_str_to_list(string: str) -> list[str]:
+    """Convert a string-based representation of a list inputted from the CLI into a list of strings."""
+
+    var_extract_regex = re.compile("\\'?([a-zA-Z_]+)\\'?")
+
+    re_search = re.search("^\\[(.*)\\]$", string)
+    if re_search:
+        return var_extract_regex.findall(re_search.group(0))
+    else:
+        raise ValueError(
+            f"The provided string, {string}, could not be reformatted as a list. An example string which can be formatted is: \"['weight', 'upstream_weight']\""
+        )
+
+
+# click formatting options
 
 
 def verbosity_option(f: Callable) -> Callable:

--- a/src/napistu/identifiers.py
+++ b/src/napistu/identifiers.py
@@ -95,7 +95,7 @@ class Identifiers:
     def print(self):
         """Print a table of identifiers"""
 
-        utils.style_df(pd.DataFrame(self.ids), hide_index=True)
+        utils.show(pd.DataFrame(self.ids), hide_index=True)
 
     def filter(self, ontologies, summarize=True):
         """Returns a bool of whether 1+ of the ontologies was represented"""

--- a/src/napistu/ingestion/sbml.py
+++ b/src/napistu/ingestion/sbml.py
@@ -175,7 +175,7 @@ class SBML:
                 ]
                 error_log = error_log[headers]
 
-            utils.style_df(error_log, headers=headers)
+            utils.show(error_log, headers=headers)
 
             return None
 
@@ -206,7 +206,7 @@ class SBML:
 
         model_summaries_dat = pd.DataFrame(model_summaries, index=[0]).T
 
-        return utils.style_df(model_summaries_dat)  # type: ignore
+        return utils.show(model_summaries_dat)  # type: ignore
 
     def _define_compartments(
         self, compartment_aliases_dict: dict | None = None

--- a/src/napistu/modify/gaps.py
+++ b/src/napistu/modify/gaps.py
@@ -679,7 +679,7 @@ def _log_protein_transport_gapfilling(
         DataFrame summarizing transport status for each species
     """
     print(
-        utils.style_df(
+        utils.show(
             species_transport_status_df.value_counts("type").to_frame().reset_index(),
             headers=["Transport Category", "# of Entries"],
             hide_index=True,

--- a/src/napistu/modify/pathwayannot.py
+++ b/src/napistu/modify/pathwayannot.py
@@ -233,7 +233,7 @@ def drop_cofactors(sbml_dfs: sbml_dfs_core.SBML_dfs) -> sbml_dfs_core.SBML_dfs:
     )
 
     styled_df = all_cofactors.value_counts().to_frame()
-    logger.info(utils.style_df(styled_df))
+    utils.show(styled_df)
 
     sbml_dfs_working = copy.copy(sbml_dfs)
     sbml_dfs_working.reaction_species = sbml_dfs_working.reaction_species[
@@ -1293,7 +1293,7 @@ def _merge_reactome_crossref_ids(
             f"{failed_joins.shape[0]} network uniprot IDs were not matched to the Reactome Crossref IDs"
         )
 
-        utils.style_df(logged_join_fails, headers="keys", hide_index=True)
+        utils.show(logged_join_fails, headers="keys", hide_index=True)
 
     # entries without reactome IDs join just by uniprot
     # outer join back to uni_rct_with_crossrefs so we won't consider a uniprot-only match
@@ -1341,10 +1341,7 @@ def _merge_reactome_crossref_ids(
             f"A gene ID could not be found for {species_with_protein_and_no_gene.shape[0]} "
             "(species, bqb) pairs with a protein ID"
         )
-
-        logger.warning(
-            utils.style_df(logged_join_fails, headers="keys", hide_index=True)
-        )
+        utils.show(logged_join_fails, headers="keys", hide_index=True)
 
     return merged_crossrefs
 

--- a/src/napistu/network/net_create.py
+++ b/src/napistu/network/net_create.py
@@ -228,7 +228,7 @@ def create_napistu_graph(
                 random.sample(duplicated_edges, min(5, len(duplicated_edges)))
             )
 
-            logger.warning(utils.style_df(example_duplicates, headers="keys"))
+            utils.show(example_duplicates, headers="keys")
 
     # convert nodes and edgelist into an igraph network
     logger.info("Formatting cpr_graph output")

--- a/src/napistu/network/net_create_utils.py
+++ b/src/napistu/network/net_create_utils.py
@@ -135,7 +135,7 @@ def wire_reaction_species(
         invalid_counts = invalid_sbo_terms.value_counts(SBML_DFS.SBO_TERM).to_frame("N")
         if not isinstance(invalid_counts, pd.DataFrame):
             raise TypeError("invalid_counts must be a pandas DataFrame")
-        logger.warning(utils.style_df(invalid_counts, headers="keys"))  # type: ignore
+        utils.show(invalid_counts, headers="keys")  # type: ignore
         raise ValueError("Some reaction species have unusable SBO terms")
 
     # load and validate the schema of wiring_approach

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -397,8 +397,8 @@ def display_post_consensus_checks(checks_results: dict) -> None:
     """
     for entity_type, entity_results in checks_results.items():
         for check_type, cooccurrences in entity_results.items():
-            display(f"Entity type: {entity_type}, Check type: {check_type}")
-            display(utils.style_df(cooccurrences))
+            utils.show(f"Entity type: {entity_type}, Check type: {check_type}")
+            utils.show(cooccurrences)
 
 
 def find_underspecified_reactions(

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -1,0 +1,11 @@
+"""Tests for CLI utilities."""
+
+import pytest
+
+from napistu import _cli
+
+
+def test_click_str_to_list():
+    assert _cli.click_str_to_list("['foo', bar]") == ["foo", "bar"]
+    with pytest.raises(ValueError):
+        _cli.click_str_to_list("foo")

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -485,12 +485,6 @@ def test_score_nameness():
     assert utils.score_nameness("pyruvate kinase") == 15
 
 
-def test_click_str_to_list():
-    assert utils.click_str_to_list("['foo', bar]") == ["foo", "bar"]
-    with pytest.raises(ValueError):
-        utils.click_str_to_list("foo")
-
-
 def test_drop_extra_cols():
     """Test the _drop_extra_cols function for removing and reordering columns."""
     # Setup test DataFrames
@@ -754,3 +748,20 @@ def test_safe_join_set():
 
     # Test empty inputs
     assert utils.safe_join_set([]) is None
+
+
+def test_show():
+    """Test that utils.show() runs without errors."""
+    import pandas as pd
+
+    # Create a simple test DataFrame
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    # Test that show() runs without raising an exception
+    # We can't easily test the output since it depends on the environment
+    utils.show(df, method="string")
+    utils.show(df, method="string", headers=["col1", "col2"])
+    utils.show(df, method="string", hide_index=True)
+
+    # Test with auto method (should work in test environment)
+    utils.show(df, method="auto")


### PR DESCRIPTION
- added `utils.show` to switch between string-based outputs (ideal for terminal) and pandas styling (ideal for ipynb). This makes nice printouts for post consensus checking but I rolled it out more broadly to replace all the other calls of utils.style_df. Closes #209 