### PR TITLE
Issue 350 - expose mygene scoping arg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.10.2
+version = 0.10.3
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/network/ng_core.py
+++ b/src/napistu/network/ng_core.py
@@ -912,6 +912,7 @@ class NapistuGraph(ig.Graph):
         negate: bool = False,
         remove_unused_vertices: bool = True,
         inplace: bool = False,
+        verbose: bool = False,
     ) -> "Optional[NapistuGraph]":
         """Filter the graph to vertices whose species_type matches a list of valid types.
 
@@ -934,6 +935,8 @@ class NapistuGraph(ig.Graph):
             If True, modify this graph in place and return None.
             If False (default), return a new NapistuGraph leaving this one unchanged.
             Note: inplace=True is destructive — vertices are permanently deleted.
+        verbose : bool, default False
+            Whether to print verbose output
 
         Returns
         -------
@@ -968,9 +971,23 @@ class NapistuGraph(ig.Graph):
         else:
             valid_species_types = species_types
 
+        if verbose:
+            logger.info(f"Keeping species types: {valid_species_types}")
+
         species_types = self.vs[SBML_DFS_METHOD_DEFS.SPECIES_TYPE]
         valid_set = set(valid_species_types)
         keep_ids = [v.index for v in self.vs if species_types[v.index] in valid_set]
+
+        n_removed_vertices = len(self.vs) - len(keep_ids)
+        if n_removed_vertices == 0:
+            logger.warning(
+                "No vertices matching the requested species types were found"
+            )
+        else:
+            if verbose:
+                logger.info(
+                    f"Removing {n_removed_vertices} vertices, retaining {len(keep_ids)} vertices"
+                )
 
         if inplace:
             # Delete the complement — igraph delete_vertices is in-place
@@ -978,8 +995,8 @@ class NapistuGraph(ig.Graph):
             remove_ids = sorted(all_ids - set(keep_ids))
             self.delete_vertices(remove_ids)
             if remove_unused_vertices:
-                self.remove_isolated_vertices(SBML_DFS.REACTIONS)
-                self.remove_isolated_vertices(SBML_DFS.SPECIES)
+                self.remove_isolated_vertices(SBML_DFS.REACTIONS, verbose=verbose)
+                self.remove_isolated_vertices(SBML_DFS.SPECIES, verbose=verbose)
 
             return None
         else:
@@ -988,8 +1005,8 @@ class NapistuGraph(ig.Graph):
             # Preserve metadata from the parent graph
             result._metadata = self._metadata.copy()
             if remove_unused_vertices:
-                result.remove_isolated_vertices(SBML_DFS.REACTIONS)
-                result.remove_isolated_vertices(SBML_DFS.SPECIES)
+                result.remove_isolated_vertices(SBML_DFS.REACTIONS, verbose=verbose)
+                result.remove_isolated_vertices(SBML_DFS.SPECIES, verbose=verbose)
             return result
 
     def get_edge_dataframe(self) -> pd.DataFrame:
@@ -2325,6 +2342,24 @@ class NapistuGraph(ig.Graph):
                     f"on graph {target_entity}. Use overwrite=True to replace them, or exclude "
                     f"these attributes from entity_data."
                 )
+
+        # Warn when entity_data references entities not in the graph
+        if isinstance(entity_data.index, pd.MultiIndex):
+            graph_entity_ids = set(zip(*(graph_df[k].values for k in merge_keys)))
+            entity_data_ids = set(entity_data.index)
+        else:
+            graph_entity_ids = set(graph_df[merge_keys[0]].dropna())
+            entity_data_ids = set(entity_data.index)
+        nonexistent = entity_data_ids - graph_entity_ids
+        if nonexistent:
+            n_extra = len(nonexistent)
+            sample = list(nonexistent)[:5]
+            logger.warning(
+                f"entity_data contains {n_extra} {target_entity} ID(s) not in the graph: "
+                f"{sample}{' ...' if n_extra > 5 else ''}. "
+                f"Filter entity_data to only include {target_entity} present in the graph, "
+                f"or ensure the graph was not filtered (e.g. filter_by_species_type) before adding."
+            )
 
         # Merge entity data with graph data
         graph_with_attrs = graph_df.merge(

--- a/src/napistu/ontologies/_validation.py
+++ b/src/napistu/ontologies/_validation.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Optional, Set
 from pydantic import BaseModel, Field, field_validator
 
 from napistu.ontologies.constants import (
+    MYGENE_DEFAULT_QUERIES,
+    MYGENE_QUERY_DEFS_LIST,
     ONTOLOGIES,
     ONTOLOGIES_LIST,
     SPECIES_TYPE_ONTOLOGIES,
@@ -99,6 +101,8 @@ class GenodexitoConfig(BaseModel):
         Optional paths to R libraries
     test_mode: bool
         Whether to limit queries for testing
+    mygene_query_strategies: List[str]
+        MyGene query strings when using the Python mapper; defaults to MYGENE_DEFAULT_QUERIES
     """
 
     organismal_species: str = Field(
@@ -115,6 +119,10 @@ class GenodexitoConfig(BaseModel):
     )
     test_mode: bool = Field(
         default=False, description="Whether to limit queries for testing"
+    )
+    mygene_query_strategies: List[str] = Field(
+        default_factory=lambda: list(MYGENE_DEFAULT_QUERIES),
+        description="MyGene.info query strategies for the Python mapper",
     )
 
     @field_validator("preferred_method")
