### PR TITLE
Issue 342 - Added a pool vertex permutation null for network propagation

### DIFF
--- a/src/napistu/consensus.py
+++ b/src/napistu/consensus.py
@@ -1,3 +1,22 @@
+"""
+Creating a consensus model by merging shared entities across pathway models.
+
+Public Functions
+----------------
+construct_consensus_model(sbml_dfs_dict, pw_index, model_source=None, dogmatic=True, check_mergeability=True, no_rxn_pathway_ids=None) -> SBML_dfs:
+    Construct a Consensus Model by merging shared entities across pathway models.
+construct_meta_entities_fk(sbml_dfs_dict, pw_index, table="compartmentalized_species", fk_lookup_tables={}, extra_defining_attrs=[]) -> tuple[pd.DataFrame, pd.Series]:
+    Construct Meta Entities Defined by Foreign Keys
+construct_meta_entities_identifiers(sbml_dfs_dict, pw_index, table, fk_lookup_tables={}, defining_biological_qualifiers=BQB_DEFINING_ATTRS) -> tuple[pd.DataFrame, pd.Series]:
+    Construct meta-entities by merging entities across models that share identifiers.
+construct_meta_entities_members(sbml_dfs_dict, pw_index=None, table="reactions", defined_by="reaction_species", defined_lookup_tables={}, defining_attrs=[SC_ID, STOICHIOMETRY]) -> tuple[pd.DataFrame, pd.Series]:
+    Construct Meta Entities Defined by Membership
+construct_sbml_dfs_dict(pw_index, strict=True, verbose=False) -> dict[str, SBML_dfs]:
+    Construct a dictionary of SBML_dfs objects from a pathway index.
+prepare_consensus_model(sbml_dfs_list) -> tuple[dict[str, SBML_dfs], PWIndex]:
+    Prepare for creating a consensus model using a list of to-be-consolidated sbml_dfs objects.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/src/napistu/indices.py
+++ b/src/napistu/indices.py
@@ -1,3 +1,19 @@
+"""
+Pathway Index for organizing metadata and paths of pathway representations.
+
+Classes
+-------
+PWIndex
+    Pathway Index for organizing metadata and paths of pathway representations.
+
+Public Functions
+----------------
+adapt_pw_index(source, organismal_species, outdir=None, update_index=False) -> PWIndex:
+    Adapt a pathway index by filtering for specific organismal species.
+create_pathway_index_df(model_keys, model_urls, model_organismal_species, base_path, data_source, model_names=None, file_extension=".sbml") -> pd.DataFrame:
+    Create a pathway index DataFrame from model definitions.
+"""
+
 from __future__ import annotations
 
 import copy

--- a/src/napistu/network/constants.py
+++ b/src/napistu/network/constants.py
@@ -294,10 +294,11 @@ NET_PROPAGATION_DEFS = SimpleNamespace(PERSONALIZED_PAGERANK="personalized_pager
 
 # null distributions
 NULL_STRATEGIES = SimpleNamespace(
-    UNIFORM="uniform",
-    PARAMETRIC="parametric",
-    VERTEX_PERMUTATION="vertex_permutation",
     EDGE_PERMUTATION="edge_permutation",
+    PARAMETRIC="parametric",
+    POOLED_VERTEX_PERMUTATION="pooled_vertex_permutation",
+    UNIFORM="uniform",
+    VERTEX_PERMUTATION="vertex_permutation",
 )
 
 VALID_NULL_STRATEGIES = NULL_STRATEGIES.__dict__.values()

--- a/src/napistu/network/ig_utils.py
+++ b/src/napistu/network/ig_utils.py
@@ -672,8 +672,11 @@ def _get_attribute_masks(
         if mask_spec is None:
             masks[attr] = np.ones(n_nodes, dtype=bool)
         elif isinstance(mask_spec, str):
-            attr_values = np.array(graph.vs[mask_spec])
-            masks[attr] = attr_values > 0
+            attr_values = graph.vs[mask_spec]
+            masks[attr] = np.array(
+                [v is not None and v == v and v > 0 for v in attr_values],
+                dtype=bool,
+            )
         elif isinstance(mask_spec, np.ndarray):
             masks[attr] = mask_spec.astype(bool)
         elif isinstance(mask_spec, list):

--- a/src/napistu/network/net_propagation.py
+++ b/src/napistu/network/net_propagation.py
@@ -1,3 +1,30 @@
+"""
+Network propagation with null distribution testing.
+
+This module provides functions for propagating vertex attributes over a network
+(e.g. personalized PageRank) and testing observed scores against null distributions.
+Supported null strategies include vertex permutation, edge permutation, parametric,
+and uniform, enabling network-based significance testing for gene prioritization
+and related analyses.
+
+Public Functions
+----------------
+network_propagation_with_null(graph, attributes, null_strategy, ...)
+    Apply network propagation and compare observed scores to a null distribution.
+net_propagate_attributes(graph, attributes, propagation_method, ...)
+    Propagate multiple attributes over a network using a propagation method.
+uniform_null(graph, attributes, propagation_method, ...)
+    Generate uniform null distribution over masked nodes.
+parametric_null(graph, attributes, propagation_method, n_samples, ...)
+    Generate null by sampling from a fitted parametric distribution.
+vertex_permutation_null(graph, attributes, propagation_method, n_samples, ...)
+    Generate null by permuting vertex labels while preserving topology.
+edge_permutation_null(graph, attributes, propagation_method, n_samples, ...)
+    Generate null by rewiring edges while preserving degree distribution.
+get_null_generator(strategy)
+    Return the null generator function for a given strategy name.
+"""
+
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union

--- a/src/napistu/network/net_propagation.py
+++ b/src/napistu/network/net_propagation.py
@@ -13,16 +13,6 @@ network_propagation_with_null(graph, attributes, null_strategy, ...)
     Apply network propagation and compare observed scores to a null distribution.
 net_propagate_attributes(graph, attributes, propagation_method, ...)
     Propagate multiple attributes over a network using a propagation method.
-uniform_null(graph, attributes, propagation_method, ...)
-    Generate uniform null distribution over masked nodes.
-parametric_null(graph, attributes, propagation_method, n_samples, ...)
-    Generate null by sampling from a fitted parametric distribution.
-vertex_permutation_null(graph, attributes, propagation_method, n_samples, ...)
-    Generate null by permuting vertex labels while preserving topology.
-edge_permutation_null(graph, attributes, propagation_method, n_samples, ...)
-    Generate null by rewiring edges while preserving degree distribution.
-get_null_generator(strategy)
-    Return the null generator function for a given strategy name.
 """
 
 import logging
