### PR TITLE
Issue 223 - precomputed distances speedups and logging bugfix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,10 @@ jobs:
     - name: Configure Docker for Artifact Registry
       run: gcloud auth configure-docker ${{ env.REGISTRY }}
 
-    - name: Build and push base image
+    - name: Build and push base image (single platform)
+      # Only run for single platform builds (no comma in platform string)
+      # Example: 'linux/amd64' or when input is empty (defaults to 'linux/amd64')
+      if: contains(inputs.docker_platforms || 'linux/amd64', ',') == false
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -169,6 +172,24 @@ jobs:
         tags: |
           ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/napistu-base:latest
           ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/napistu-base:${{ needs.check-release-needed.outputs.version }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    
+    - name: Build and push base image (multi-platform)
+      # Only run for multi-platform builds (comma detected in platform string)
+      # Example: 'linux/amd64,linux/arm64' - adds -multiplatform tags
+      if: contains(inputs.docker_platforms || 'linux/amd64', ',')
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.base
+        platforms: ${{ inputs.docker_platforms || 'linux/amd64' }}
+        push: true
+        tags: |
+          ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/napistu-base:latest
+          ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/napistu-base:${{ needs.check-release-needed.outputs.version }}
+          ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/napistu-base:latest-multiplatform
+          ${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/napistu-base:${{ needs.check-release-needed.outputs.version }}-multiplatform
         cache-from: type=gha
         cache-to: type=gha,mode=max
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.6.3
+version = 0.6.4
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -883,7 +883,7 @@ def export_igraph(
     "--partition_size",
     "-p",
     type=int,
-    default=5000,
+    default=1000,
     help="The number of species to process together when computing distances",
 )
 @click.option(

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -1029,16 +1029,16 @@ def validate_sbml_dfs(sbml_dfs_uri):
 @helpers.command(name="validate_assets")
 @sbml_dfs_input
 @click.option(
-    "--napistu-graph-uri", "-g", type=str, help="URI to NapistuGraph pickle file"
+    "--napistu_graph_uri", "-g", type=str, help="URI to NapistuGraph pickle file"
 )
 @click.option(
-    "--precomputed-distances-uri",
+    "--precomputed_distances_uri",
     "-d",
     type=str,
     help="URI to precomputed distances parquet file",
 )
 @click.option(
-    "--identifiers-df-uri", "-i", type=str, help="URI to identifiers DataFrame TSV file"
+    "--identifiers_df_uri", "-i", type=str, help="URI to identifiers DataFrame TSV file"
 )
 @verbosity_option
 def validate_assets(

--- a/src/napistu/network/ng_utils.py
+++ b/src/napistu/network/ng_utils.py
@@ -1025,7 +1025,7 @@ def _validate_assets_graph_dist(
     edges = pd.DataFrame(
         [{**{"index": e.index}, **e.attributes()} for e in napistu_graph.es]
     )
-    direct_interactions = precomputed_distances.query("path_length == 1")
+    direct_interactions = precomputed_distances.query(f"{DISTANCES.PATH_LENGTH} == 1")
     edges_with_distances = direct_interactions.merge(
         edges[
             [
@@ -1039,13 +1039,14 @@ def _validate_assets_graph_dist(
         right_on=[NAPISTU_GRAPH_EDGES.FROM, NAPISTU_GRAPH_EDGES.TO],
     )
     inconsistent_weights = edges_with_distances.query(
-        f"{DISTANCES.PATH_WEIGHT} != {NAPISTU_GRAPH_EDGES.WEIGHT}"
+        # shortest weighted paths cannot be greater than the path weight for a direct connection
+        f"{DISTANCES.PATH_WEIGHT} <= {NAPISTU_GRAPH_EDGES.WEIGHT}"
     )
     if inconsistent_weights.shape[0] > 0:
         logger.warning(
-            f"{inconsistent_weights.shape[0]} edges' weights are inconsistent between",
-            "edges in the napistu_graph and length 1 paths in precomputed_distances."
-            f"This is {inconsistent_weights.shape[0] / edges_with_distances.shape[0]:.2%} of all edges.",
+            f"{inconsistent_weights.shape[0]} edges' weights are inconsistent between "
+            f"edges in the napistu_graph and length 1 paths in precomputed_distances. "
+            f"This is {inconsistent_weights.shape[0] / edges_with_distances.shape[0]:.2%} of all edges."
         )
     return None
 

--- a/src/napistu/network/ng_utils.py
+++ b/src/napistu/network/ng_utils.py
@@ -1040,7 +1040,7 @@ def _validate_assets_graph_dist(
     )
     inconsistent_weights = edges_with_distances.query(
         # shortest weighted paths cannot be greater than the path weight for a direct connection
-        f"{DISTANCES.PATH_WEIGHT} <= {NAPISTU_GRAPH_EDGES.WEIGHT}"
+        f"{DISTANCES.PATH_WEIGHT} > {NAPISTU_GRAPH_EDGES.WEIGHT}"
     )
     if inconsistent_weights.shape[0] > 0:
         logger.warning(

--- a/src/napistu/network/precompute.py
+++ b/src/napistu/network/precompute.py
@@ -118,7 +118,9 @@ def precompute_distances(
     ).reset_index(drop=True)
 
     # validate the precomputed distances
+    logger.info("Validating precomputed distances")
     _validate_precomputed_distances(filtered_precomputed_distances)
+
     return filtered_precomputed_distances
 
 
@@ -369,7 +371,7 @@ def _filter_precomputed_distances(
 
     # Combine masks: keep rows where at least one weight variable is below cutoff
     # (i.e., keep rows that are True in at least one mask)
-    combined_mask = pd.concat(masks, axis=1).any(axis=1)
+    combined_mask = np.logical_or.reduce([mask.values for mask in masks])
 
     # Filter to rows which have at least one weight variable below the cutoff
     low_weight_precomputed_distances = precomputed_distances[combined_mask].copy()

--- a/src/napistu/network/precompute.py
+++ b/src/napistu/network/precompute.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -24,9 +25,9 @@ logger = logging.getLogger(__name__)
 
 def precompute_distances(
     napistu_graph: NapistuGraph,
-    max_steps: int = -1,
+    max_steps: Optional[int] = None,
     max_score_q: float = float(1),
-    partition_size: int = int(5000),
+    partition_size: int = int(1000),
     weight_vars: list[str] = [
         NAPISTU_GRAPH_EDGES.WEIGHT,
         NAPISTU_GRAPH_EDGES.UPSTREAM_WEIGHT,
@@ -62,14 +63,11 @@ def precompute_distances(
 
     """
 
-    if max_steps == -1:
-        max_steps = int(100000)
-
     # validate inputs
-    if max_steps < 1:
+    if max_steps is not None and max_steps < 1:
         raise ValueError(f"max_steps must >= 1, but was {max_steps}")
 
-    if (max_score_q < 0) or (max_score_q > 1):
+    if (max_score_q <= 0) or (max_score_q > 1):
         raise ValueError(f"max_score_q must be between 0 and 1 but was {max_score_q}")
 
     # make sure weight vars exist
@@ -92,7 +90,7 @@ def precompute_distances(
     vs_to_partition["partition"] = vs_to_partition.index % n_paritions
     vs_to_partition = vs_to_partition.set_index("partition").sort_index()
 
-    # interate through all partitions of "from" nodes and find their shortest and lowest weighted paths
+    # iterate through all partitions of "from" nodes and find their shortest and lowest weighted paths
     unique_partitions = vs_to_partition.index.unique().tolist()
 
     logger.info(f"Calculating distances for {len(unique_partitions)} partitions")
@@ -103,23 +101,24 @@ def precompute_distances(
                 vs_to_partition,
                 vs_to_partition.loc[uq_part],
                 weight_vars=weight_vars,
+                max_steps=max_steps,
             )
             for uq_part in unique_partitions
         ]
     ).query(f"{DISTANCES.SC_ID_ORIGIN} != {DISTANCES.SC_ID_DEST}")
 
     # filter by path length and/or weight
-
     logger.info(
         f"Filtering distances by path length ({max_steps}) and score quantile ({max_score_q})"
     )
     filtered_precomputed_distances = _filter_precomputed_distances(
         precomputed_distances=precomputed_distances,
-        max_steps=max_steps,
         max_score_q=max_score_q,
         path_weight_vars=["path_" + w for w in weight_vars],
     ).reset_index(drop=True)
 
+    # validate the precomputed distances
+    _validate_precomputed_distances(filtered_precomputed_distances)
     return filtered_precomputed_distances
 
 
@@ -187,58 +186,159 @@ def _calculate_distances_subset(
         NAPISTU_GRAPH_EDGES.WEIGHT,
         NAPISTU_GRAPH_EDGES.UPSTREAM_WEIGHT,
     ],
+    max_steps: Optional[int] = None,
 ) -> pd.DataFrame:
-    """Calculate distances from a subset of vertices to all vertices."""
+    """
+    Calculate shortest path distances from a subset of vertices to all vertices.
 
-    d_steps = (
-        pd.DataFrame(
-            np.array(
-                napistu_graph.distances(
-                    source=one_partition[SBML_DFS.SC_ID],
-                    target=vs_to_partition[SBML_DFS.SC_ID],
-                )
-            ),
-            index=one_partition[SBML_DFS.SC_ID].rename(NAPISTU_EDGELIST.SC_ID_ORIGIN),
-            columns=vs_to_partition[SBML_DFS.SC_ID].rename(NAPISTU_EDGELIST.SC_ID_DEST),
+    This function computes both unweighted (hop count) and weighted shortest path
+    distances from a subset of source vertices to all target vertices in the graph.
+    Memory optimization is achieved through early filtering of invalid paths and
+    deduplication of identical weight variables.
+
+    Parameters
+    ----------
+    napistu_graph : NapistuGraph
+        The network graph containing vertices and weighted edges. Must be a
+        subclass of igraph.Graph with edge attributes specified in `weight_vars`.
+    vs_to_partition : pd.DataFrame
+        DataFrame containing all target vertices in the graph. Must have columns
+        matching `SBML_DFS.SC_ID` and `NAPISTU_GRAPH_VERTICES.NODE_TYPE`.
+        Represents the full set of potential destination nodes.
+    one_partition : pd.DataFrame
+        DataFrame containing the subset of source vertices for this calculation.
+        Must be a subset of `vs_to_partition` with the same column structure.
+        Represents the source nodes for shortest path calculations.
+    weight_vars : list of str, default ['weight', 'upstream_weight']
+        List of edge attribute names to use for weighted shortest path calculations.
+        Each variable will result in a corresponding 'path_{weight_var}' column
+        in the output. Identical weight variables are automatically detected and
+        deduplicated to avoid redundant calculations.
+    max_steps : int, optional
+        Maximum number of hops to consider in shortest paths. If specified,
+        paths longer than `max_steps` are filtered out during calculation
+        rather than after, reducing memory usage. If None, no early filtering
+        is applied.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with shortest path information containing:
+
+        - `sc_id_origin` : str
+            Source vertex identifier from `one_partition`
+        - `sc_id_dest` : str
+            Destination vertex identifier from `vs_to_partition`
+        - `path_length` : int
+            Minimum number of hops in unweighted shortest path
+        - `path_{weight_var}` : float
+            Minimum weighted path cost for each weight variable specified.
+            One column per entry in `weight_vars`. Values are np.nan for
+            unreachable vertex pairs.
+
+    Notes
+    -----
+    Implementation optimizations:
+
+    1. **Early filtering**: If `max_steps` is provided, only paths ≤ max_steps
+       and finite distances are retained, significantly reducing memory usage
+       for sparse or filtered networks.
+
+    2. **Weight deduplication**: Identical weight variables (checked via
+       `np.array_equal`) are detected automatically. Only unique weight
+       calculations are performed, with results copied to duplicate columns.
+
+    3. **Memory efficiency**: Distance matrices are processed immediately
+       after calculation and masked arrays are used to avoid storing
+       full NxM matrices for large graphs.
+
+    The function assumes that `napistu_graph.distances()` returns finite values
+    for connected vertex pairs and `np.inf` for disconnected pairs. Self-loops
+    (same origin and destination) are not filtered at this level.
+
+    Examples
+    --------
+    >>> # Calculate distances from first 100 nodes to all nodes
+    >>> partition_0 = vs_to_partition.iloc[:100]
+    >>> distances = _calculate_distances_subset(
+    ...     graph, vs_to_partition, partition_0,
+    ...     weight_vars=['weight', 'upstream_weight'],
+    ...     max_steps=5
+    ... )
+    >>> distances.head()
+    """
+
+    # Calculate unweighted distances
+    distances_matrix = np.array(
+        napistu_graph.distances(
+            source=one_partition[SBML_DFS.SC_ID],
+            target=vs_to_partition[SBML_DFS.SC_ID],
         )
-        .reset_index()
-        .melt(NAPISTU_EDGELIST.SC_ID_ORIGIN, value_name=DISTANCES.PATH_LENGTH)
-        .replace([np.inf, -np.inf], np.nan, inplace=False)
-        .dropna()
     )
 
-    d_weights_list = list()
-    for weight_type in weight_vars:
-        d_weights_subset = (
-            pd.DataFrame(
-                np.array(
-                    napistu_graph.distances(
-                        source=one_partition[SBML_DFS.SC_ID],
-                        target=vs_to_partition[SBML_DFS.SC_ID],
-                        weights=weight_type,
-                    )
-                ),
-                index=one_partition[SBML_DFS.SC_ID].rename(
-                    NAPISTU_EDGELIST.SC_ID_ORIGIN
-                ),
-                columns=vs_to_partition[SBML_DFS.SC_ID].rename(
-                    NAPISTU_EDGELIST.SC_ID_DEST
-                ),
+    if max_steps is not None:
+        valid_mask = (distances_matrix <= max_steps) & np.isfinite(distances_matrix)
+    else:
+        valid_mask = np.isfinite(distances_matrix)
+
+    # Get valid positions
+    valid_rows, valid_cols = np.where(valid_mask)
+
+    # Create the unweighted distances DataFrame - only for valid entries
+    d_steps = pd.DataFrame(
+        {
+            NAPISTU_EDGELIST.SC_ID_ORIGIN: one_partition[SBML_DFS.SC_ID]
+            .iloc[valid_rows]
+            .values,
+            NAPISTU_EDGELIST.SC_ID_DEST: vs_to_partition[SBML_DFS.SC_ID]
+            .iloc[valid_cols]
+            .values,
+            DISTANCES.PATH_LENGTH: distances_matrix[valid_rows, valid_cols],
+        }
+    )
+
+    # in some setups multiple weight variables are identical. Becasue of this only calculate distances
+    # with unique variables; then assign the calculated values to all weight variables
+    unique_vars_map, representatives = _find_unique_weight_vars(
+        napistu_graph, weight_vars
+    )
+
+    # Calculate distances only for unique weight variables
+    calculated_weights = {}  # Maps representative_var -> calculated values
+
+    for rep_var in representatives.keys():
+        weight_matrix = np.array(
+            napistu_graph.distances(
+                source=one_partition[SBML_DFS.SC_ID],
+                target=vs_to_partition[SBML_DFS.SC_ID],
+                weights=rep_var,
             )
-            .reset_index()
-            .melt(NAPISTU_EDGELIST.SC_ID_ORIGIN, value_name=f"path_{weight_type}")
-            .replace([np.inf, -np.inf], np.nan, inplace=False)
-            .dropna()
         )
 
-        d_weights_list.append(d_weights_subset)
+        # Extract values using the same mask
+        weight_values = weight_matrix[valid_rows, valid_cols]
+        calculated_weights[rep_var] = np.where(
+            np.isfinite(weight_values), weight_values, np.nan
+        )
 
-    d_weights = d_weights_list.pop()
-    while len(d_weights_list) > 0:
-        d_weights = d_weights.merge(d_weights_list.pop())
+    # Create weight DataFrames for all requested variables (including duplicates)
+    d_weights_data = {
+        NAPISTU_EDGELIST.SC_ID_ORIGIN: one_partition[SBML_DFS.SC_ID]
+        .iloc[valid_rows]
+        .values,
+        NAPISTU_EDGELIST.SC_ID_DEST: vs_to_partition[SBML_DFS.SC_ID]
+        .iloc[valid_cols]
+        .values,
+    }
 
-    # merge shortest path distances by length and by weight
-    # note: these may be different paths! e.g., a longer path may have a lower weight than a short one
+    # Assign calculated values to all requested weight variables
+    for var in weight_vars:
+        rep_var = unique_vars_map[var]
+        d_weights_data[f"path_{var}"] = calculated_weights[rep_var]
+
+    d_weights = pd.DataFrame(d_weights_data)
+
+    # Merge shortest path distances by length and by weight
     path_summaries = d_steps.merge(
         d_weights,
         left_on=[NAPISTU_EDGELIST.SC_ID_ORIGIN, NAPISTU_EDGELIST.SC_ID_DEST],
@@ -251,7 +351,6 @@ def _calculate_distances_subset(
 
 def _filter_precomputed_distances(
     precomputed_distances: pd.DataFrame,
-    max_steps: float | int = np.inf,
     max_score_q: float = 1,
     path_weight_vars: list[str] = [
         DISTANCES.PATH_WEIGHT,
@@ -260,34 +359,23 @@ def _filter_precomputed_distances(
 ) -> pd.DataFrame:
     """Filter precomputed distances by maximum steps and/or to low scores by quantile."""
 
-    # filter by path lengths
-    short_precomputed_distances = precomputed_distances[
-        precomputed_distances[DISTANCES.PATH_LENGTH] <= max_steps
-    ]
-    n_filtered_by_path_length = (
-        precomputed_distances.shape[0] - short_precomputed_distances.shape[0]
-    )
-    if n_filtered_by_path_length > 0:
-        logger.info(
-            f"filtered {n_filtered_by_path_length} possible paths with length > {max_steps}"
-        )
-
-    # filter by path weights
+    # Create masks for each path_weight_var indicating whether the path is below the cutoff
+    masks = []
     for wt_var in path_weight_vars:
-        score_q_cutoff = np.quantile(short_precomputed_distances[wt_var], max_score_q)
+        score_q_cutoff = np.quantile(precomputed_distances[wt_var], max_score_q)
+        # Mask is True if weight is below or equal to cutoff (keep the row)
+        mask = precomputed_distances[wt_var] <= score_q_cutoff
+        masks.append(mask)
 
-        short_precomputed_distances.loc[
-            short_precomputed_distances[wt_var] > score_q_cutoff, wt_var
-        ] = np.nan
+    # Combine masks: keep rows where at least one weight variable is below cutoff
+    # (i.e., keep rows that are True in at least one mask)
+    combined_mask = pd.concat(masks, axis=1).any(axis=1)
 
-    valid_weights = short_precomputed_distances[path_weight_vars].dropna(how="all")
-
-    low_weight_precomputed_distances = short_precomputed_distances[
-        short_precomputed_distances.index.isin(valid_weights.index.tolist())
-    ]
+    # Filter to rows which have at least one weight variable below the cutoff
+    low_weight_precomputed_distances = precomputed_distances[combined_mask].copy()
 
     n_filtered_by_low_weight = (
-        short_precomputed_distances.shape[0] - low_weight_precomputed_distances.shape[0]
+        precomputed_distances.shape[0] - low_weight_precomputed_distances.shape[0]
     )
 
     if n_filtered_by_low_weight > 0:
@@ -296,14 +384,107 @@ def _filter_precomputed_distances(
         )
         logger.info(f"than the {max_score_q} quantile of the path weight distribution")
 
-    weight_nan_summary = valid_weights.isnull().sum()
-    if any(weight_nan_summary != 0):
-        nan_summary = " and ".join(
-            [
-                f"{k} has {v} np.nan values"
-                for k, v in weight_nan_summary.to_dict().items()
-            ]
-        )
-        logger.info(nan_summary)
-
     return low_weight_precomputed_distances
+
+
+def _find_unique_weight_vars(
+    napistu_graph: NapistuGraph, weight_vars: list[str]
+) -> tuple[dict, dict]:
+    """
+    Find unique weight variables to avoid redundant distance calculations.
+
+    Returns:
+        tuple: (unique_vars_map, representatives)
+            - unique_vars_map: Maps weight_var -> representative_var for calculation
+            - representatives: Maps representative_var -> list of vars it represents
+    """
+    if len(weight_vars) == 0:
+        raise ValueError("weight_vars cannot be empty")
+
+    if len(weight_vars) == 1:
+        single_var_map = {var: var for var in weight_vars}
+        single_representatives = {var: [var] for var in weight_vars}
+        return single_var_map, single_representatives
+
+    # Get edge attributes for comparison
+    weight_arrays = {}
+    for var in weight_vars:
+        weight_arrays[var] = np.array(napistu_graph.es[var])
+
+    # Find which variables are identical
+    unique_vars = {}  # Maps var -> representative var to calculate
+    representatives = {}  # Maps representative -> list of vars it represents
+
+    for var in weight_vars:
+        # Check if this var is identical to any already processed var
+        found_match = False
+        for rep_var in representatives.keys():
+            if np.array_equal(weight_arrays[var], weight_arrays[rep_var]):
+                unique_vars[var] = rep_var
+                representatives[rep_var].append(var)
+                found_match = True
+                break
+
+        if not found_match:
+            # This is a new unique variable
+            unique_vars[var] = var
+            representatives[var] = [var]
+
+    # Log the deduplication results
+    total_vars = len(weight_vars)
+    unique_count = len(representatives)
+    if unique_count < total_vars:
+        logger.debug(
+            f"Weight deduplication: {total_vars} vars -> {unique_count} unique calculations"
+        )
+        for rep_var, identical_vars in representatives.items():
+            if len(identical_vars) > 1:
+                logger.debug(f"  '{rep_var}' represents: {identical_vars}")
+
+    return unique_vars, representatives
+
+
+def _validate_precomputed_distances(precomputed_distances: pd.DataFrame) -> None:
+    """
+    Validate the precomputed distances DataFrame.
+
+    This function checks the following:
+    1. All required variables are present.
+    2. All weight variables are numeric.
+    3. No missing values are present.
+    4. No negative weights are present.
+    5. No infinite weights are present.
+    """
+
+    REQUIRED_VARS = {NAPISTU_EDGELIST.SC_ID_ORIGIN, NAPISTU_EDGELIST.SC_ID_DEST}
+
+    missing_vars = REQUIRED_VARS - set(precomputed_distances.columns)
+    if missing_vars:
+        raise ValueError(
+            f"'precomputed_distances' is missing required variables: {missing_vars}"
+        )
+
+    # check for non-numeric weights
+    weight_vars = list(set(precomputed_distances.columns) - REQUIRED_VARS)
+    for var in weight_vars:
+        if not pd.api.types.is_numeric_dtype(precomputed_distances[var]):
+            raise ValueError(f"Variable '{var}' is not numeric")
+
+    # check for missing values
+    rows_with_nans = sum(precomputed_distances.isna().any(axis=1))
+    if rows_with_nans > 0:
+        raise ValueError(f"{rows_with_nans} rows have missing values")
+
+    # check for negative weights
+    negative_weights = precomputed_distances[weight_vars].lt(0).any().any()
+    if negative_weights:
+        raise ValueError("Negative weights detected")
+
+    # check for infinite weights
+    infinite_weights = (
+        precomputed_distances[weight_vars].isin([np.inf, -np.inf]).any().any()
+    )
+    if infinite_weights:
+        raise ValueError("Infinite weights detected")
+
+    return None

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -229,6 +229,16 @@ def precomputed_distances_metabolism(napistu_graph_metabolism):
     )
 
 
+@fixture
+def species_identifiers_metabolism(sbml_dfs_metabolism):
+    """
+    Pytest fixture to create a species identifiers DataFrame from sbml_dfs_metabolism.
+    This creates a DataFrame with the structure expected by validate_assets.
+    """
+
+    return sbml_dfs_metabolism.get_characteristic_species_ids()
+
+
 @pytest.fixture
 def reaction_species_examples():
     """

--- a/src/tests/test_network_ng_utils.py
+++ b/src/tests/test_network_ng_utils.py
@@ -415,3 +415,67 @@ def test_pluck_side_loaded_data():
         ng_utils.pluck_data(
             data_tables, {"test": {"table": "missing", "variable": "col1"}}
         )
+
+
+def test_validate_assets_only_sbml_dfs(sbml_dfs_metabolism, caplog):
+    """Test validate_assets with only sbml_dfs provided - should log warning."""
+    import logging
+
+    # Clear any previous log records
+    caplog.clear()
+
+    # Call validate_assets with only sbml_dfs
+    result = ng_utils.validate_assets(sbml_dfs_metabolism)
+
+    # Should return None
+    assert result is None
+
+    # Should log a warning
+    assert caplog.records
+    assert any(
+        "Only sbml_dfs was provided; nothing to validate" in record.message
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    )
+
+
+def test_validate_assets_with_napistu_graph(
+    sbml_dfs_metabolism, napistu_graph_metabolism
+):
+    """Test validate_assets with sbml_dfs and napistu_graph."""
+    # Should not raise any errors or warnings
+    result = ng_utils.validate_assets(
+        sbml_dfs_metabolism, napistu_graph=napistu_graph_metabolism
+    )
+    assert result is None
+
+
+def test_validate_assets_precomputed_distances_without_graph(
+    sbml_dfs_metabolism, precomputed_distances_metabolism
+):
+    """Test validate_assets with precomputed_distances but no napistu_graph - should raise ValueError."""
+    # Should raise ValueError when precomputed_distances is provided without napistu_graph
+    with pytest.raises(
+        ValueError,
+        match="napistu_graph must be provided if precomputed_distances is provided",
+    ):
+        ng_utils.validate_assets(
+            sbml_dfs_metabolism, precomputed_distances=precomputed_distances_metabolism
+        )
+
+
+def test_validate_assets_all_valid_assets(
+    sbml_dfs_metabolism,
+    napistu_graph_metabolism,
+    precomputed_distances_metabolism,
+    species_identifiers_metabolism,
+):
+    """Test validate_assets with all valid assets provided."""
+    # Should not raise any errors when all assets are provided and valid
+    result = ng_utils.validate_assets(
+        sbml_dfs_metabolism,
+        napistu_graph=napistu_graph_metabolism,
+        precomputed_distances=precomputed_distances_metabolism,
+        identifiers_df=species_identifiers_metabolism,
+    )
+    assert result is None


### PR DESCRIPTION
- added explicit multi-platform image tag for images built with ARM-support. Closes #225 
- fix failed validation message. this wasn't actually interfering with anything but it ruined the logs. updated the validation condition to allow for shortest path weights less than or equal to length 1 path weights because many indirect paths now exist which are lower weight than direct ones. Closes #223 
- overhauled precomputed distances to understand the inconsistencies flagged by #223
    - improved memory and overall performance by:
        - setting a lower partition size (I validated that lowering this by ~5X causes _calculate_distances_subset to run 5X faster so there isn't much of a performance overhead to working with more, smaller partitions and it does decrease the memory footprint.
        - switched to filtering for max steps during `_calculate_distances_subset` so the concatenated output is smaller and there is no need to perform this operation on the full precomputed distances table.
        - create masks based on shortest distances which can be used on shortest weighted paths calculations
        - if multiple weight variables are the same across edges then only find shortest-weighted paths using 1 of them and then propagate the changes in the final output.
    -  switched from masking distance connections with NaNs in _calculate_distances_subset to outright filtering rows which are outside the chosen quantiles for all weights. This results in a filtered output with the same rows values as the input, just with some rows removed. Closes #224 