@@ -136,6 +144,18 @@ class GenodexitoConfig(BaseModel):
         """Validate that r_paths contains only strings."""
         if v is not None and not all(isinstance(path, str) for path in v):
             raise ValueError("All elements in r_paths must be strings")
+        return v
+
+    @field_validator("mygene_query_strategies")
+    @classmethod
+    def validate_mygene_query_strategies(cls, v: List[str]) -> List[str]:
+        """Validate MyGene query strategy strings."""
+        invalid = set(v) - set(MYGENE_QUERY_DEFS_LIST)
+        if invalid:
+            raise ValueError(
+                f"Invalid mygene_query_strategies: {', '.join(sorted(invalid))}. "
+                f"Valid queries are: {', '.join(MYGENE_QUERY_DEFS_LIST)}"
+            )
         return v
 
 

--- a/src/napistu/ontologies/genodexito.py
+++ b/src/napistu/ontologies/genodexito.py
@@ -37,6 +37,9 @@ class Genodexito:
         Optional paths to R libraries for Bioconductor, by default None
     test_mode : bool, optional
         If True, limit queries to 1000 genes for testing purposes, by default False
+    mygene_query_strategies : list of str, optional
+        MyGene.info query strings when using the Python mapper; omitted uses
+        ``MYGENE_DEFAULT_QUERIES``
 
     Attributes
     ----------
@@ -92,6 +95,7 @@ class Genodexito:
         allow_fallback: bool = True,
         r_paths: Optional[List[str]] = None,
         test_mode: bool = False,
+        mygene_query_strategies: Optional[List[str]] = None,
     ) -> None:
         """
         Initialize unified gene mapper
@@ -108,21 +112,28 @@ class Genodexito:
             Optional paths to R libraries for Bioconductor, by default None
         test_mode : bool, optional
             If True, limit queries to 1000 genes for testing purposes, by default False
+        mygene_query_strategies : Optional[List[str]], optional
+            MyGene.info query strategies for the Python mapper; omitted uses
+            ``MYGENE_DEFAULT_QUERIES``
         """
         # Validate configuration using Pydantic model
-        config = GenodexitoConfig(
+        config_fields = dict(
             organismal_species=organismal_species,
             preferred_method=preferred_method,
             allow_fallback=allow_fallback,
             r_paths=r_paths,
             test_mode=test_mode,
         )
+        if mygene_query_strategies is not None:
+            config_fields["mygene_query_strategies"] = mygene_query_strategies
+        config = GenodexitoConfig(**config_fields)
 
         self.organismal_species = config.organismal_species
         self.preferred_method = config.preferred_method
         self.allow_fallback = config.allow_fallback
         self.r_paths = config.r_paths
         self.test_mode = config.test_mode
+        self.mygene_query_strategies = config.mygene_query_strategies
 
         # Initialize empty attributes
         self.mappings: Optional[Dict[str, pd.DataFrame]] = None
@@ -178,6 +189,7 @@ class Genodexito:
                         mappings=mappings,
                         species=self.organismal_species,
                         test_mode=self.test_mode,
+                        query_strategies=self.mygene_query_strategies,
                     )
                     self.mapper_used = GENODEXITO_DEFS.PYTHON
                 else:
@@ -192,6 +204,7 @@ class Genodexito:
                     mappings=mappings,
                     species=self.organismal_species,
                     test_mode=self.test_mode,