@@ -106,6 +96,11 @@ def network_propagation_with_null(
     draws from a distribution fit to the observed values. First fits a parametric distribution to the observed scores
     and then samples `n_samples` null samples for each vertex to compare observed to null quantiles.
 
+    **Pooled vertex permutation** ('pooled_vertex_permutation'): Vertex permutation of statistically exchangeable attribute
+    to pool null samples across attributes. This is much faster than vertex permutation since attribute-level permutations
+    are not performed but it is only valid when attributes are exchangeable and its only supported when all attributes share
+    an identical mask.
+
     Creating Masks
     --------------
     Most null strategies benefit from including a mask which indicates which nodes are being tested.
@@ -166,7 +161,7 @@ def network_propagation_with_null(
     )
 
     # 2. Get null generator function
-    null_generator = get_null_generator(null_strategy)
+    null_generator = _get_null_generator(null_strategy)
 
     # 3. Generate null distribution
     if null_strategy == NULL_STRATEGIES.UNIFORM:
@@ -259,81 +254,223 @@ def net_propagate_attributes(
     return pd.DataFrame(np.column_stack(results), index=names, columns=attributes)
 
 
-def uniform_null(
+# setup propagation methods
+
+
+def _pagerank_wrapper(graph: ig.Graph, attr_data: np.ndarray, **kwargs):
+    return graph.personalized_pagerank(reset=attr_data.tolist(), **kwargs)
+
+
+_pagerank_method = PropagationMethod(method=_pagerank_wrapper, non_negative=True)
+NET_PROPAGATION_METHODS: dict[str, PropagationMethod] = {
+    NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK: _pagerank_method
+}
+VALID_NET_PROPAGATION_METHODS = NET_PROPAGATION_METHODS.keys()
+
+
+def _ensure_propagation_method(
+    propagation_method: Union[str, PropagationMethod],
+) -> PropagationMethod:
+    if isinstance(propagation_method, str):
+        if propagation_method not in VALID_NET_PROPAGATION_METHODS:
+            raise ValueError(f"Invalid propagation method: {propagation_method}")
+        return NET_PROPAGATION_METHODS[propagation_method]
+    return propagation_method
+
+
+# other private methods
+
+
+def _build_pooled_universe(
+    graph: ig.Graph, attributes: List[str], mask: np.ndarray
+) -> np.ndarray:
+    """Collect all masked, non-zero values across all attributes into a single array."""
+    universe_parts = []
+    for attr in attributes:
+        attr_values = np.array(graph.vs[attr])
+        masked_values = attr_values[mask]
+        universe_parts.append(masked_values[masked_values > 0])
+
+    universe = np.concatenate(universe_parts)
+
+    if len(universe) == 0:
+        raise ValueError(
+            "No non-zero values found across any attribute within the mask. "
+            "Cannot construct pooled universe."
+        )
+
+    return universe
+
+
+def _edge_permutation_null(
     graph: ig.Graph,
     attributes: List[str],
     propagation_method: Union[
         str, PropagationMethod
     ] = NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK,
     additional_propagation_args: Optional[dict] = None,
-    mask: Optional[Union[str, np.ndarray, List, Dict]] = MASK_KEYWORDS.ATTR,
+    burn_in_ratio: float = 10,
+    sampling_ratio: float = 0.1,
+    n_samples: int = 100,
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generate uniform null distribution over masked nodes and apply propagation method.
+    Generate null distribution by edge rewiring and apply propagation method.
 
     Parameters
     ----------
     graph : ig.Graph
         Input graph.
     attributes : List[str]
-        Attribute names to generate nulls for.
-    propagation_method : str
+        Attribute names to use (values unchanged by rewiring).
+    propagation_method : str or PropagationMethod
         Network propagation method to apply.
     additional_propagation_args : dict, optional
         Additional arguments to pass to the network propagation method.
-    mask : str, np.ndarray, List, Dict, or None
-        Mask specification. Default is "attr" (use each attribute as its own mask).
+    burn_in_ratio : float
+        Multiplier for initial rewiring.
+    sampling_ratio : float
+        Proportion of edges to rewire between samples.
+    n_samples : int
+        Number of null samples to generate.
     verbose : bool, optional
         Extra reporting. Default is False.
 
     Returns
     -------
     pd.DataFrame
-        Propagated null sample with uniform distribution over masked nodes.
-        Shape: (n_nodes, n_attributes)
+        Propagated null samples from rewired network.
+        Shape: (n_samples * n_nodes, n_attributes)
     """
 
     # Validate attributes
     propagation_method = _ensure_propagation_method(propagation_method)
     _validate_vertex_attributes(graph, attributes, propagation_method)
 
-    # Parse mask input
-    mask_specs = _parse_mask_input(mask, attributes, verbose=verbose)
-    masks = _get_attribute_masks(graph, mask_specs)
-
-    # Create null graph with uniform attributes
-    # we'll use these updated attributes when calling net_propagate_attributes() below
+    # Setup rewired graph
     null_graph = graph.copy()
+    n_edges = len(null_graph.es)
 
-    for _, attr in enumerate(attributes):
-        attr_mask = masks[attr]
-        n_masked = attr_mask.sum()
+    # Initial burn-in
+    null_graph.rewire(n=burn_in_ratio * n_edges)
 
-        if n_masked == 0:
-            raise ValueError(f"No nodes in mask for attribute '{attr}'")
-
-        # Check for constant attribute values when mask is the same as attribute
-        if isinstance(mask_specs[attr], str) and mask_specs[attr] == attr:
-            attr_values = np.array(graph.vs[attr])
-            nonzero_values = attr_values[attr_values > 0]
-            if len(np.unique(nonzero_values)) == 1:
-                logger.warning(
-                    f"Attribute '{attr}' has constant non-zero values, uniform null may not be meaningful."
-                )
-
-        # Set uniform values for masked nodes
-        null_attr_values = np.zeros(graph.vcount())
-        null_attr_values[attr_mask] = 1.0 / n_masked
-        null_graph.vs[attr] = null_attr_values.tolist()
-
-    # Apply propagation method to null graph
-    return net_propagate_attributes(
-        null_graph, attributes, propagation_method, additional_propagation_args
+    # Get node names
+    node_names = (
+        graph.vs[NAPISTU_GRAPH_VERTICES.NAME]
+        if NAPISTU_GRAPH_VERTICES.NAME in graph.vs.attributes()
+        else list(range(graph.vcount()))
     )
 
+    # Pre-allocate for results
+    all_results = []
 
-def parametric_null(
+    # Generate samples
+    for _ in range(n_samples):
+        # Incremental rewiring
+        null_graph.rewire(n=int(sampling_ratio * n_edges))
+
+        # Apply propagation method to rewired graph (attributes unchanged)
+        result = net_propagate_attributes(
+            null_graph, attributes, propagation_method, additional_propagation_args
+        )
+        all_results.append(result)
+
+    # Combine all results
+    full_index = node_names * n_samples
+    all_data = np.vstack([result.values for result in all_results])
+
+    return pd.DataFrame(all_data, index=full_index, columns=attributes)
+
+
+def _fit_distribution_parameters(
+    graph: ig.Graph,
+    attributes: List[str],
+    masks: Dict[str, np.ndarray],
+    distribution: Any,
+    fit_kwargs: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    """Fit distribution parameters for each attribute using masked data."""
+    params = {}
+
+    for attr in attributes:
+        attr_mask = masks[attr]
+        attr_values = np.array(graph.vs[attr])
+        masked_values = attr_values[attr_mask]
+        masked_nonzero = masked_values[masked_values > 0]
+
+        if len(masked_nonzero) == 0:
+            raise ValueError(f"No nonzero values in mask for attribute '{attr}'")
+
+        try:
+            # Let SciPy handle parameter estimation and validation
+            fitted_params = distribution.fit(masked_nonzero, **fit_kwargs)
+
+            params[attr] = {
+                "fitted_params": fitted_params,
+                "mask": attr_mask,
+                "distribution": distribution,
+            }
+
+        except Exception as e:
+            dist_name = (
+                distribution.name
+                if hasattr(distribution, "name")
+                else str(distribution)
+            )
+            raise ValueError(
+                f"Failed to fit {dist_name} distribution to attribute '{attr}': {str(e)}"
+            )
+
+    return params
+
+
+def _generate_parametric_null_sample(
+    null_graph: ig.Graph,
+    attributes: List[str],
+    params: Dict[str, Dict[str, Any]],
+    ensure_nonnegative: bool,
+) -> None:
+    """Generate one null sample by modifying graph attributes in-place."""
+    for attr in attributes:
+        attr_mask = params[attr]["mask"]
+        fitted_params = params[attr]["fitted_params"]
+        distribution = params[attr]["distribution"]
+
+        # Generate values for masked nodes using fitted distribution
+        null_attr_values = np.zeros(null_graph.vcount())
+        n_masked = attr_mask.sum()
+
+        # Sample from fitted distribution
+        sampled_values = distribution.rvs(*fitted_params, size=n_masked)
+
+        # Ensure non-negative if requested (common for PageRank)
+        if ensure_nonnegative:
+            # warning if there are negative samples since this suggests that the wrong
+            # distribution is being used
+            if np.any(sampled_values < 0):
+                logger.warning(
+                    f"Negative samples for attribute '{attr}' suggest that the wrong distribution is being used"
+                )
+            sampled_values = np.maximum(sampled_values, 0)
+
+        null_attr_values[attr_mask] = sampled_values
+        null_graph.vs[attr] = null_attr_values.tolist()
+
+
+def _get_distribution_object(distribution: Union[str, Any]) -> Any:
+    """Get scipy.stats distribution object from string name or object."""
+    if isinstance(distribution, str):
+        try:
+            return getattr(stats, distribution)
+        except AttributeError:
+            raise ValueError(
+                f"Unknown distribution: '{distribution}'. "
+                f"Must be a valid scipy.stats distribution name."
+            )
+    return distribution
+
+
+def _parametric_null(
     graph: ig.Graph,
     attributes: List[str],
     propagation_method: Union[
@@ -449,7 +586,221 @@ def parametric_null(
     return pd.DataFrame(all_data, index=full_index, columns=attributes)
 
 
-def vertex_permutation_null(
+def _pooled_vertex_permutation_null(
+    graph: ig.Graph,
+    attributes: List[str],
+    propagation_method: Union[
+        str, PropagationMethod
+    ] = NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK,
+    additional_propagation_args: Optional[dict] = None,
+    mask: Optional[Union[str, np.ndarray, List, Dict]] = MASK_KEYWORDS.ATTR,
+    n_samples: int = 100,
+    verbose: bool = False,
+) -> pd.DataFrame:
+    """
+    Generate null distribution by sampling from a pooled empirical universe across
+    all attributes and applying the propagation method.
+
+    Rather than permuting each attribute independently (as in vertex_permutation_null),
+    this strategy constructs a single empirical universe by merging all masked, non-zero
+    values across all attributes. Each null sample draws from this universe once,
+    propagates a single synthetic attribute vector, and broadcasts the result across
+    all attribute columns.
+
+    This reduces propagation calls from n_attributes * n_samples to n_samples,
+    making it suitable for large attribute sets (e.g. 200+ patient-level summaries).
+
+    Assumptions
+    -----------
+    All attributes must share an identical mask. Attributes are assumed to be
+    exchangeable and on comparable scales — this is a caller contract, not validated
+    beyond mask equality. If attributes have meaningfully different scales or
+    interpretations, pooling is not appropriate and vertex_permutation_null should
+    be used instead.
+
+    Parameters
+    ----------
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        Attribute names to generate nulls for. All must share the same mask.
+    propagation_method : str or PropagationMethod
+        Network propagation method to apply.
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to the network propagation method.
+    mask : str, np.ndarray, List, Dict, or None
+        Mask specification. Default is "attr" (use each attribute as its own mask).
+        All attributes must resolve to the same mask.
+    n_samples : int
+        Number of null samples to generate.
+    verbose : bool, optional
+        Extra reporting. Default is False.
+
+    Returns
+    -------
+    pd.DataFrame
+        Propagated null samples with shape (n_samples * n_nodes, n_attributes).
+        Each block of n_nodes rows corresponds to one null sample, with the same
+        propagated vector broadcast across all attribute columns.
+    """
+    # Validate attributes
+    propagation_method = _ensure_propagation_method(propagation_method)
+    _validate_vertex_attributes(graph, attributes, propagation_method)
+
+    # Parse and validate masks - all attributes must share the same mask
+    mask_specs = _parse_mask_input(mask, attributes, verbose=verbose)
+    masks = _get_attribute_masks(graph, mask_specs)
+
+    _validate_masks_identical(masks, attributes)
+    shared_mask = masks[attributes[0]]
+
+    # Build empirical universe from all masked, non-zero values across all attributes
+    universe = _build_pooled_universe(graph, attributes, shared_mask)
+
+    # Get node names
+    node_names = (
+        graph.vs[NAPISTU_GRAPH_VERTICES.NAME]
+        if NAPISTU_GRAPH_VERTICES.NAME in graph.vs.attributes()
+        else list(range(graph.vcount()))
+    )
+
+    null_graph = graph.copy()
+    # Use a single synthetic attribute name to avoid collisions
+    _POOLED_ATTR = "__pooled_null__"
+    all_results = []
+
+    n_masked = shared_mask.sum()
+
+    for _ in range(n_samples):
+        # Sample from empirical universe with replacement
+        sampled_values = np.random.choice(universe, size=n_masked, replace=True)
+
+        null_attr_values = np.zeros(graph.vcount())
+        null_attr_values[shared_mask] = sampled_values
+        null_graph.vs[_POOLED_ATTR] = null_attr_values.tolist()
+
+        # Single propagation per sample
+        result = net_propagate_attributes(
+            null_graph, [_POOLED_ATTR], propagation_method, additional_propagation_args
+        )
+
+        # Broadcast single propagated vector across all attribute columns
+        propagated = result[_POOLED_ATTR].values
+        broadcast = np.column_stack([propagated] * len(attributes))
+        all_results.append(broadcast)
+
+    full_index = node_names * n_samples
+    all_data = np.vstack(all_results)
+
+    return pd.DataFrame(all_data, index=full_index, columns=attributes)
+
+
+def _uniform_null(
+    graph: ig.Graph,
+    attributes: List[str],
+    propagation_method: Union[
+        str, PropagationMethod
+    ] = NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK,
+    additional_propagation_args: Optional[dict] = None,
+    mask: Optional[Union[str, np.ndarray, List, Dict]] = MASK_KEYWORDS.ATTR,
+    verbose: bool = False,
+) -> pd.DataFrame:
+    """
+    Generate uniform null distribution over masked nodes and apply propagation method.
+
+    Parameters
+    ----------
+    graph : ig.Graph
+        Input graph.
+    attributes : List[str]
+        Attribute names to generate nulls for.
+    propagation_method : str
+        Network propagation method to apply.
+    additional_propagation_args : dict, optional
+        Additional arguments to pass to the network propagation method.
+    mask : str, np.ndarray, List, Dict, or None
+        Mask specification. Default is "attr" (use each attribute as its own mask).
+    verbose : bool, optional
+        Extra reporting. Default is False.
+
+    Returns
+    -------
+    pd.DataFrame
+        Propagated null sample with uniform distribution over masked nodes.
+        Shape: (n_nodes, n_attributes)
+    """
+
+    # Validate attributes
+    propagation_method = _ensure_propagation_method(propagation_method)
+    _validate_vertex_attributes(graph, attributes, propagation_method)
+
+    # Parse mask input
+    mask_specs = _parse_mask_input(mask, attributes, verbose=verbose)
+    masks = _get_attribute_masks(graph, mask_specs)
+
+    # Create null graph with uniform attributes
+    # we'll use these updated attributes when calling net_propagate_attributes() below
+    null_graph = graph.copy()
+
+    for _, attr in enumerate(attributes):
+        attr_mask = masks[attr]
+        n_masked = attr_mask.sum()
+
+        if n_masked == 0:
+            raise ValueError(f"No nodes in mask for attribute '{attr}'")
+
+        # Check for constant attribute values when mask is the same as attribute
+        if isinstance(mask_specs[attr], str) and mask_specs[attr] == attr:
+            attr_values = np.array(graph.vs[attr])
+            nonzero_values = attr_values[attr_values > 0]
+            if len(np.unique(nonzero_values)) == 1:
+                logger.warning(
+                    f"Attribute '{attr}' has constant non-zero values, uniform null may not be meaningful."
+                )
+
+        # Set uniform values for masked nodes
+        null_attr_values = np.zeros(graph.vcount())
+        null_attr_values[attr_mask] = 1.0 / n_masked
+        null_graph.vs[attr] = null_attr_values.tolist()
+
+    # Apply propagation method to null graph
+    return net_propagate_attributes(
+        null_graph, attributes, propagation_method, additional_propagation_args
+    )
+
+
+def _validate_masks_identical(
+    masks: Dict[str, np.ndarray], attributes: List[str]
+) -> None:
+    """Validate that all attribute masks are identical."""
+    reference = masks[attributes[0]]
+    for attr in attributes[1:]:
+        if not np.array_equal(reference, masks[attr]):
+            raise ValueError(
+                f"Attribute '{attr}' has a different mask than '{attributes[0]}'. "
+                "pooled_vertex_permutation_null requires all attributes to share "
+                "an identical mask. Consider running vertex_permutation_null "
+                "separately per mask group."
+            )
+
+
+def _validate_vertex_attributes(
+    graph: ig.Graph, attributes: List[str], propagation_method: str
+) -> None:
+    """Validate vertex attributes for propagation method."""
+
+    propagation_method = _ensure_propagation_method(propagation_method)
+
+    # check that the attributes are numeric and non-negative if required
+    for attr in attributes:
+        _ = _ensure_valid_attribute(
+            graph, attr, non_negative=propagation_method.non_negative
+        )
+
+    return None
+
+
+def _vertex_permutation_null(
     graph: ig.Graph,
     attributes: List[str],
     propagation_method: Union[
@@ -552,225 +903,20 @@ def vertex_permutation_null(
     return pd.DataFrame(all_data, index=full_index, columns=attributes)
 
 
-def edge_permutation_null(
-    graph: ig.Graph,
-    attributes: List[str],
-    propagation_method: Union[
-        str, PropagationMethod
-    ] = NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK,
-    additional_propagation_args: Optional[dict] = None,
-    burn_in_ratio: float = 10,
-    sampling_ratio: float = 0.1,
-    n_samples: int = 100,
-    verbose: bool = False,
-) -> pd.DataFrame:
-    """
-    Generate null distribution by edge rewiring and apply propagation method.
-
-    Parameters
-    ----------
-    graph : ig.Graph
-        Input graph.
-    attributes : List[str]
-        Attribute names to use (values unchanged by rewiring).
-    propagation_method : str or PropagationMethod
-        Network propagation method to apply.
-    additional_propagation_args : dict, optional
-        Additional arguments to pass to the network propagation method.
-    burn_in_ratio : float
-        Multiplier for initial rewiring.
-    sampling_ratio : float
-        Proportion of edges to rewire between samples.
-    n_samples : int
-        Number of null samples to generate.
-    verbose : bool, optional
-        Extra reporting. Default is False.
-
-    Returns
-    -------
-    pd.DataFrame
-        Propagated null samples from rewired network.
-        Shape: (n_samples * n_nodes, n_attributes)
-    """
-
-    # Validate attributes
-    propagation_method = _ensure_propagation_method(propagation_method)
-    _validate_vertex_attributes(graph, attributes, propagation_method)
-
-    # Setup rewired graph
-    null_graph = graph.copy()
-    n_edges = len(null_graph.es)
-
-    # Initial burn-in
-    null_graph.rewire(n=burn_in_ratio * n_edges)
-
-    # Get node names
-    node_names = (
-        graph.vs[NAPISTU_GRAPH_VERTICES.NAME]
-        if NAPISTU_GRAPH_VERTICES.NAME in graph.vs.attributes()
-        else list(range(graph.vcount()))
-    )
-
-    # Pre-allocate for results
-    all_results = []
-
-    # Generate samples
-    for _ in range(n_samples):
-        # Incremental rewiring
-        null_graph.rewire(n=int(sampling_ratio * n_edges))
-
-        # Apply propagation method to rewired graph (attributes unchanged)
-        result = net_propagate_attributes(
-            null_graph, attributes, propagation_method, additional_propagation_args
-        )
-        all_results.append(result)
-
-    # Combine all results
-    full_index = node_names * n_samples
-    all_data = np.vstack([result.values for result in all_results])
-
-    return pd.DataFrame(all_data, index=full_index, columns=attributes)
-
-
 # Null generator registry
 NULL_GENERATORS = {
-    NULL_STRATEGIES.UNIFORM: uniform_null,
-    NULL_STRATEGIES.PARAMETRIC: parametric_null,
-    NULL_STRATEGIES.VERTEX_PERMUTATION: vertex_permutation_null,
-    NULL_STRATEGIES.EDGE_PERMUTATION: edge_permutation_null,
+    NULL_STRATEGIES.EDGE_PERMUTATION: _edge_permutation_null,
+    NULL_STRATEGIES.PARAMETRIC: _parametric_null,
+    NULL_STRATEGIES.POOLED_VERTEX_PERMUTATION: _pooled_vertex_permutation_null,
+    NULL_STRATEGIES.UNIFORM: _uniform_null,
+    NULL_STRATEGIES.VERTEX_PERMUTATION: _vertex_permutation_null,
 }
 
 
-def get_null_generator(strategy: str):
+def _get_null_generator(strategy: str):
     """Get null generator function by name."""
     if strategy not in VALID_NULL_STRATEGIES:
         raise ValueError(
             f"Unknown null strategy: {strategy}. Available: {VALID_NULL_STRATEGIES}"
         )
     return NULL_GENERATORS[strategy]
-
-
-def _get_distribution_object(distribution: Union[str, Any]) -> Any:
-    """Get scipy.stats distribution object from string name or object."""
-    if isinstance(distribution, str):
-        try:
-            return getattr(stats, distribution)
-        except AttributeError:
-            raise ValueError(
-                f"Unknown distribution: '{distribution}'. "
-                f"Must be a valid scipy.stats distribution name."
-            )
-    return distribution
-
-
-def _fit_distribution_parameters(
-    graph: ig.Graph,
-    attributes: List[str],
-    masks: Dict[str, np.ndarray],
-    distribution: Any,
-    fit_kwargs: Dict[str, Any],
-) -> Dict[str, Dict[str, Any]]:
-    """Fit distribution parameters for each attribute using masked data."""
-    params = {}
-
-    for attr in attributes:
-        attr_mask = masks[attr]
-        attr_values = np.array(graph.vs[attr])
-        masked_values = attr_values[attr_mask]
-        masked_nonzero = masked_values[masked_values > 0]
-
-        if len(masked_nonzero) == 0:
-            raise ValueError(f"No nonzero values in mask for attribute '{attr}'")
-
-        try:
-            # Let SciPy handle parameter estimation and validation
-            fitted_params = distribution.fit(masked_nonzero, **fit_kwargs)
-
-            params[attr] = {
-                "fitted_params": fitted_params,
-                "mask": attr_mask,
-                "distribution": distribution,
-            }
-
-        except Exception as e:
-            dist_name = (
-                distribution.name
-                if hasattr(distribution, "name")
-                else str(distribution)
-            )
-            raise ValueError(
-                f"Failed to fit {dist_name} distribution to attribute '{attr}': {str(e)}"
-            )
-
-    return params
-
-
-def _generate_parametric_null_sample(
-    null_graph: ig.Graph,
-    attributes: List[str],
-    params: Dict[str, Dict[str, Any]],
-    ensure_nonnegative: bool,
-) -> None:
-    """Generate one null sample by modifying graph attributes in-place."""
-    for attr in attributes:
-        attr_mask = params[attr]["mask"]
-        fitted_params = params[attr]["fitted_params"]
-        distribution = params[attr]["distribution"]
-
-        # Generate values for masked nodes using fitted distribution
-        null_attr_values = np.zeros(null_graph.vcount())
-        n_masked = attr_mask.sum()
-
-        # Sample from fitted distribution
-        sampled_values = distribution.rvs(*fitted_params, size=n_masked)
-
-        # Ensure non-negative if requested (common for PageRank)
-        if ensure_nonnegative:
-            # warning if there are negative samples since this suggests that the wrong
-            # distribution is being used
-            if np.any(sampled_values < 0):
-                logger.warning(
-                    f"Negative samples for attribute '{attr}' suggest that the wrong distribution is being used"
-                )
-            sampled_values = np.maximum(sampled_values, 0)
-
-        null_attr_values[attr_mask] = sampled_values
-        null_graph.vs[attr] = null_attr_values.tolist()
-
-
-def _validate_vertex_attributes(
-    graph: ig.Graph, attributes: List[str], propagation_method: str
-) -> None:
-    """Validate vertex attributes for propagation method."""
-
-    propagation_method = _ensure_propagation_method(propagation_method)
-
-    # check that the attributes are numeric and non-negative if required
-    for attr in attributes:
-        _ = _ensure_valid_attribute(
-            graph, attr, non_negative=propagation_method.non_negative
-        )
-
-    return None
-
-
-def _pagerank_wrapper(graph: ig.Graph, attr_data: np.ndarray, **kwargs):
-    return graph.personalized_pagerank(reset=attr_data.tolist(), **kwargs)
-
-
-_pagerank_method = PropagationMethod(method=_pagerank_wrapper, non_negative=True)
-
-NET_PROPAGATION_METHODS: dict[str, PropagationMethod] = {
-    NET_PROPAGATION_DEFS.PERSONALIZED_PAGERANK: _pagerank_method
-}
-VALID_NET_PROPAGATION_METHODS = NET_PROPAGATION_METHODS.keys()
-
-
-def _ensure_propagation_method(
-    propagation_method: Union[str, PropagationMethod],
-) -> PropagationMethod:
-    if isinstance(propagation_method, str):
-        if propagation_method not in VALID_NET_PROPAGATION_METHODS:
-            raise ValueError(f"Invalid propagation method: {propagation_method}")
-        return NET_PROPAGATION_METHODS[propagation_method]
-    return propagation_method

--- a/src/napistu/network/ng_core.py
+++ b/src/napistu/network/ng_core.py
@@ -2218,12 +2218,18 @@ class NapistuGraph(ig.Graph):
             )
 
         # Remove overlapping attributes from graph_df if overwrite=True to avoid _x/_y suffixes
-        if overwrite:
-            overlapping_in_graph = [
-                attr for attr in attrs_to_add if attr in graph_df.columns
-            ]
-            if overlapping_in_graph:
+        overlapping_in_graph = [
+            attr for attr in attrs_to_add if attr in graph_df.columns
+        ]
+        if overlapping_in_graph:
+            if overwrite:
                 graph_df = graph_df.drop(columns=overlapping_in_graph)
+            else:
+                raise ValueError(
+                    f"Cannot add entity data: attributes {overlapping_in_graph} already exist "
+                    f"on graph {target_entity}. Use overwrite=True to replace them, or exclude "
+                    f"these attributes from entity_data."
+                )
 
         # Merge entity data with graph data
         graph_with_attrs = graph_df.merge(

--- a/src/napistu/network/ng_core.py
+++ b/src/napistu/network/ng_core.py
@@ -1,14 +1,19 @@
+"""Core graph class for molecular network analysis.
+
+Classes
+-------
+NapistuGraph
+    Core graph class for molecular network analysis.
+"""
+
 from __future__ import annotations
 
 import copy
 import logging
-from typing import TYPE_CHECKING, Any, List, Mapping, MutableMapping, Optional, Union
+from typing import Any, List, Mapping, MutableMapping, Optional, Union
 
 import igraph as ig
 import pandas as pd
-
-if TYPE_CHECKING:
-    pass
 
 from napistu import utils
 from napistu.constants import (
@@ -42,6 +47,7 @@ from napistu.network.constants import (
     WEIGHTING_SPEC,
 )
 from napistu.sbml_dfs_core import SBML_dfs
+from napistu.utils.pd_utils import series_to_none_filled_list
 
 logger = logging.getLogger(__name__)
 
@@ -2234,9 +2240,13 @@ class NapistuGraph(ig.Graph):
         added_count = 0
         for attr_name in attrs_to_add:
             if target_entity == NAPISTU_GRAPH.EDGES:
-                self.es[attr_name] = graph_with_attrs[attr_name].values
+                self.es[attr_name] = series_to_none_filled_list(
+                    graph_with_attrs[attr_name]
+                )
             else:  # vertices
-                self.vs[attr_name] = graph_with_attrs[attr_name].values
+                self.vs[attr_name] = series_to_none_filled_list(
+                    graph_with_attrs[attr_name]
+                )
             added_count += 1
 
         # Log the results

--- a/src/napistu/sbml_dfs_utils.py
+++ b/src/napistu/sbml_dfs_utils.py
@@ -1,3 +1,48 @@
+"""
+Utilities supporting creation and manipulation of SBML_dfs instances.
+
+Public Functions
+----------------
+add_missing_ids_column(contingency_table, reference_table, other_column_name="other") -> pd.DataFrame:
+    Add an 'other' column to a contingency table for IDs that exist in a reference table but are missing from the contingency table.
+add_sbo_role(reaction_species) -> pd.DataFrame:
+    Add an sbo_role column to the reaction_species table.
+check_entity_data_index_matching(sbml_dfs, table) -> sbml_dfs:
+    Update the input smbl_dfs's entity_data (dict) index with match_entitydata_index_to_entity, so that index for dataframe(s) in entity_data (dict) matches the sbml_dfs' corresponding entity, and then passes sbml_dfs.validate()
+construct_formula_string(reaction_species_df, reactions_df, name_var) -> str:
+    Construct Formula String
+create_reaction_formula_series(reaction_data, reactions_df, species_name_col, sort_cols, group_cols=None, add_compartment_prefix=False, r_id_col=SBML_DFS.R_ID, c_name_col=SBML_DFS.C_NAME) -> pd.Series:
+    Create a pd.Series of reaction formula strings.
+display_post_consensus_checks(checks_results) -> None:
+    Display post-consensus checks results.
+find_underspecified_reactions(reaction_species_w_roles) -> pd.DataFrame:
+    Find underspecified reactions in a reaction_species table.
+find_unused_entities(sbml_dfs_or_dict) -> dict[str, set[str]]:
+    Find unused entities in a SBML_dfs or dict of SBML_dfs instances.
+filter_to_characteristic_species_ids(species_ids, max_complex_size=4, max_promiscuity=20, defining_biological_qualifiers=BQB_DEFINING_ATTRS) -> pd.DataFrame:
+    Filter to characteristic species IDs.
+force_edgelist_consistency(interaction_edgelist, species_df, compartments_df) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    Force edgelist consistency.
+format_sbml_dfs_summary(data) -> str:
+    Format a summary of a SBML_dfs instance.
+get_current_max_id(sbml_dfs_table) -> int:
+    Get the current maximum ID for a given SBML_dfs table.
+id_formatter(input_vals, id_type, id_len=8) -> pd.Series:
+    Format a list of input values as a series of identifiers.
+id_formatter_inv(ids) -> list:
+    Invert the id_formatter function.
+match_entitydata_index_to_entity(entity_data_dict, an_entity_data_type, consensus_entity_df, entity_schema, table) -> pd.DataFrame:
+    Match the index of an entity data dictionary to the index of a consensus entity DataFrame.
+species_type_types(x, ontology_to_species_type=ONTOLOGY_TO_SPECIES_TYPE, prioritized_species_types=PRIORITIZED_SPECIES_TYPES) -> str:
+    Determine the species type of a given entity.
+stub_compartments(stubbed_compartment=GENERIC_COMPARTMENT, with_source=False) -> pd.DataFrame:
+    Stub compartments in a SBML_dfs instance.
+unnest_identifiers(id_table, id_var) -> pd.DataFrame:
+    Unnest identifiers from a table.
+validate_sbml_dfs_table(df, table) -> None:
+    Validate that a DataFrame is a valid SBML_dfs table.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/src/napistu/utils/pd_utils.py
+++ b/src/napistu/utils/pd_utils.py
@@ -22,6 +22,8 @@ matrix_to_edgelist(matrix: np.ndarray, row_labels: Optional[List] = None, col_la
     Convert a matrix to an edgelist format.
 safe_series_tolist(x: str | pd.Series) -> list:
     Convert either a list or str to a list.
+series_to_none_filled_list(series: pd.Series) -> list:
+    Convert a pandas Series to a Python list, replacing all NA-like values with None.
 style_df(df: pd.DataFrame, headers: Union[str, list[str], None] = "keys", hide_index: bool = False) -> Styler:
     Style a pandas DataFrame with simple formatting options.
 update_pathological_names(names: pd.Series, prefix: str) -> pd.Series:
@@ -369,6 +371,27 @@ def safe_series_tolist(x):
         return x.tolist()
     else:
         raise TypeError(f"x was a {type(x)} but only str and pd.Series are supported")
+
+
+def series_to_none_filled_list(series: pd.Series) -> list:
+    """
+    Convert a pandas Series to a Python list, replacing all NA-like values with None.
+
+    Pandas represents missing values as NaN (a float) in numeric Series, but many
+    downstream consumers (e.g. igraph, JSON serialization) expect None for missing
+    values. This function normalizes missing values consistently across all dtypes.
+
+    Parameters
+    ----------
+    series : pd.Series
+        The Series to convert. May be any dtype.
+
+    Returns
+    -------
+    list
+        Python list with NaN, pd.NA, and other NA-like values replaced by None.
+    """
+    return series.astype(object).where(series.notna(), other=None).tolist()
 
 
 def style_df(

--- a/src/tests/test_network_net_propagation.py
+++ b/src/tests/test_network_net_propagation.py
@@ -9,12 +9,12 @@ from napistu.network.constants import (
 )
 from napistu.network.net_propagation import (
     NULL_GENERATORS,
-    edge_permutation_null,
+    _edge_permutation_null,
+    _parametric_null,
+    _uniform_null,
+    _vertex_permutation_null,
     net_propagate_attributes,
     network_propagation_with_null,
-    parametric_null,
-    uniform_null,
-    vertex_permutation_null,
 )
 
 
@@ -123,7 +123,34 @@ def test_network_propagation_with_null():
     assert isinstance(result_masked, pd.DataFrame)
     assert result_masked.shape == (5, 1)
 
-    # Test 7: Error handling - invalid null strategy
+    # Test 7: Pooled vertex permutation PPR null (requires shared mask, multiple attributes)
+    graph_pooled = ig.Graph(5)
+    graph_pooled.vs[NAPISTU_GRAPH_VERTICES.NAME] = ["A", "B", "C", "D", "E"]
+    graph_pooled.vs["attr1"] = [1.0, 0.0, 2.0, 0.0, 1.5]
+    graph_pooled.vs["attr2"] = [
+        0.5,
+        0.0,
+        1.0,
+        0.0,
+        2.0,
+    ]  # Same mask pattern (nonzero where attr1 nonzero)
+    graph_pooled.add_edges([(0, 1), (1, 2), (2, 3), (3, 4)])
+    shared_mask = np.array([True, False, True, False, True])
+    result_pooled = network_propagation_with_null(
+        graph_pooled,
+        ["attr1", "attr2"],
+        null_strategy=NULL_STRATEGIES.POOLED_VERTEX_PERMUTATION,
+        n_samples=10,
+        mask=shared_mask,
+    )
+    assert isinstance(result_pooled, pd.DataFrame)
+    assert result_pooled.shape == (5, 2)
+    assert list(result_pooled.columns) == ["attr1", "attr2"]
+    pooled_values = result_pooled.values[~np.isnan(result_pooled.values)]
+    assert (pooled_values >= 0).all(), "Quantiles should be >= 0"
+    assert (pooled_values <= 1).all(), "Quantiles should be <= 1"
+
+    # Test 8: Error handling - invalid null strategy
     with pytest.raises(ValueError, match="Unknown null strategy"):
         network_propagation_with_null(
             graph, attributes, null_strategy="invalid_strategy"
@@ -204,6 +231,10 @@ def test_all_null_generators_structure():
     n_samples = 3  # Small for testing
 
     for generator_name, generator_func in NULL_GENERATORS.items():
+
+        if generator_name == NULL_STRATEGIES.POOLED_VERTEX_PERMUTATION:
+            continue  # not supported because the attributes have different masks
+
         print(f"Testing {generator_name}")
 
         if generator_name == NULL_STRATEGIES.UNIFORM:
@@ -321,32 +352,32 @@ def test_edge_cases_and_errors():
 
     # Test 1: All zero attribute should raise error for all generators
     with pytest.raises(ValueError):
-        uniform_null(graph, ["bad_attr"])
+        _uniform_null(graph, ["bad_attr"])
 
     with pytest.raises(ValueError):
-        parametric_null(graph, ["bad_attr"])
+        _parametric_null(graph, ["bad_attr"])
 
     with pytest.raises(ValueError):
-        vertex_permutation_null(graph, ["bad_attr"])
+        _vertex_permutation_null(graph, ["bad_attr"])
 
     with pytest.raises(ValueError):
-        edge_permutation_null(graph, ["bad_attr"])
+        _edge_permutation_null(graph, ["bad_attr"])
 
     # Test 2: Empty mask should raise error
     empty_mask = np.array([False, False, False])
     with pytest.raises(ValueError, match="No nodes in mask"):
-        uniform_null(graph, ["attr1"], mask=empty_mask)
+        _uniform_null(graph, ["attr1"], mask=empty_mask)
 
     # Test 3: Single node mask (edge case)
     single_mask = np.array([True, False, False])
-    result = uniform_null(graph, ["attr1"], mask=single_mask)
+    result = _uniform_null(graph, ["attr1"], mask=single_mask)
     assert result.shape == (3, 1)  # Should work
 
     # Test 4: Replace parameter in node permutation
-    result_no_replace = vertex_permutation_null(
+    result_no_replace = _vertex_permutation_null(
         graph, ["attr1"], replace=False, n_samples=2
     )
-    result_replace = vertex_permutation_null(
+    result_replace = _vertex_permutation_null(
         graph, ["attr1"], replace=True, n_samples=2
     )
 
@@ -362,8 +393,8 @@ def test_propagation_method_parameters():
     graph.add_edges([(0, 1), (1, 2), (2, 3)])
 
     # Test different damping parameters produce different results
-    result_default = uniform_null(graph, ["attr1"])
-    result_damped = uniform_null(
+    result_default = _uniform_null(graph, ["attr1"])
+    result_damped = _uniform_null(
         graph, ["attr1"], additional_propagation_args={"damping": 0.5}
     )
 

--- a/src/tests/test_network_ng_core.py
+++ b/src/tests/test_network_ng_core.py
@@ -769,7 +769,13 @@ def test_transform_edges_basic_functionality(test_graph, minimal_valid_sbml_dfs)
 
     # Check transformation was applied (string_inv: 1/(x/1000))
     transformed_values = test_graph.es["raw_scores"]
-    assert transformed_values != original_values
+    for i, (t, o) in enumerate(zip(transformed_values, original_values)):
+        if o is None:
+            assert t is None, f"edge {i}: original was None but transformed is {t}"
+        else:
+            assert (
+                t != o
+            ), f"edge {i}: expected transformation to change {o} but got {t}"
 
     # Check metadata was updated
     assert (
@@ -864,7 +870,10 @@ def test_transform_edges_retransformation_behavior(test_graph, minimal_valid_sbm
     second_transform = test_graph.es["scores"][:]
 
     # Values should be different after re-transformation
-    assert first_transform != second_transform
+    for i, (first, second) in enumerate(zip(first_transform, second_transform)):
+        if first is None and second is None:
+            continue  # unmatched edge, skip
+        assert first != second, f"edge {i} was not retransformed: both are {first}"
     assert (
         test_graph.get_metadata("transformations_applied")["reactions"]["scores"]
         == "string_inv"
@@ -1632,6 +1641,87 @@ def test_add_attributes_to_graph_inplace_vertices(test_graph):
         assert vertex_expressions[i] == vertex_data["vertex_expression"].iloc[i]
         assert vertex_confidences[i] == vertex_data["vertex_confidence"].iloc[i]
         assert vertex_locations[i] == vertex_data["vertex_location"].iloc[i]
+
+
+def test_add_attributes_df_entities_not_in_df_get_none(test_graph):
+    """Test that vertices and edges not in entity_data are assigned None (not np.nan)."""
+    # Vertices: test_graph has A, B, C - only provide data for A and B
+    partial_vertex_data = pd.DataFrame(
+        {"sparse_attr": [10.0, 20.0]},
+        index=pd.Index(["A", "B"], name=IGRAPH_DEFS.NAME),
+    )
+    test_graph._add_attributes_df(
+        entity_data=partial_vertex_data,
+        target_entity=IGRAPH_DEFS.VERTICES,
+        overwrite=False,
+    )
+    assert test_graph.vs[2]["sparse_attr"] is None  # C not in entity_data
+    assert test_graph.vs[0]["sparse_attr"] == 10.0
+    assert test_graph.vs[1]["sparse_attr"] == 20.0
+
+    # None is actually None, not nan — confirm it's not just falsy
+    assert not isinstance(test_graph.vs[2]["sparse_attr"], float)
+
+    # String attributes: unmatched vertices should also get None, not "nan" or ""
+    partial_string_data = pd.DataFrame(
+        {"label_attr": ["foo", "bar"]},
+        index=pd.Index(["A", "B"], name=IGRAPH_DEFS.NAME),
+    )
+    test_graph._add_attributes_df(
+        entity_data=partial_string_data,
+        target_entity=IGRAPH_DEFS.VERTICES,
+        overwrite=False,
+    )
+    assert test_graph.vs[2]["label_attr"] is None
+    assert test_graph.vs[0]["label_attr"] == "foo"
+
+    # Integer attributes: unmatched vertices should get None, not 0
+    partial_int_data = pd.DataFrame(
+        {"int_attr": [1, 2]},
+        index=pd.Index(["A", "B"], name=IGRAPH_DEFS.NAME),
+    )
+    test_graph._add_attributes_df(
+        entity_data=partial_int_data,
+        target_entity=IGRAPH_DEFS.VERTICES,
+        overwrite=False,
+    )
+    assert test_graph.vs[2]["int_attr"] is None
+    assert test_graph.vs[0]["int_attr"] == 1
+
+    # Edges: test_graph has (A,B), (B,C) - only provide data for first edge
+    edge_df = test_graph.get_edge_dataframe()
+    first_edge = (
+        edge_df[NAPISTU_GRAPH_EDGES.FROM].iloc[0],
+        edge_df[NAPISTU_GRAPH_EDGES.TO].iloc[0],
+    )
+    partial_edge_data = pd.DataFrame(
+        {"sparse_edge_attr": [99.0]},
+        index=pd.MultiIndex.from_tuples(
+            [first_edge],
+            names=[NAPISTU_GRAPH_EDGES.FROM, NAPISTU_GRAPH_EDGES.TO],
+        ),
+    )
+    test_graph._add_attributes_df(
+        entity_data=partial_edge_data,
+        target_entity=IGRAPH_DEFS.EDGES,
+        overwrite=False,
+    )
+    assert (
+        test_graph.es[1]["sparse_edge_attr"] is None
+    )  # second edge not in entity_data
+    assert test_graph.es[0]["sparse_edge_attr"] == 99.0
+
+    # Fully matched data should have no Nones anywhere
+    full_vertex_data = pd.DataFrame(
+        {"full_attr": [1.0, 2.0, 3.0]},
+        index=pd.Index(["A", "B", "C"], name=IGRAPH_DEFS.NAME),
+    )
+    test_graph._add_attributes_df(
+        entity_data=full_vertex_data,
+        target_entity=IGRAPH_DEFS.VERTICES,
+        overwrite=False,
+    )
+    assert all(v["full_attr"] is not None for v in test_graph.vs)
 
 
 def test_add_attributes_to_graph_inplace_overwrite(test_graph):

--- a/src/tests/test_utils_pd_utils.py
+++ b/src/tests/test_utils_pd_utils.py
@@ -13,6 +13,7 @@ from napistu.utils.pd_utils import (
     infer_entity_type,
     match_pd_vars,
     matrix_to_edgelist,
+    series_to_none_filled_list,
     style_df,
     update_pathological_names,
     validate_merge,
@@ -523,3 +524,42 @@ def test_validate_merge():
     validate_merge(
         left_multi, right_multi_dup, ["key1", "key2"], ["key1", "key2"], "1:m"
     )
+
+
+def test_series_to_none_filled_list():
+    """Test that series_to_none_filled_list correctly replaces all NA-like values with None."""
+
+    # float Series: np.nan should become None
+    float_series = pd.Series([1.0, np.nan, 3.0])
+    result = series_to_none_filled_list(float_series)
+    assert result == [1.0, None, 3.0]
+    assert result[1] is None  # not just falsy — must be exactly None
+    assert not isinstance(result[1], float)  # np.nan is a float; None is not
+
+    # integer Series: no missing values, should pass through unchanged
+    int_series = pd.Series([1, 2, 3])
+    result = series_to_none_filled_list(int_series)
+    assert result == [1, 2, 3]
+    assert all(v is not None for v in result)
+
+    # object Series with None: None should stay None
+    obj_series = pd.Series(["a", None, "c"], dtype=object)
+    result = series_to_none_filled_list(obj_series)
+    assert result == ["a", None, "c"]
+    assert result[1] is None
+
+    # pd.NA (nullable integer dtype): should become None
+    na_series = pd.array([1, pd.NA, 3], dtype="Int64")
+    result = series_to_none_filled_list(pd.Series(na_series))
+    assert result[1] is None
+    assert result[0] == 1
+
+    # all missing: every value should be None
+    all_nan = pd.Series([np.nan, np.nan])
+    result = series_to_none_filled_list(all_nan)
+    assert all(v is None for v in result)
+
+    # no missing: no Nones introduced
+    no_nan = pd.Series([1.0, 2.0, 3.0])
+    result = series_to_none_filled_list(no_nan)
+    assert all(v is not None for v in result)


### PR DESCRIPTION
- Added `_pooled_vertex_permutation_null` as a new null distribution for network propagation. This compares a set of attribute's propagation scores to a common set of nulls derived by selecting observed signals from all attributes and assigning them to random vertices within the masked subset of vertices.
- When adding attributes to the graph set None for undefined attributes rather than NaNs. This is consistent with how igraph thinks about missingness and helps to clarify whether downstream signals should be interpreted as missing or invalid.

Closes #342 