### PR TITLE
pin max pydantic version s

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     numpy>=1.24.0,<3.0.0
     pandas>=1.5.0,<3.0.0
     pyarrow>=15.0.0,<20.0.0
-    pydantic>=2.0.0,<3.0.0
+    pydantic>=2.0.0,<2.12.0
     python-libsbml
     PyYAML>=6.0.0,<7.0.0
     omnipath


### PR DESCRIPTION
pin max pydantic version since new pydantic release 2.12 breaks the currently pinned version of FastMCP