### PR TITLE
Issue 236 - SBO term occurrence

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.6.6
+version = 0.7.0
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/network/ng_core.py
+++ b/src/napistu/network/ng_core.py
@@ -1790,6 +1790,12 @@ class NapistuGraph(ig.Graph):
             entity_data, left_on=merge_keys, right_index=True, how="left"
         )
 
+        # validate that there wasn't a 1-to-many merge
+        if graph_with_attrs.shape[0] != graph_df.shape[0]:
+            raise ValueError(
+                f"1-to-many merge occurred when adding {entity_data.shape[0]} {entity_data.index.names} to graph {target_entity}"
+            )
+
         # Add new attributes directly to the graph
         added_count = 0
         for attr_name in attrs_to_add:
@@ -1804,6 +1810,8 @@ class NapistuGraph(ig.Graph):
         logger.info(
             f"Added {added_count} {entity_name} attributes to graph: {attrs_to_add}"
         )
+
+        return None
 
     def _transform_entity_attributes(
         self,
@@ -1978,6 +1986,8 @@ class NapistuGraph(ig.Graph):
         logger.info(
             f"Transformed {len(attrs_to_transform)} {target_entity} attributes: {list(attrs_to_transform)}"
         )
+
+        return None
 
 
 def _apply_edge_reversal_mapping(edges_df: pd.DataFrame) -> pd.DataFrame:

--- a/src/napistu/network/ng_utils.py
+++ b/src/napistu/network/ng_utils.py
@@ -834,7 +834,6 @@ def separate_entity_attrs_by_source(
         sbml_dfs and side_loaded_attributes have overlapping table names, if neither data
         source is provided, or if required table names are missing from both sources
     """
-    from napistu.network.constants import SBML_DFS, WEIGHTING_SPEC
 
     # Validate entity_type
     if entity_type not in [SBML_DFS.REACTIONS, SBML_DFS.SPECIES]:
@@ -1305,6 +1304,13 @@ def _validate_side_loaded_attributes(
                 f"side_loaded_attributes[{table_name}] has index names {current_index_names}, "
                 f"but other tables have index names {reference_index_names}. "
                 f"All DataFrames must have the same index names for concatenation."
+            )
+
+        # check that index is unique
+        if not df.index.is_unique:
+            raise ValueError(
+                f"side_loaded_attributes[{table_name}] has non-unique index. "
+                f"All DataFrames must have a unique index for concatenation."
             )
 
 

--- a/src/napistu/sbml_dfs_core.py
+++ b/src/napistu/sbml_dfs_core.py
@@ -1018,6 +1018,40 @@ class SBML_dfs:
 
         return stats
 
+    def get_sbo_term_occurrence(
+        self, name_terms=True, include_interactor_reactions=False
+    ) -> pd.DataFrame:
+        """
+        Get the occurrence of SBO terms for reactions.
+
+        Parameters
+        ----------
+        name_terms : bool, optional
+            Whether to name the SBO terms, by default True
+        include_interactor_reactions : bool, optional
+            Whether to exclude interactor reactions, by default True
+        """
+
+        reaction_species = self.reaction_species
+        if not include_interactor_reactions:
+            # ignore reactions which are all interactors
+            valid_reactions = self._get_non_interactor_reactions()
+            reaction_species = reaction_species[
+                reaction_species[SBML_DFS.R_ID].isin(valid_reactions.index.values)
+            ]
+
+        rxn_sbo_term_counts = reaction_species.pivot_table(
+            index=SBML_DFS.R_ID, columns=SBML_DFS.SBO_TERM, aggfunc="size", fill_value=0
+        )
+
+        if name_terms:
+            # map columns sbo_terms to sbo_term_names
+            rxn_sbo_term_counts.columns = rxn_sbo_term_counts.columns.map(
+                MINI_SBO_TO_NAME
+            )
+
+        return rxn_sbo_term_counts
+
     def get_source_cooccurrence(
         self,
         entity_type: str,

--- a/src/tests/test_sbml_dfs_core.py
+++ b/src/tests/test_sbml_dfs_core.py
@@ -24,6 +24,8 @@ from napistu.constants import (
     SBOTERM_NAMES,
     SCHEMA_DEFS,
     SOURCE_SPEC,
+    VALID_SBO_TERM_NAMES,
+    VALID_SBO_TERMS,
 )
 from napistu.ingestion import sbml
 from napistu.ingestion.constants import (
@@ -1189,3 +1191,50 @@ def test_post_consensus_checks(sbml_dfs_metabolism):
             assert pd.api.types.is_numeric_dtype(
                 df.values
             ), f"Values for {entity_type}/{check_type} should be numeric"
+
+
+def test_get_sbo_term_occurrence(sbml_dfs_metabolism):
+    """Test get_sbo_term_occurrence method returns SBO term occurrence summary."""
+    # Test basic functionality
+    occurrence_df = sbml_dfs_metabolism.get_sbo_term_occurrence()
+
+    # Print dimensions for inspection
+    print(f"SBO term occurrence dimensions: {occurrence_df.shape}")
+    print(f"Columns: {list(occurrence_df.columns)}")
+
+    assert isinstance(occurrence_df, pd.DataFrame), "Should return a DataFrame"
+    assert occurrence_df.shape == (
+        86,
+        5,
+    ), f"Expected (86, 5), got {occurrence_df.shape}"
+
+    # Test that columns are valid SBO term names (default name_terms=True)
+    column_names = occurrence_df.columns.tolist()
+    assert all(
+        isinstance(col, str) for col in column_names
+    ), "Column names should be strings when name_terms=True"
+    assert all(
+        col in VALID_SBO_TERM_NAMES for col in column_names
+    ), f"All column names should be valid SBO term names. Got: {column_names}"
+
+    # Test with name_terms=False
+    occurrence_df_numeric = sbml_dfs_metabolism.get_sbo_term_occurrence(
+        name_terms=False
+    )
+    assert isinstance(occurrence_df_numeric, pd.DataFrame), "Should return a DataFrame"
+    assert occurrence_df_numeric.shape == (
+        86,
+        5,
+    ), f"Expected (86, 5), got {occurrence_df_numeric.shape}"
+
+    # Test that columns are valid SBO terms (numeric codes) when name_terms=False
+    column_terms = occurrence_df_numeric.columns.tolist()
+    assert all(
+        col in VALID_SBO_TERMS for col in column_terms
+    ), f"All column terms should be valid SBO terms. Got: {column_terms}"
+
+    # Values should be non-negative integers (counts)
+    assert (occurrence_df >= 0).all().all(), "All values should be non-negative"
+    assert occurrence_df.dtypes.apply(
+        lambda x: x.kind in "iu"
+    ).all(), "All values should be integers"

--- a/src/tests/test_sbml_dfs_core.py
+++ b/src/tests/test_sbml_dfs_core.py
@@ -1238,3 +1238,42 @@ def test_get_sbo_term_occurrence(sbml_dfs_metabolism):
     assert occurrence_df.dtypes.apply(
         lambda x: x.kind in "iu"
     ).all(), "All values should be integers"
+
+
+def test_get_sbo_term_x_source_cooccurrence(sbml_dfs_metabolism):
+    """Test get_sbo_term_x_source_cooccurrence method returns co-occurrence matrix."""
+    # Test basic functionality
+    cooccurrence_matrix = sbml_dfs_metabolism.get_sbo_term_x_source_cooccurrence()
+
+    # Verify the result is a DataFrame with correct data types
+    assert isinstance(cooccurrence_matrix, pd.DataFrame), "Should return a DataFrame"
+    assert cooccurrence_matrix.shape == (
+        5,
+        4,
+    ), f"Expected (5, 4), got {cooccurrence_matrix.shape}"
+    assert (cooccurrence_matrix >= 0).all().all(), "All values should be non-negative"
+    assert cooccurrence_matrix.dtypes.apply(
+        lambda x: pd.api.types.is_integer_dtype(x)
+    ).all(), "All values should be integers"
+
+    # Test that row names are valid SBO term names (default name_terms=True)
+    row_names = cooccurrence_matrix.index.tolist()
+    assert all(
+        name in VALID_SBO_TERM_NAMES for name in row_names
+    ), f"All row names should be valid SBO term names. Got: {row_names}"
+
+    # Test with name_terms=False
+    numeric_cooccurrence = sbml_dfs_metabolism.get_sbo_term_x_source_cooccurrence(
+        name_terms=False
+    )
+    assert isinstance(numeric_cooccurrence, pd.DataFrame), "Should return a DataFrame"
+    assert numeric_cooccurrence.shape == (
+        5,
+        4,
+    ), f"Expected (5, 4), got {numeric_cooccurrence.shape}"
+
+    # Test that row names are valid SBO terms (numeric codes) when name_terms=False
+    row_terms = numeric_cooccurrence.index.tolist()
+    assert all(
+        term in VALID_SBO_TERMS for term in row_terms
+    ), f"All row terms should be valid SBO terms. Got: {row_terms}"


### PR DESCRIPTION
- added guardrails to avoid 1-to-many matches when adding attributes to a graph since this would error is unexpected ways. Closes #221 
- Added SBO term occurrence and term x source cooccurrence methods to SBML_dfs. Closes #236 