+                    query_strategies=self.mygene_query_strategies,
                 )
                 self.mapper_used = GENODEXITO_DEFS.PYTHON
             except Exception as e:

--- a/src/napistu/ontologies/mygene.py
+++ b/src/napistu/ontologies/mygene.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 def create_python_mapping_tables(
-    mappings: Set[str], species: str = "Homo sapiens", test_mode: bool = False
+    mappings: Set[str],
+    species: str = "Homo sapiens",
+    test_mode: bool = False,
+    query_strategies: List[str] = MYGENE_DEFAULT_QUERIES,
 ) -> Dict[str, pd.DataFrame]:
     """Create genome-wide mapping tables between Entrez and other gene identifiers.
 
@@ -39,6 +42,8 @@ def create_python_mapping_tables(
         SPECIES_TO_TAXID or a valid NCBI taxonomy ID.
     test_mode : bool, default False
         If True, only fetch the first 1000 genes for testing purposes.
+    query_strategies : list of str, default ``MYGENE_DEFAULT_QUERIES``
+        MyGene.info query strings to run (see ``MYGENE_QUERY_DEFS_LIST``).
 
     Returns
     -------
@@ -77,7 +82,11 @@ def create_python_mapping_tables(
     # Fetch comprehensive gene data
     logger.info("Fetching genome-wide gene data from MyGene...")
     all_genes_df = _fetch_mygene_data_all_queries(
-        mg=mg, taxa_id=taxa_id, fields=mygene_fields, test_mode=test_mode
+        mg=mg,
+        taxa_id=taxa_id,
+        fields=mygene_fields,
+        query_strategies=query_strategies,
+        test_mode=test_mode,
     )
 
     if all_genes_df.empty:

--- a/src/tests/test_network_ng_core.py
+++ b/src/tests/test_network_ng_core.py
@@ -1699,6 +1699,52 @@ def test_add_attributes_to_graph_inplace_vertices(test_graph):
         assert vertex_locations[i] == vertex_data["vertex_location"].iloc[i]
 
 
+def test_add_attributes_df_entity_data_has_nonexistent_vertices(test_graph, caplog):
+    """Test _add_attributes_df warns when entity_data includes vertices not in graph.
+
+    Simulates the scenario: graph is filtered (e.g. filter_by_species_type), then
+    add_feature_abundances / _add_attributes_df is called with entity_data built from
+    the unfiltered species set. Entity_data may contain rows for vertices that were
+    removed by filtering. This should log a warning and proceed.
+    """
+    # Filter graph to subset of vertices (simulating filter_by_species_type)
+    filtered = test_graph.induced_subgraph([0, 1])  # keep A, B only
+    filtered_ng = NapistuGraph.from_igraph(filtered)
+    assert filtered_ng.vcount() == 2
+    assert set(filtered_ng.vs[NAPISTU_GRAPH_VERTICES.NAME]) == {"A", "B"}
+
+    # Entity_data has rows for A, B (exist) and Z (does not exist in filtered graph)
+    entity_data_extra = pd.DataFrame(
+        {"feature_attr": [1.0, 2.0, 99.0]},
+        index=pd.Index(["A", "B", "Z"], name=NAPISTU_GRAPH_VERTICES.NAME),
+    )
+    with caplog.at_level(logging.WARNING):
+        filtered_ng._add_attributes_df(
+            entity_data=entity_data_extra,
+            target_entity=NAPISTU_GRAPH.VERTICES,
+            overwrite=False,
+        )
+    assert "entity_data contains" in caplog.text
+    assert filtered_ng.vs[0]["feature_attr"] == 1.0
+    assert filtered_ng.vs[1]["feature_attr"] == 2.0
+
+    # Entity_data with ONLY non-existent vertices: all graph vertices get None
+    filtered2 = test_graph.induced_subgraph([0, 1])
+    filtered2_ng = NapistuGraph.from_igraph(filtered2)
+    entity_data_nonexistent = pd.DataFrame(
+        {"orphan_attr": [10.0, 20.0]},
+        index=pd.Index(["Z", "W"], name=NAPISTU_GRAPH_VERTICES.NAME),
+    )
+    with caplog.at_level(logging.WARNING):
+        filtered2_ng._add_attributes_df(
+            entity_data=entity_data_nonexistent,
+            target_entity=NAPISTU_GRAPH.VERTICES,
+            overwrite=False,
+        )
+    assert filtered2_ng.vs[0]["orphan_attr"] is None
+    assert filtered2_ng.vs[1]["orphan_attr"] is None
+
+
 def test_add_attributes_df_entities_not_in_df_get_none(test_graph):
     """Test that vertices and edges not in entity_data are assigned None (not np.nan)."""
     # Vertices: test_graph has A, B, C - only provide data for A and B

--- a/src/tests/test_ontologies_genodexito.py
+++ b/src/tests/test_ontologies_genodexito.py
@@ -1,12 +1,40 @@
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from napistu.ontologies.constants import (
     GENODEXITO_DEFS,
     INTERCONVERTIBLE_GENIC_ONTOLOGIES,
+    MYGENE_DEFAULT_QUERIES,
+    MYGENE_QUERY_DEFS,
     PROTEIN_ONTOLOGIES,
 )
 from napistu.ontologies.genodexito import Genodexito
+
+
+def test_genodexito_mygene_query_strategies():
+    """Default list, custom list, and invalid strategies (Pydantic) behave as expected."""
+    geno_default = Genodexito(
+        preferred_method=GENODEXITO_DEFS.PYTHON,
+        allow_fallback=False,
+    )
+    assert geno_default.mygene_query_strategies == list(MYGENE_DEFAULT_QUERIES)
+
+    strategies = [MYGENE_QUERY_DEFS.PROTEIN_CODING]
+    geno_custom = Genodexito(
+        preferred_method=GENODEXITO_DEFS.PYTHON,
+        allow_fallback=False,
+        mygene_query_strategies=strategies,
+    )
+    assert geno_custom.mygene_query_strategies == strategies
+
+    with pytest.raises(ValidationError) as exc:
+        Genodexito(
+            preferred_method=GENODEXITO_DEFS.PYTHON,
+            allow_fallback=False,
+            mygene_query_strategies=["type_of_gene:invalid"],
+        )
+    assert "Invalid mygene_query_strategies" in str(exc.value)
 
 
 @pytest.skip_on_timeout(5)

--- a/src/tests/test_ontologies_mygene.py
+++ b/src/tests/test_ontologies_mygene.py
@@ -1,7 +1,48 @@
+from unittest.mock import MagicMock
+
 import pytest
 
-from napistu.ontologies.constants import INTERCONVERTIBLE_GENIC_ONTOLOGIES
-from napistu.ontologies.mygene import create_python_mapping_tables
+from napistu.ontologies.constants import (
+    INTERCONVERTIBLE_GENIC_ONTOLOGIES,
+    MYGENE_QUERY_DEFS,
+)
+from napistu.ontologies.mygene import (
+    _fetch_mygene_data_all_queries,
+    create_python_mapping_tables,
+)
+
+
+def test_create_python_mapping_tables_rejects_invalid_query_strategies():
+    """Invalid query_strategies should fail before any MyGene fetch runs."""
+    with pytest.raises(ValueError, match="Invalid queries"):
+        create_python_mapping_tables(
+            mappings={"symbol"},
+            species="Homo sapiens",
+            test_mode=True,
+            query_strategies=["type_of_gene:not-a-real-mygene-query"],
+        )
+
+
+def test_fetch_mygene_data_all_queries_runs_each_strategy_once():
+    """Custom query_strategies should drive one MyGene query per strategy (mocked)."""
+    strategies = [MYGENE_QUERY_DEFS.PROTEIN_CODING, MYGENE_QUERY_DEFS.NCRNA]
+    mg = MagicMock()
+
+    def query_impl(query, species, fields, fetch_all=True):
+        yield {"entrezgene": 1, "symbol": f"hit-for-{query[:20]}"}
+
+    mg.query.side_effect = query_impl
+
+    df = _fetch_mygene_data_all_queries(
+        mg=mg,
+        taxa_id=9606,
+        fields=["entrezgene", "symbol"],
+        query_strategies=strategies,
+        test_mode=True,
+    )
+
+    assert mg.query.call_count == 2
+    assert list(df["query_type"]) == strategies
 
 
 @pytest.skip_on_timeout(5)


### PR DESCRIPTION
- added better warnings when trying to add entity data to a graph which is missing those vertices/edges. This can occur when the graph is trimmed (e.g., to a subgraph).
- exposed *mygene* scoping arg to Genodexito so that annotations can be pulled for non-default sets of genes/RNAs. Closes #350 