### PR TITLE
Fix strict dtype checks for pandas 3.0 compatibility (closes #358)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu
-version = 0.11.0
+version = 0.11.1
 description = Connecting high-dimensional data to curated pathways
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu/context/discretize.py
+++ b/src/napistu/context/discretize.py
@@ -50,20 +50,22 @@ def discretize_expression_data(
 
     """
 
-    expression_data_types = expression_data.dtypes
     if metadata_attributes is None:
         metadata_attributes = [
             col
-            for col in expression_data_types.index
-            if expression_data_types[col] == "object"
+            for col in expression_data.columns
+            if pd.api.types.is_string_dtype(expression_data[col])
         ]
 
     expression_numpy_df = expression_data.drop(columns=metadata_attributes)
     # ensure that all variables are numeric
     invalid_variables = [
-        x
-        for x, y in zip(expression_numpy_df.columns, expression_numpy_df.dtypes)
-        if y not in ["int64", "float64"]
+        col
+        for col in expression_numpy_df.columns
+        if not (
+            pd.api.types.is_integer_dtype(expression_numpy_df[col])
+            or pd.api.types.is_float_dtype(expression_numpy_df[col])
+        )
     ]
 
     if len(invalid_variables) > 0:

--- a/src/napistu/context/filtering.py
+++ b/src/napistu/context/filtering.py
@@ -371,9 +371,9 @@ def _binarize_species_data(species_data: pd.DataFrame) -> pd.DataFrame:
     """
     binary_series = []
     for c in species_data.columns:
-        if species_data[c].dtype == "bool":
+        if pd.api.types.is_bool_dtype(species_data[c]):
             binary_series.append(species_data[c].astype(int))
-        elif species_data[c].dtype == "int64":
+        elif pd.api.types.is_integer_dtype(species_data[c]):
             if species_data[c].isin([0, 1]).all():
                 binary_series.append(species_data[c])
             else:

--- a/src/napistu/ontologies/genodexito.py
+++ b/src/napistu/ontologies/genodexito.py
@@ -420,7 +420,7 @@ class Genodexito:
         # Check that all identifiers are strings
         for ontology, df in self.mappings.items():
             # Check index (which should be NCBI_ENTREZ_GENE)
-            if not df.index.dtype == "object":
+            if not pd.api.types.is_string_dtype(df.index):
                 raise TypeError(
                     f"Index of mapping table for {ontology} contains non-string values. "
                     f"Found type: {df.index.dtype}"
@@ -428,7 +428,7 @@ class Genodexito:
 
             # Check all columns
             for col in df.columns:
-                if not df[col].dtype == "object":
+                if not pd.api.types.is_string_dtype(df[col]):
                     raise TypeError(
                         f"Column {col} in mapping table for {ontology} contains non-string values. "
                         f"Found type: {df[col].dtype}"

--- a/src/napistu/source.py
+++ b/src/napistu/source.py
@@ -886,7 +886,7 @@ def _ensure_source_total_counts(
         source_total_counts.index.name = SOURCE_SPEC.PATHWAY_ID
 
     # index should be character and values should be integerish
-    if not source_total_counts.index.dtype == "object":
+    if not pd.api.types.is_string_dtype(source_total_counts.index):
         raise ValueError(
             f"source_total_counts index must be a string, but got {source_total_counts.index.dtype}"
         )

--- a/src/napistu/utils/display_utils.py
+++ b/src/napistu/utils/display_utils.py
@@ -169,7 +169,7 @@ def _create_left_align_formatters(df):
     formatters = {}
     for col in df.columns:
         # Only apply to object/string columns
-        if df[col].dtype == "object":
+        if pd.api.types.is_string_dtype(df[col]):
             # Calculate max width for this column
             if len(df) > 0:
                 content_max = df[col].astype(str).str.len().max()


### PR DESCRIPTION
## Summary

- Replace strict `dtype == "object"` / `"int64"` / `"float64"` literal comparisons with `pd.api.types.is_*_dtype` helpers so the modern dtype family (`StringDtype`, nullable `Int64`/`Float64`, `int32`, etc.) is accepted alongside the legacy NumPy dtypes — pandas 3.0 compatibility.
- Original report: `Genodexito._check_mappings_are_strings` rejected mygene-derived mapping tables once their indices became `StringDtype` instead of `object`.
- Bumped version to `0.11.1`.

## Changes

- [src/napistu/ontologies/genodexito.py](src/napistu/ontologies/genodexito.py) — `_check_mappings_are_strings` index + column checks use `is_string_dtype`.
- [src/napistu/source.py](src/napistu/source.py) — `_ensure_source_total_counts` index check uses `is_string_dtype`.
- [src/napistu/utils/display_utils.py](src/napistu/utils/display_utils.py) — `_create_left_align_formatters` now also left-aligns `StringDtype` columns.
- [src/napistu/context/filtering.py](src/napistu/context/filtering.py) — `_binarize_species_data` accepts nullable `boolean` and any integer dtype (`Int64`, `int32`, …) when locating binary columns.
- [src/napistu/context/discretize.py](src/napistu/context/discretize.py) — `discretize_expression_data` metadata auto-detection uses `is_string_dtype`; numeric-column validation accepts any int/float dtype.
- [setup.cfg](setup.cfg) — `0.11.0` → `0.11.1`.

Closes #358.

## Test plan

- [x] `pytest src/tests/test_ontologies_genodexito.py` — 2/2 pass.
- [x] `pytest src/tests/test_context_filtering.py::test_binarize_species_data` — pass.
- [x] `pytest src/tests/test_context_discretize.py` — 3/3 pass.
- [x] `pytest src/tests/test_utils_display_utils.py` — pass.
- [x] `pytest src/tests/test_source.py::test_source_set_coverage_enrichment` — previously failing on installed package with `ValueError: ... got str`; **now passes** after the fix.
- [x] Manual sanity check: `_binarize_species_data` now picks up `Int64`, `int32`, and nullable-bool binary columns.
- [x] Confirm CI passes on this PR.

Two pre-existing unrelated test failures (`test_collapse_source_df_dataframe`, `test_filter_reactions_with_disconnected_cspecies`) were verified to also fail on `main` and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)