### PR TITLE
Issue 233 - species/source occurrence speedup with include_missing = True; patches for problems with new sbmls

### DIFF
--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -27,6 +27,7 @@ from napistu._cli import (
     sbml_dfs_io,
     sbml_dfs_output,
     setup_logging,
+    target_uri_output,
     verbosity_option,
 )
 from napistu.constants import ONTOLOGIES, RESOLVE_MATCHES_AGGREGATORS
@@ -101,7 +102,7 @@ def ingest_bigg(base_folder: str, overwrite: bool):
 
 
 @ingestion.command(name="trrust")
-@click.argument("target_uri", type=str)
+@target_uri_output
 @verbosity_option
 def ingest_ttrust(target_uri: str):
     logger.info("Start downloading TRRUST to %s", target_uri)
@@ -109,7 +110,7 @@ def ingest_ttrust(target_uri: str):
 
 
 @ingestion.command(name="proteinatlas_subcell")
-@click.argument("target_uri", type=str)
+@target_uri_output
 @click.option(
     "--url",
     type=str,
@@ -122,7 +123,7 @@ def ingest_proteinatlas_subcell(target_uri: str, url: str):
 
 
 @ingestion.command(name="gtex-rnaseq-expression")
-@click.argument("target_uri", type=str)
+@target_uri_output
 @click.option(
     "--url",
     type=str,
@@ -135,15 +136,15 @@ def ingest_gtex_rnaseq(target_uri: str, url: str):
 
 
 @ingestion.command(name="string_db")
-@click.argument("target_uri", type=str)
 @organismal_species_argument
+@target_uri_output
 @verbosity_option
 def ingest_string_db(organismal_species: str, target_uri: str):
     string.download_string(target_uri, organismal_species)
 
 
 @ingestion.command(name="string_aliases")
-@click.argument("target_uri", type=str)
+@target_uri_output
 @organismal_species_argument
 @verbosity_option
 def ingest_string_aliases(organismal_species: str, target_uri: str):
@@ -151,7 +152,7 @@ def ingest_string_aliases(organismal_species: str, target_uri: str):
 
 
 @ingestion.command(name="reactome_fi")
-@click.argument("target_uri", type=str)
+@target_uri_output
 @click.option(
     "--url",
     type=str,
@@ -494,8 +495,9 @@ def refine():
 
 
 @refine.command(name="add_reactome_entity_sets")
-@sbml_dfs_io
+@sbml_dfs_input
 @click.argument("entity_set_csv", type=str)
+@sbml_dfs_output
 def add_reactome_entity_sets(
     sbml_dfs_uri: str, entity_set_csv: str, output_model_uri: str
 ):
@@ -510,8 +512,9 @@ def add_reactome_entity_sets(
 
 
 @refine.command(name="add_reactome_identifiers")
-@sbml_dfs_io
+@sbml_dfs_input
 @click.argument("crossref_csv", type=str)
+@sbml_dfs_output
 def add_reactome_identifiers(
     sbml_dfs_uri: str, crossref_csv: str, output_model_uri: str
 ):
@@ -594,8 +597,9 @@ def add_transportation_reaction(
 
 
 @refine.command(name="apply_manual_curations")
-@sbml_dfs_io
+@sbml_dfs_input
 @click.argument("curation_dir", type=str)
+@sbml_dfs_output
 def apply_manual_curations(sbml_dfs_uri: str, curation_dir: str, output_model_uri: str):
     """Apply manual curations to a consensus model
 
@@ -608,8 +612,9 @@ def apply_manual_curations(sbml_dfs_uri: str, curation_dir: str, output_model_ur
 
 
 @refine.command(name="expand_identifiers")
-@sbml_dfs_io
+@sbml_dfs_input
 @organismal_species_argument
+@sbml_dfs_output
 @click.option(
     "--ontologies", "-o", multiple=True, type=str, help="Ontologies to add or complete"
 )
@@ -689,9 +694,10 @@ def dogmatic_scaffold(
 
 
 @refine.command(name="filter_gtex_tissue")
-@sbml_dfs_io
+@sbml_dfs_input
 @click.argument("gtex_file_uri", type=str)
 @click.argument("tissue", type=str)
+@sbml_dfs_output
 @verbosity_option
 def filter_gtex_tissue(
     sbml_dfs_uri: str, gtex_file_uri: str, output_model_uri: str, tissue: str
@@ -730,8 +736,9 @@ def filter_gtex_tissue(
 
 
 @refine.command(name="filter_hpa_compartments")
-@sbml_dfs_io
+@sbml_dfs_input
 @click.argument("hpa_file_uri", type=str)
+@sbml_dfs_output
 @verbosity_option
 def filter_hpa_gene_compartments(
     sbml_dfs_uri: str, hpa_file_uri: str, output_model_uri: str
@@ -1026,10 +1033,10 @@ def validate_sbml_dfs(sbml_dfs_uri):
     logger.info(f"Successfully validated: {sbml_dfs_uri}")
 
 
-@helpers.command(name="summary")
+@helpers.command(name="summarize_sbml_dfs")
 @sbml_dfs_input
 @verbosity_option
-def show_sbml_dfs_summary(sbml_dfs_uri):
+def summarize_sbml_dfs(sbml_dfs_uri):
     """Display a summary of an SBML_dfs object"""
     sbml_dfs = SBML_dfs.from_pickle(sbml_dfs_uri)
     sbml_dfs.show_summary()

--- a/src/napistu/__main__.py
+++ b/src/napistu/__main__.py
@@ -1120,7 +1120,7 @@ def stats():
 def calculate_sbml_dfs_stats(sbml_dfs_uri, output_uri):
     """Calculate statistics for a sbml_dfs object"""
     model = SBML_dfs.from_pickle(sbml_dfs_uri)
-    stats = model.get_network_summary()
+    stats = model.get_sbml_dfs_summary()
     utils.save_json(output_uri, stats)
 
 

--- a/src/napistu/_cli.py
+++ b/src/napistu/_cli.py
@@ -130,6 +130,13 @@ def overwrite_option(f: Callable) -> Callable:
     )(f)
 
 
+def target_uri_output(f: Callable) -> Callable:
+    """
+    Decorator that adds a standardized target_uri argument.
+    """
+    return click.argument(NAPISTU_CLI.TARGET_URI, type=str)(f)
+
+
 def sbml_dfs_input(f: Callable) -> Callable:
     """
     Decorator that adds a standardized model_uri argument.

--- a/src/napistu/constants.py
+++ b/src/napistu/constants.py
@@ -24,6 +24,7 @@ NAPISTU_CLI = SimpleNamespace(
     SBML_DFS_URI="sbml_dfs_uri",
     OUTPUT_MODEL_URI="output_model_uri",
     OVERWRITE="overwrite",
+    TARGET_URI="target_uri",
 )
 
 FILE_EXT_ZIP = "zip"

--- a/src/napistu/identifiers.py
+++ b/src/napistu/identifiers.py
@@ -10,7 +10,7 @@ import libsbml
 import pandas as pd
 from pydantic import BaseModel
 
-from napistu import sbml_dfs_core, sbml_dfs_utils, utils
+from napistu import sbml_dfs_core, utils
 from napistu.constants import (
     BIOLOGICAL_QUALIFIER_CODES,
     BQB,
@@ -231,7 +231,7 @@ def df_to_identifiers(df: pd.DataFrame) -> pd.Series:
         Series indexed by index_col containing Identifiers objects
     """
 
-    entity_type = sbml_dfs_utils.infer_entity_type(df)
+    entity_type = utils.infer_entity_type(df)
     table_schema = SBML_DFS_SCHEMA.SCHEMA[entity_type]
     if SCHEMA_DEFS.ID not in table_schema:
         raise ValueError(f"The entity type {entity_type} does not have an id column")

--- a/src/napistu/ingestion/sbml.py
+++ b/src/napistu/ingestion/sbml.py
@@ -260,6 +260,12 @@ class SBML:
                     }
                 )
 
+        if len(compartments) == 0:
+            logger.warning(
+                "No compartments were found in the SBML model. using default compartment GO CELLULAR_COMPONENT"
+            )
+            return sbml_dfs_utils.stub_compartments(with_source=True)
+
         return pd.DataFrame(compartments).set_index(SBML_DFS.C_ID)
 
     def _define_cspecies(self) -> pd.DataFrame:
@@ -302,6 +308,11 @@ class SBML:
         comp_species_df[SBML_DFS.C_ID] = comp_species_df[SBML_DFS.C_ID].replace(
             "", None
         )
+
+        # if all entries are missing then c_id was likely stubbed with sbml_dfs_utils.stub_compartments()
+        if all(comp_species_df[SBML_DFS.C_ID].isnull()):
+            default_cid = sbml_dfs_utils.stub_compartments().index[0]
+            comp_species_df[SBML_DFS.C_ID] = default_cid
 
         return comp_species_df
 

--- a/src/napistu/ingestion/sbml.py
+++ b/src/napistu/ingestion/sbml.py
@@ -94,7 +94,10 @@ class SBML:
         if errors is not None:
             critical_errors = errors[errors[SBML_DEFS.ERROR_SEVERITY] >= 2]
             critical_errors = set(critical_errors[SBML_DEFS.ERROR_DESCRIPTION].unique())
-            known_errors = {"<layout> must have 'id' and may have 'name'"}
+            known_errors = {
+                "<layout> must have 'id' and may have 'name'",
+                "Missing value for the 'compartment' attribute",
+            }
 
             found_known_errors = known_errors.intersection(critical_errors)
             if len(found_known_errors) > 0:
@@ -293,6 +296,11 @@ class SBML:
         comp_species_df = pd.DataFrame(comp_species).set_index(SBML_DFS.SC_ID)
         comp_species_df[SBML_DFS.SC_NAME] = utils.update_pathological_names(
             comp_species_df[SBML_DFS.SC_NAME], "SC"
+        )
+
+        # replace empty strings for c_id with None so the resolve function will properly fill these
+        comp_species_df[SBML_DFS.C_ID] = comp_species_df[SBML_DFS.C_ID].replace(
+            "", None
         )
 
         return comp_species_df

--- a/src/napistu/ontologies/id_tables.py
+++ b/src/napistu/ontologies/id_tables.py
@@ -3,7 +3,7 @@ from typing import Optional, Set, Union
 
 import pandas as pd
 
-from napistu import sbml_dfs_utils, utils
+from napistu import utils
 from napistu.constants import (
     BQB,
     BQB_DEFINING_ATTRS_LOOSE,
@@ -47,7 +47,7 @@ def filter_id_table(
         If the id_table or filter values are invalid, or required columns are missing.
     """
 
-    entity_type = sbml_dfs_utils.infer_entity_type(id_table)
+    entity_type = utils.infer_entity_type(id_table)
     _validate_id_table(id_table, entity_type)
 
     # bqbs

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -554,7 +554,6 @@ def filter_to_characteristic_species_ids(
 
 def format_model_summary(data):
     """Format model data into a clean summary table for Jupyter display"""
-    import pandas as pd
 
     # Calculate species percentages
     total_species = data["n_species"]
@@ -578,8 +577,14 @@ def format_model_summary(data):
         ]
     )
 
-    # Add compartment breakdown
-    for comp in data["dict_n_species_per_compartment"]:
+    # Sort compartments by species count (descending) and add compartment breakdown
+    sorted_compartments = sorted(
+        data["dict_n_species_per_compartment"],
+        key=lambda x: x["n_species"],
+        reverse=True,
+    )
+
+    for comp in sorted_compartments:
         comp_pct = comp["n_species"] / data["n_cspecies"] * 100
         summary_data.append(
             [f"- {comp['c_name']}", f"{comp['n_species']:,} ({comp_pct:.1f}%)"]

--- a/src/napistu/source.py
+++ b/src/napistu/source.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 import numpy as np
 import pandas as pd
 
-from napistu import indices, sbml_dfs_core, sbml_dfs_utils, utils
+from napistu import indices, sbml_dfs_core, utils
 from napistu.constants import (
     SBML_DFS_SCHEMA,
     SCHEMA_DEFS,
@@ -385,7 +385,7 @@ def unnest_sources(source_table: pd.DataFrame) -> pd.DataFrame:
     to include one row per source
     """
 
-    table_type = sbml_dfs_utils.infer_entity_type(source_table)
+    table_type = utils.infer_entity_type(source_table)
     source_table_schema = SBML_DFS_SCHEMA.SCHEMA[table_type]
 
     if SCHEMA_DEFS.SOURCE not in source_table_schema.keys():
@@ -461,7 +461,7 @@ def source_set_coverage(
 
     """
 
-    table_type = sbml_dfs_utils.infer_entity_type(select_sources_df)
+    table_type = utils.infer_entity_type(select_sources_df)
     pk = SBML_DFS_SCHEMA.SCHEMA[table_type][SCHEMA_DEFS.PK]
 
     if source_total_counts is not None:
@@ -537,7 +537,7 @@ def source_set_coverage(
 def _deduplicate_source_df(source_df: pd.DataFrame) -> pd.DataFrame:
     """Combine entries in a source table when multiple models have the same members."""
 
-    table_type = sbml_dfs_utils.infer_entity_type(source_df)
+    table_type = utils.infer_entity_type(source_df)
     source_table_schema = SBML_DFS_SCHEMA.SCHEMA[table_type]
 
     # drop entries which are missing required attributes and throw an error if none are left
@@ -813,7 +813,7 @@ def _update_unaccounted_for_members(
         the dataframe of unaccounted for members with the top pathway removed
     """
 
-    table_type = sbml_dfs_utils.infer_entity_type(unaccounted_for_members)
+    table_type = utils.infer_entity_type(unaccounted_for_members)
     pk = SBML_DFS_SCHEMA.SCHEMA[table_type][SCHEMA_DEFS.PK]
 
     members_captured = (

--- a/src/napistu/utils.py
+++ b/src/napistu/utils.py
@@ -36,7 +36,7 @@ with warnings.catch_warnings():
     from fs.tempfs import TempFS
     from fs.zipfs import ZipFS
 
-from napistu.constants import FILE_EXT_GZ, FILE_EXT_ZIP
+from napistu.constants import FILE_EXT_GZ, FILE_EXT_ZIP, SBML_DFS_SCHEMA, SCHEMA_DEFS
 
 logger = logging.getLogger(__name__)
 
@@ -87,14 +87,21 @@ def download_and_extract(
 
     Download an archive and then extract to a new folder
 
-    Args:
-        url (str): Url of archive.
-        output_dir_path (str): Path to output directory.
-        overwrite (bool): Overwrite an existing output directory.
+    Parameters
+    ----------
+    url : str
+        Url of archive.
+    output_dir_path : str
+        Path to output directory.
+    download_method : str
+        Method to use to download the archive.
+    overwrite : bool
+        Overwrite an existing output directory.
 
-
-    Returns:
-        None
+    Returns
+    -------
+    None
+        Files are downloaded and extracted to the specified directory
     """
 
     # initialize output directory
@@ -1414,3 +1421,73 @@ def _create_left_align_formatters(df):
             formatters[col] = lambda x, w=width: f"{str(x):<{w}}"
 
     return formatters
+
+
+def infer_entity_type(df: pd.DataFrame) -> str:
+    """
+    Infer the entity type of a DataFrame based on its structure and schema.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to analyze
+
+    Returns
+    -------
+    str
+        The inferred entity type name
+
+    Raises
+    ------
+    ValueError
+        If no entity type can be determined
+    """
+    schema = SBML_DFS_SCHEMA.SCHEMA
+
+    # Get all primary keys
+    primary_keys = [
+        entity_schema.get(SCHEMA_DEFS.PK) for entity_schema in schema.values()
+    ]
+    primary_keys = [pk for pk in primary_keys if pk is not None]
+
+    # Check if index matches a primary key
+    if df.index.name in primary_keys:
+        for entity_type, entity_schema in schema.items():
+            if entity_schema.get(SCHEMA_DEFS.PK) == df.index.name:
+                return entity_type
+
+    # Get DataFrame columns that are also primary keys, including index or MultiIndex names
+    index_names = []
+    if isinstance(df.index, pd.MultiIndex):
+        index_names = [name for name in df.index.names if name is not None]
+    elif df.index.name is not None:
+        index_names = [df.index.name]
+
+    df_columns = set(df.columns).union(index_names).intersection(primary_keys)
+
+    # Check for exact match with primary key + foreign keys
+    for entity_type, entity_schema in schema.items():
+        expected_keys = set()
+
+        # Add primary key
+        pk = entity_schema.get(SCHEMA_DEFS.PK)
+        if pk:
+            expected_keys.add(pk)
+
+        # Add foreign keys
+        fks = entity_schema.get(SCHEMA_DEFS.FK, [])
+        expected_keys.update(fks)
+
+        # Check for exact match
+        if len(df_columns) == 1 and set(df_columns) == {pk}:
+            # only a single key is present and its this entities pk
+            return entity_type
+
+        if df_columns == expected_keys:
+            # all primary and foreign keys are present
+            return entity_type
+
+    # No match found
+    raise ValueError(
+        f"No entity type matches DataFrame with index: {df.index.names} and columns: {sorted(df_columns)}"
+    )

--- a/src/tests/test_sbml_dfs_utils.py
+++ b/src/tests/test_sbml_dfs_utils.py
@@ -285,94 +285,6 @@ def test_sbo_constants_internal_consistency():
         assert MINI_SBO_FROM_NAME[name] == term
 
 
-def test_infer_entity_type():
-    """Test entity type inference with valid keys"""
-    # when index matches primary key.
-    # Test compartments with index as primary key
-    df = pd.DataFrame(
-        {SBML_DFS.C_NAME: ["cytoplasm"], SBML_DFS.C_IDENTIFIERS: ["GO:0005737"]}
-    )
-    df.index.name = SBML_DFS.C_ID
-    result = sbml_dfs_utils.infer_entity_type(df)
-    assert result == SBML_DFS.COMPARTMENTS
-
-    # Test species with index as primary key
-    df = pd.DataFrame(
-        {SBML_DFS.S_NAME: ["glucose"], SBML_DFS.S_IDENTIFIERS: ["CHEBI:17234"]}
-    )
-    df.index.name = SBML_DFS.S_ID
-    result = sbml_dfs_utils.infer_entity_type(df)
-    assert result == SBML_DFS.SPECIES
-
-    # Test entity type inference by exact column matching.
-    # Test compartmentalized_species (has foreign keys)
-    df = pd.DataFrame(
-        {
-            SBML_DFS.SC_ID: ["glucose_c"],
-            SBML_DFS.S_ID: ["glucose"],
-            SBML_DFS.C_ID: ["cytoplasm"],
-        }
-    )
-    result = sbml_dfs_utils.infer_entity_type(df)
-    assert result == "compartmentalized_species"
-
-    # Test reaction_species (has foreign keys)
-    df = pd.DataFrame(
-        {
-            SBML_DFS.RSC_ID: ["rxn1_glc"],
-            SBML_DFS.R_ID: ["rxn1"],
-            SBML_DFS.SC_ID: ["glucose_c"],
-        }
-    )
-    result = sbml_dfs_utils.infer_entity_type(df)
-    assert result == SBML_DFS.REACTION_SPECIES
-
-    # Test reactions (only primary key)
-    df = pd.DataFrame({SBML_DFS.R_ID: ["rxn1"]})
-    result = sbml_dfs_utils.infer_entity_type(df)
-    assert result == SBML_DFS.REACTIONS
-
-
-def test_infer_entity_type_errors():
-    """Test error cases for entity type inference."""
-    # Test no matching entity type
-    df = pd.DataFrame({"random_column": ["value"], "another_col": ["data"]})
-    with pytest.raises(ValueError, match="No entity type matches DataFrame"):
-        sbml_dfs_utils.infer_entity_type(df)
-
-    # Test partial match (missing required foreign key)
-    df = pd.DataFrame(
-        {SBML_DFS.SC_ID: ["glucose_c"], SBML_DFS.S_ID: ["glucose"]}
-    )  # Missing c_id
-    with pytest.raises(ValueError):
-        sbml_dfs_utils.infer_entity_type(df)
-
-    # Test extra primary keys that shouldn't be there
-    df = pd.DataFrame(
-        {SBML_DFS.R_ID: ["rxn1"], SBML_DFS.S_ID: ["glucose"]}
-    )  # Two primary keys
-    with pytest.raises(ValueError):
-        sbml_dfs_utils.infer_entity_type(df)
-
-
-def test_infer_entity_type_multindex():
-    # DataFrame with MultiIndex (r_id, foo), should infer as reactions
-    df = pd.DataFrame({"some_col": [1, 2]})
-    df.index = pd.MultiIndex.from_tuples(
-        [("rxn1", "a"), ("rxn2", "b")], names=[SBML_DFS.R_ID, "foo"]
-    )
-    result = sbml_dfs_utils.infer_entity_type(df)
-    assert result == SBML_DFS.REACTIONS
-
-    # DataFrame with MultiIndex (sc_id, bar), should infer as compartmentalized_species
-    df = pd.DataFrame({"some_col": [1, 2]})
-    df.index = pd.MultiIndex.from_tuples(
-        [("glucose_c", "a"), ("atp_c", "b")], names=[SBML_DFS.SC_ID, "bar"]
-    )
-    result = sbml_dfs_utils.infer_entity_type(df)
-    assert result == SBML_DFS.COMPARTMENTALIZED_SPECIES
-
-
 def test_get_interaction_symbol():
 
     # Test SBO names (strings)
@@ -725,7 +637,7 @@ def test_add_missing_ids_column(sbml_dfs):
 def test_format_model_summary(sbml_dfs):
     """Test format_model_summary function with sbml_dfs fixture."""
     # Get network summary from the sbml_dfs
-    summary_stats = sbml_dfs.get_network_summary()
+    summary_stats = sbml_dfs.get_sbml_dfs_summary()
 
     # Call format_model_summary
     result = sbml_dfs_utils.format_model_summary(summary_stats)


### PR DESCRIPTION
- added recovery for SBML missing some/all compartment information. Closes #233
    - ignoring this critical libsbml error: "Missing value for the 'compartment' attribute"
    - replace missing compartment empty strings with None so the existing `SBML_dfs.infer_uncompartmentalized_species_location` method could recover.
-  `include_missing` = True was making reaction ontology and source occurrence counting prohibitively slow
    - switched the reference table to filter interactor reactions consistent with how the contingency tables were created in the first place.
    - optimized `add_missing_ids_column` - there was a silly concatenating with a for loop; and unnecessary calculation of duplicates. 
- cleanup table summaries of `SBML_dfs` to pool rare compartments for reporting and left adjusting strings.  Closes #235 Closes #229